### PR TITLE
MTL-1545 Dependencies for Backporting the 1.2 Bootcode Updates

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -30,12 +30,13 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.10.1-1.noarch
     - csm-testing-1.6.40-1.noarch
     - dracut-metal-dmk8s-1.5.2-1.noarch
-    - dracut-metal-luksetcd-1.5.2-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
     - goss-servers-1.6.39-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
-    - metal-net-scripts-0.0.2-1.noarch
+    - ilorest-3.2.3-1.x86_64
     - metal-basecamp-1.1.9-1.x86_64
+    - metal-net-scripts-0.0.2-1.noarch
+    - pit-init-1.2.11-1.noarch
     - platform-utils-0.2.6-1.noarch
 http://car.dev.cray.com/artifactory/csm/SPET/sle15_sp2_ncn/x86_64/release/csm-1.0/:
   rpms:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This change does two things:
- Alphabetically sorts and organizes the metal RPMs so as many as possible are fetched from GCP
- MTL-1545 Adds MTL-1535's new bootcode to the pre-upgrade script section

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes; 0.9, 1.0, and forwards compatible with 1.2.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1545](https://connect.us.cray.com/jira/browse/MTL-1545)
* Merge before/with https://github.com/Cray-HPE/docs-csm/pull/510

## Testing

_List the environments in which these changes were tested._

Testing of the new content was already done, testing of this hotfix in the context of this repo was not done.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

This must be invoked before deploying NCNs, the new settings applied to any NCN requires a reboot. This reboot comes for free during deployment.

The changes here do not mandate a reboot, as they do fix aspects of the bootorder prior to reboot. The BIOS tweaks for HPE servers (none exist for GB and Intel at this time) require a reboot to apply.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

