### PR TITLE
Update HSM manifest for CASMHMS-5250

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -359,7 +359,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-sls:
     - 1.8.12
     cray-smd:
-    - 1.28.25
+    - 1.28.30
     cray-sonar:
     - 0.1.1
     cray-tftpd:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,7 +19,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 1.28.25
+    version: 1.28.30
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This updates the HSM manifest for CASMHMS-5250 - Backport Discovery for Bard Peak to 1.0.1

## Issues and Related PRs

* Resolves CASMHMS-5250 (https://connect.us.cray.com/jira/browse/CASMHMS-5250)

## Testing

For testing, see:
https://github.com/Cray-HPE/hms-smd/pull/54

## Risks and Mitigations

low

