### PR TITLE
CASMPET-5122 Bump spire to 0.11.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -160,5 +160,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 0.11.4
+    version: 0.11.5
     namespace: spire


### PR DESCRIPTION
This fixes an issue where the CA TTL was shorter than 6x the SVID TTL, causing the svids to occasionally be generated with too short a TTL, causing issues with kdump.