### PR TITLE
Add priority field for BSS ETCD cluster

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -276,7 +276,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.9.388
 
     cray-bss:
-    - 1.9.10
+    - 1.11.0
     cray-bss-ipxe:
     - 1.8.200
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -20,7 +20,7 @@ spec:
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 1.9.10
+    version: 1.11.0
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60


### PR DESCRIPTION
Resolves CASMHMS-5225 priorityClassName not found in cray-bss-etcd cluster