### PR TITLE
CASMCMS-7678: cfs-trust: Use api-gw-service-nmn not api_gw_service

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -266,7 +266,7 @@ artifactory.algol60.net/csm-docker/stable:
     cfs-hwsync-agent:
     - 1.6.70
     cfs-trust:
-    - 1.3.87
+    - 1.3.94
 
     cray-aee:
     - 1.2.73

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -70,7 +70,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.3.87
+    version: 1.3.94
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -1,7 +1,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.89-1.x86_64
+    - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-1.0.13-1.x86_64
     - craycli-0.41.8-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -20,7 +20,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.89-1.x86_64
+    - cfs-trust-1.3.94-1.x86_64
     - cray-cmstools-crayctldeploy-1.2.105-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-1.0.13-1.x86_64

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,4 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.89-1.x86_64
+    - cfs-trust-1.3.94-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -2,7 +2,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.89-1.x86_64
+    - cfs-trust-1.3.94-1.x86_64
     - cray-cmstools-crayctldeploy-1.2.105-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
See code PR for details:
https://github.com/Cray-HPE/cfs-trust/pull/19