### PR TITLE
CASMINST-3432 LiveCD with CSI 1.9.5-1

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,9 +3,9 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211026162820-ge4aceb1.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211026162820-ge4aceb1.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211026162820-ge4aceb1.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211027221744-ge4aceb1.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211027221744-ge4aceb1.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211027221744-ge4aceb1.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.9.5-1.x86_64
+    - cray-site-init-1.9.6-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
This adds a LiveCD with CSI 1.9.5-1.
CSI 1.9.5-1 is still/already included in the RPM YAML, this is just a LiveCD.
This needs to be attached to a CASMREL.