### PR TITLE
spire 1.2.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,5 +159,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.0.2
+    version: 1.2.0
     namespace: spire


### PR DESCRIPTION
Updates spire to 1.2.0, which resolves the following issues:

- [CASMPET-3939](https://connect.us.cray.com/jira/browse/CASMPET-3939) Added external-dns support 
- [CASMPET-4699](https://connect.us.cray.com/jira/browse/CASMPET-4699) Updated cray-service requirement to 6.2.0 
- [CASMPET-3941](https://connect.us.cray.com/jira/browse/CASMPET-3941) Added network policy to limit access to spire-tokens service 
- [CASMPET-5142](https://connect.us.cray.com/jira/browse/CASMPET-5142]) Updated how workloads are created so that new workloads can be easily added
  without requiring upgrade scripts 
- [CASMPET-5148](https://connect.us.cray.com/jira/browse/CASMPET-5148) - enable xname validation support by default