### PR TITLE
FAS to 1.8.13 for CASMHMS-5203

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -318,7 +318,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.5.8 # update platform.yaml cray-precache-images with this
 
     cray-firmware-action:
-    - 1.8.12
+    - 1.8.13
     cray-hbtd:
     - 1.11.3
     cray-hmnfd:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -28,7 +28,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 1.8.12
+    version: 1.8.13
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60


### PR DESCRIPTION
Update FAS to v1.8.13 for CASMHMS-5203 - Gigabyte "Downloading" bug
csm-1.1