### PR TITLE
CASMPET-5125 main : Release csm-testing v1.8.19

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.5-1.noarch
     - csm-ssh-keys-roles-1.3.5-1.noarch
-    - csm-testing-1.8.17-1.noarch
+    - csm-testing-1.8.19-1.noarch
     - docs-csm-1.12.3-1.noarch
-    - goss-servers-1.8.11-1.noarch
+    - goss-servers-1.8.19-1.noarch
     - hms-ct-test-crayctldeploy-1.8.5-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.1-1.noarch


### PR DESCRIPTION
Releases the following changes for main
* CASMPET-4997 : AUTOMATION: refactor goss-k8s-resolve-external-dns.yaml for airgapped
* CASMPET-4688 : Create a spire goss test suite
* CASMINST-3423 : WASP: "Bond Members Have Links" goss test failure
* CASMINST-3424 : WASP: "Default Gateway Same as CAN Gateway" goss test failure
* CASMINST-3390 : TESTS: BIOS Baseline and Firmware and BIOS versions tests are failing in 1.2