### PR TITLE
CASMNET-1016 - Change name of cray-dns-powerdns-can to cray-dns-powerdns-cmn

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -306,7 +306,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.9.8
 
     cray-dns-powerdns:
-    - 0.1.4 # update platform.yaml cray-precache-images with this
+    - 0.1.5 # update platform.yaml cray-precache-images with this
     cray-dns-unbound:
     - 0.6.9 # update platform.yaml cray-precache-images with this
 

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -59,11 +59,11 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.1.4
+    version: 0.1.5
     namespace: services
     values:
       global:
-        appVersion: 0.1.4
+        appVersion: 0.1.5
 
   - name: cray-powerdns-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -221,7 +221,7 @@ spec:
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
       - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.9
-      - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.4
+      - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.5
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/proxyv2:1.8.6-cray1-distroless


### PR DESCRIPTION
### Summary and Scope

The cray-dns-powerdns services that were on the CAN when we were developing it on 1.0 systems for 1.1 have the name cray-dns-powerdns-can-[tcp|udp]. With BiCAN in 1.2, we these are now on the CMN so they should be named cray-dns-powerdns-cmn-[tcp|udp].

### Issues and Related PRs

* Resolves [CASMNET-1016](https://connect.us.cray.com/jira/browse/CASMNET-1016)
* Merge with https://stash.us.cray.com/projects/SHASTA-CFG/repos/stable/pull-requests/761/overview

### Testing

Tested on:

* wasp - `cray-dns-powerdns` has been upgraded and rolled back successfully.

### Risks and Mitigations

N/A

Requires:

* CSM fresh install and update testing







