### PR TITLE
Update cephcsi version to v3.4.0 and add upgrade support for imageFeatures/layering

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -104,8 +104,6 @@ artifactory.algol60.net/csm-docker/stable:
     # quay.io images
     quay.io/bitnami/sealed-secrets-controller:
     - v0.12.1
-    quay.io/cephcsi/cephcsi: # XXX cephcsi/cephcsi
-    - v3.1.1
     quay.io/coreos/configmap-reload: # XXX coreos/configmap-reload
     - v0.0.1
     quay.io/coreos/etcd:
@@ -130,18 +128,6 @@ artifactory.algol60.net/csm-docker/stable:
     - v0.14.1
     quay.io/jetstack/cert-manager-webhook:
     - v0.14.1
-    # Note: The proper upstream for the quay.io/k8scsi/ images may actually be under k8s.gcr.io/sig-storage/
-    quay.io/k8scsi/csi-attacher: # XXX k8scsi/csi-attacher
-    - v2.1.1
-    quay.io/k8scsi/csi-node-driver-registrar: # XXX k8scsi/csi-node-driver-registrar
-    - v1.3.0
-    quay.io/k8scsi/csi-provisioner: # XXX k8scsi/csi-provisioner
-    - v1.6.0
-    quay.io/k8scsi/csi-resizer: # XXX k8scsi/csi-resizer
-    - v0.5.0
-    quay.io/k8scsi/csi-snapshotter: # XXX k8scsi/csi-snapshotter
-    - v2.1.0
-    - v2.1.1
     quay.io/keycloak/keycloak-gatekeeper: # XXX keycloak/keycloak-gatekeeper
     - 9.0.0
     # k8s.gcr.io images
@@ -432,5 +418,20 @@ artifactory.algol60.net/docker.io:
 
 quay.io:
   images:
+    cephcsi/cephcsi:
+    - v3.4.0
     skopeo/stable:
     - latest
+
+k8s.gcr.io:
+  images:
+    sig-storage/csi-attacher:
+    - v3.2.1
+    sig-storage/csi-node-driver-registrar:
+    - v2.2.0
+    sig-storage/csi-provisioner:
+    - v2.2.2
+    sig-storage/csi-resizer:
+    - v1.2.0
+    sig-storage/csi-snapshotter:
+    - v4.1.1

--- a/docker/transform.sh
+++ b/docker/transform.sh
@@ -83,10 +83,8 @@ DISTDIR=$1
     mv -v library/postgres:* cache/
     mv -v quay.io/strimzi/ strimzi/
     mv -v quay.io/bitnami/* bitnami/
-    mv -v quay.io/cephcsi/ cephcsi/
     mv -v quay.io/coreos coreos/
     mv -v quay.io/jetstack jetstack/
-    mv -v quay.io/k8scsi/ k8scsi/
     mv -v quay.io/keycloak/ keycloak/
     mv -v quay.io/prometheus/ prometheus/
     mv -v quay.io/sighup/ sighup/

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -228,12 +228,13 @@ spec:
       - k8s.gcr.io/pause:3.2
       # TODO remove the following once fixed to use k8s.gcr.io/pause:3.2:
       - dtr.dev.cray.com/k8s.gcr.io/pause:3.2
-      - k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
-      - k8s.gcr.io/sig-storage/csi-attacher:v2.2.0
-      - k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
-      - k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.0
-      - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
-      - quay.io/cephcsi/cephcsi:v3.1.1
+      # Used by cray-ceph-csi-* charts:
+      - k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+      - k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+      - k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+      - k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+      - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+      - quay.io/cephcsi/cephcsi:v3.4.0
   - name: cray-metallb
     source: csm-algol60
     version: 0.13.0

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -4,15 +4,15 @@ metadata:
 spec:
   sources:
     charts:
-    - name: csm
+    - name: csm-algol60
       type: repo
-      location: https://arti.dev.cray.com/artifactory/csm-helm-stable-local/
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
   charts:
   - name: cray-ceph-csi-rbd
-    source: csm
+    source: csm-algol60
     namespace: default
-    version: 3.1.5
+    version: 3.3.0
   - name: cray-ceph-csi-cephfs
-    source: csm
+    source: csm-algol60
     namespace: default
-    version: 3.1.3
+    version: 3.3.0


### PR DESCRIPTION
NOTE: This also brings in the pod priority support for these charts:
      cray-ceph-csi-rbd
      cray-ceph-csi-cephfs