### PR TITLE
CASMINST-3432: Change can-external-dns to cmn-external-dns in csi config init

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.9.4-1.x86_64
+    - cray-site-init-1.9.5-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
Tested on wasp