### PR TITLE
CASMHMS-3977 hms-discovery ignore disabled

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -365,7 +365,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.12.2-cray
 
     hms-discovery:
-    - 1.7.7
+    - 1.9.0
     hms-hmcollector:
     - 2.14.0
     hms-pytest:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -38,7 +38,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 1.7.7
+    version: 1.9.0
     namespace: services
 
   # Cray DHCP Kea


### PR DESCRIPTION
### Summary and Scope

The hms-discovery job was trying to power on disabled nodes. Newer CAPMC code errors out an entire power request if just one of the components is disabled. This prevents hms-discovery from powering on components when one of them is disabled. Added a check to ignore disabled components as well as adding the Continue option to the power command to do a best effort power on.

### Issues and Related PRs

* Resolves [CASMHMS-3977](https://connect.us.cray.com/jira/browse/CASMHMS-3977)
* Resolves [CASMFEAT-50](https://connect.us.cray.com/jira/browse/CASMFEAT-50)

### Testing

Tested on:

* loki

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Powered Off and Disabled a slot and verified hms-discovery was trying to power it On. Rolled out new hms-discovery and modified the cronjob to pick up the new image. hms-discovery no longer tried to power On the disabled blade. Re-enabled the blade and hms-discovery properly powered it On.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y
