### PR TITLE
New platform-utils with a couple fixes:

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -45,7 +45,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-sls-ct-test-1.11.0-1.x86_64
     - hms-smd-ct-test-1.32.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
-    - platform-utils-1.2.1-1.noarch
+    - platform-utils-1.2.4-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-0.0.6-1.x86_64


### PR DESCRIPTION
CASMPET-4915: enhance etcd restore automation script to remove crd
CASMINST-3420: WASP: ncnHealthChecks.sh checks for backups of a removed etcd cluster
CASMINST-3516: ncnHealthCheck.sh script should choose reachable node to ssh to for ceph status
