### PR TITLE
CASMPET-5104: Updates for upgrade to Istio 1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Istio is updated to version 1.8.6, Kiali to 1.28.1
 - Updated cray-opa to 1.2.0 to add policy check for xforward as used by oauth2-proxy
 - Updated three new tests to only run after PIT has been rebooted
 - Updated cray-site-init to 1.9.12 to add CHN network

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -55,8 +55,6 @@ arti.dev.cray.com/csm-docker-stable-local:
     loftsman: # XXX loftsman/loftsman
     # cray-product-catalog depends on this as well
     - 0.5.1
-    proxyv2:
-    - 1.7.8-cray1-distroless
 
 # dtr.dev.cray.com/cray
 arti.dev.cray.com/analytics-docker-stable-local:
@@ -380,19 +378,19 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.6.0
 
     istio/operator: # Istio operator image
-    - 1.7.8-cray2-distroless # istio 1.7.8
-    - 1.7.8-cray2 # istio 1.7.8; includes tools to help with debugging
-
+    - 1.8.6-cray1-distroless # istio 1.8.6
+    - 1.8.6-cray1 # istio 1.8.6; includes tools to help with debugging
     istio/pilot: # Istio pilot image
-    - 1.7.8-cray2-distroless # istio 1.7.8
-    - 1.7.8-cray2 # istio 1.7.8; includes tools to help with debugging
+    - 1.8.6-cray1-distroless # istio 1.8.6
+    - 1.8.6-cray1 # istio 1.8.6; includes tools to help with debugging
+    istio/proxyv2: # Istio proxyv2 image
+    - 1.8.6-cray1-distroless # istio 1.8.6; update platform.yaml cray-precache-images with this.
+    - 1.8.6-cray1 # istio 1.8.6; includes tools to help with debugging
+
     postgres-operator:
     - 1.9.1
     postgres-operator-ui:
     - 1.9.1
-    istio/proxyv2: # Istio proxyv2 image
-    - 1.7.8-cray2-distroless # istio 1.7.8; update platform.yaml cray-precache-images with this.
-    - 1.7.8-cray2 # istio 1.7.8; includes tools to help with debugging
 
     registry.opensource.zalan.do/acid/spilo-12:
     - 1.6-p3
@@ -406,9 +404,9 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.0.0
 
     quay.io/kiali/kiali:
-    - v1.25.0
+    - v1.28.1
     quay.io/kiali/kiali-operator:
-    - v1.25.0
+    - v1.28.1
 
 artifactory.algol60.net/docker.io:
   tls-verify: true

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,11 +88,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.22.0
+    version: 1.23.0
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.25.0
+    version: 1.26.0
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm
@@ -132,11 +132,11 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.3.0
+    version: 2.4.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.1.1
+    version: 0.2.0
     namespace: operators
   - name: cray-externaldns
     source: csm
@@ -224,7 +224,6 @@ spec:
       - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.4
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/proxyv2:1.8.6-cray1-distroless
       - k8s.gcr.io/pause:3.2
       # TODO remove the following once fixed to use k8s.gcr.io/pause:3.2:
       - dtr.dev.cray.com/k8s.gcr.io/pause:3.2


### PR DESCRIPTION
Istio is upgraded to 1.8.6 for 1.2 and this required changes to
cray-kiali, cray-istio-operator, cray-istio-deploy, and cray-istio
charts and the associated images.