### PR TITLE
CASMNET-1008:  Add CHN pools to metallb config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cray-site-init to 1.9.12 to add CHN network
 - Added no_wipe test to ncn-healthcheck suites
 - Updated spire health storage suite to only run after the PIT has been rebooted
 - Automated goss test improvements and additions

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.9.10-1.x86_64
+    - cray-site-init-1.9.12-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

Adds CHN network to CSI generation.

## Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMNET-1008

## Testing

### Tested on:

  * wasp

### Test description:

Tested on wasp by running csi config init with various different system_config.yaml files.
* with no CHN inputs
* with chn-cidr but no static or dynamic pools
* with only static pool
* with only dynamic pool
* with both static and dynamic pools
I inspected the files generated by CSI; in particular sls_input_file.json, pit-files, metallb.yaml

## Risks and Mitigations

This is a little risky in that it introduces new configuration. This risk is expected at this point as we continue integration of CHN.


## Pull Request Checklist

- [ x] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [x ] License file intact
- [x ] Target branch correct
- [ x] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [x ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

