### PR TITLE
CASMHMS-5241 capmc show_all filter fix

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -281,7 +281,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.8.200
 
     cray-capmc:
-    - 1.27.0
+    - 1.29.0
 
     cray-cfs:
     - 1.8.83

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -24,7 +24,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 1.27.0
+    version: 1.29.0
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
Resolves a problem where BOA could not boot nodes because the status query could not find the target node.