### PR TITLE
CASMREL-802

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,21 +3,21 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.6/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.6-20211022164059-ge14be20.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.6/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.6-20211022164059-ge14be20.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.6/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.6-20211022164059-ge14be20.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211026162820-ge4aceb1.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211026162820-ge4aceb1.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211026162820-ge4aceb1.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.9/kubernetes-0.2.9.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.9/5.3.18-59.27-default-0.2.9.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.9/initrd.img-0.2.9.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.10/kubernetes-0.2.10.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.10/5.3.18-59.19-default-0.2.10.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.10/initrd.img-0.2.10.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.9/storage-ceph-0.2.9.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.9/5.3.18-59.27-default-0.2.9.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.9/initrd.img-0.2.9.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.10/storage-ceph-0.2.10.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.10/5.3.18-59.19-default-0.2.10.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.10/initrd.img-0.2.10.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
- CASMINST-3294
- CASMTRIAGE-2521
- MTL-1514
- CASMTRIAGE-2476
- _CASMINST-3432_ **REVERTED** (downgraded to 1.9.4-1; replaced LiveCD with an earlier build that still contained all the other changes from today [kernel backtrace CASMTRIAGE-2476 and vlan ifcfg files CASMINST-3294 still made it]; PR for reverting the change in CSI repo is here: https://github.com/Cray-HPE/cray-site-init/pull/63)
- CASMINST-3265
- 