### PR TITLE
CASMCMS-7661 - console-node fixes for non-root user on fresh install

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -293,7 +293,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-console-data:
     - 1.2.63
     cray-console-node:
-    - 1.2.84
+    - 1.2.89
     cray-console-operator:
     - 1.2.62
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -89,7 +89,7 @@ spec:
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.2.84
+    version: 1.2.89
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope
The non-root user fixes did not work on a fresh install. I have changed the helm hook to run on installs as well as upgrades, modified the hook to also create the directories that will be used later so the permissions are set correctly even on a fresh install, and had to fix a SNYK scan failure to get the build to complete.

Code PR:
https://github.com/Cray-HPE/console-node/pull/23

### Issues and Related PRs
* Resolves CASMCMS-7661

### Testing
Tested on:
* Wasp

Was a fresh Install tested? Y (assuming a helm uninstall / install counts as a fresh install)
Was an Upgrade tested? Y
Was a Downgrade tested? Y

I uninstalled the cray-console-operator and cray-console-node helm charts. They are the two services that depend on the PVC that was having permissions problems. That completely removes the PVC and the install will start from scratch simulating a fresh install. I then installed both cray-console-operator and the new cray-console-node that is being tested. I verified the services came up and ran correctly with the correct dir/file permissions in place. I then uninstalled both services again and installed the original helm charts, replicating the original failure. I then upgraded to the new cray-console-operator helm chart and verified the fix was applied correctly and everything worked as expected.

### Risks and Mitigations
This is a low risk change as it will not come up correctly now on a fresh install.