### PR TITLE
CASMPET-4763 CASMPET-5126 CASMPET-5127

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.20-1.noarch
+    - csm-testing-1.8.22-1.noarch
     - docs-csm-1.12.7-1.noarch
-    - goss-servers-1.8.20-1.noarch
+    - goss-servers-1.8.22-1.noarch
     - hms-ct-test-crayctldeploy-1.8.5-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.1-1.noarch


### PR DESCRIPTION
Pull in fixes for
* CASMPET-4763 : Create a 'general k8s health' goss-test suite
* CASMPET-5126 : Create a ncn-healthcheck automated goss testing script
* CASMPET-5127 : Remove check for externaldns backups from Etcd-backups goss test