### PR TITLE
CASMPET-4308: Change OPA Policy to check different header for JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cray-opa to 1.2.0 to add policy check for xforward as used by oauth2-proxy
 - Updated three new tests to only run after PIT has been rebooted
 - Updated cray-site-init to 1.9.12 to add CHN network
 - Added no_wipe test to ncn-healthcheck suites

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.1.1
+    version: 1.2.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates cray-opa to version 1.2.0 which updates the policy to check http header xforward-auth which is used by oauth2-proxy to send the authentication JWT.

## Issues and Related PRs

* Resolves CASMPET-4308

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? Yes.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

