### PR TITLE
Added /heartbeat/{xname} API.

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -313,7 +313,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-firmware-action:
     - 1.9.14
     cray-hbtd:
-    - 1.12.4
+    - 1.14.0
     cray-hmnfd:
     - 1.9.7
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -32,7 +32,7 @@ spec:
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 1.12.4
+    version: 1.14.0
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Added /heartbeat/{xname} API.  This is part of a security
enhancement to prevent malfeasance by bad actors on compute
nodes by using OPA to filter out unauthorized actors from
sending heartbeats.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Resolves CASMHMS-5231
* Will need associated OPA filter mod.

### Testing

* Local build machine.

Was a fresh Install tested? N   No need.
Was an Upgrade tested?      N   No chart change
Was a Downgrade tested?     N   " "
Was a CT test run?          N   Not tested on real system.
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

Since the nature of the mod is a very trivial change to the
API routing, it is trivial to test locally.

Ran HBTD locally with debug turned all the way up.
Used CURL to verify that the existing /heartbeat
still works, as well as the new /heartbeat/{xname} API.

### Risks and Mitigations

Very low risk, change was trivial.