### PR TITLE
CASMPET-5129: Update keycloak-gatekeeper for Bi-Can change

### DIFF
--- a/manifests/keycloak-gatekeeper.yaml
+++ b/manifests/keycloak-gatekeeper.yaml
@@ -4,11 +4,11 @@ metadata:
 spec:
   sources:
     charts:
-    - name: csm
+    - name: csm-algol60
       type: repo
-      location: https://arti.dev.cray.com/artifactory/csm-helm-stable-local/
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
   charts:
   - name: cray-keycloak-gatekeeper
-    source: csm
-    version: 0.4.0
+    source: csm-algol60
+    version: 1.0.0
     namespace: services


### PR DESCRIPTION
This picks up the change for:

* CASMPET-5129: cray-keycloak-gatekeeper-ingress has the wrong address pool specified