### PR TITLE
Casminst 3520

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -276,6 +276,11 @@ spec:
             - api-gw-service.local
             - api-gw-service-nmn.local
             - istio-ingressgateway.istio-system.svc.cluster.local
+            - '*.cmn.{{ network.dns.external }}'
+            - '*.can.{{ network.dns.external }}'
+            - '*.chn.{{ network.dns.external }}'
+            - '*.nmn.{{ network.dns.external }}'
+            - '*.hmn.{{ network.dns.external }}'
             - '*.{{ network.dns.external }}'
           commonName: '{{ network.dns.external }}'
         authn:


### PR DESCRIPTION
## Summary and Scope

This adds the network-specific names (e.g. *.cmn.wasp.dev.cray.com) to the ingress-gateway certificate.  RFC 6125 states that the wildcard can only match the left-most label.   Therefore, *.wasp.dev.cray.com will not match grafana.cmn.wasp.dev.cray.com.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://connect.us.cray.com/jira/browse/CASMINST-3520

## Testing

Tested regeneration of site-init on wasp. 

### Test description:

Upgrade testing will be handled by CASMINST-3409.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

