### PR TITLE
CASMREL-813 New NCN Images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -9,15 +9,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.13/kubernetes-0.2.13.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.13/5.3.18-59.19-default-0.2.13.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.13/initrd.img-0.2.13.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.14/kubernetes-0.2.14.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.14/5.3.18-59.19-default-0.2.14.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.14/initrd.img-0.2.14.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.13/storage-ceph-0.2.13.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.13/5.3.18-59.19-default-0.2.13.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.13/initrd.img-0.2.13.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.14/storage-ceph-0.2.14.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.14/5.3.18-59.19-default-0.2.14.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.14/initrd.img-0.2.14.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

This provides the latest stable NCN images 0.2.14 (original PR: https://github.com/Cray-HPE/node-image-build/pull/78)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves MTL-1535 MTL-1537 CASMINST-3502
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._
- redbull (Intel)

### Tested on:

  * `redbull`
  * `drax`
  * `wasp`

### Test description:

Metal smoke tests

> Note: The insert here was skipped today for time, normally goss tests are not checked. Metal will start doing that asap before these PRs.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [] Testing is appropriate and complete, if applicable
- [] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

