### PR TITLE
CASMPET-5112 Bump cray-opa to 1.1.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.1.0
+    version: 1.1.1
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
This change disables the POST parsing for opa. This is broken in our version of opa, but should work once we update opa-envoy to the latest release.