### PR TITLE
CASMPET-5139-1.2 : Includes CASMPET-5132 & CASMPET-5128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Added no_wipe test to ncn-healthcheck suites
+- Updated spire health storage suite to only run after the PIT has been rebooted
 - Automated goss test improvements and additions
 - The Jaeger service for tracing HTTP requests is no longer deployed.
 - Istio no longer deploys its own Prometheus. The cray-sysmgmt-health Prometheus does the monitoring.

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.22-1.noarch
+    - csm-testing-1.8.23-1.noarch
     - docs-csm-1.12.7-1.noarch
-    - goss-servers-1.8.22-1.noarch
+    - goss-servers-1.8.23-1.noarch
     - hms-ct-test-crayctldeploy-1.8.5-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.1-1.noarch


### PR DESCRIPTION
Update to index to pull in v1.8.23 released version of csm-testing
This pulls in changes for
* CASMPET-5132 : Create a no-wipe test
* CASMPET-5128 : Remove spire healthcheck from PIT node storage check