### PR TITLE
CASMPET-5122 Bump cray-spire to 0.8.23

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -135,5 +135,5 @@ spec:
 
   # Spire service
   - name: spire
-    version: 0.8.21
+    version: 0.8.23
     namespace: spire


### PR DESCRIPTION
This fixes an issue where the CA TTL was shorter than 6x the SVID TTL, causing the svids to occasionally be generated with too short a TTL, causing issues with kdump.