### PR TITLE
CASMINST-3426 Update to latest hpe-csm-scripts RPM to add missing HSM script main

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -12,7 +12,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
 http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/noarch/release/csm-1.0/:
   rpms:
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.0.20-20210728163955_8e17129.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
 http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/x86_64/release/csm-1.0/:
   rpms:
@@ -38,3 +37,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-0.0.6-1.x86_64
+https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/csm-1.2/:
+  rpms:
+    - hpe-csm-scripts-0.0.28-20211005110449_38c41f8.noarch


### PR DESCRIPTION
### Summary and Scope

This change updates the hpe-csm-scripts RPM to the latest version to add the missing run_hms_ct_tests.sh automation script to installs. The RPM artifact is now published to a different repository than it was previously, so specify the new directory such that the latest RPM version can be found.

### Issues and Related PRs

* Partially resolves CASMINST-3426 in main.

### Testing

Ran wget locally with the new URL followed by the new RPM name/version and verified that it was retrieved successfully.

### Risks and Mitigations

Low risk.