### PR TITLE
CASMREL-817 New NCN Images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -9,15 +9,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.15/kubernetes-0.2.15.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.15/5.3.18-59.19-default-0.2.15.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.15/initrd.img-0.2.15.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.16/kubernetes-0.2.16.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.16/5.3.18-59.19-default-0.2.16.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.16/initrd.img-0.2.16.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.15/storage-ceph-0.2.15.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.15/5.3.18-59.19-default-0.2.15.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.15/initrd.img-0.2.15.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.16/storage-ceph-0.2.16.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.16/5.3.18-59.19-default-0.2.16.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.16/initrd.img-0.2.16.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMINST-3489 new metal-cloud-init RPM with clock syncing fixes.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

No.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3489](https://connect.us.cray.com/jira/browse/CASMINST-3489)
* Change will also be needed in `main`
* Merge with/before/after https://github.com/Cray-HPE/docs-csm/pull/511

## Testing

_List the environments in which these changes were tested._

- redbull

### Tested on:

  * `redbull`
  * Local development environment
  * Virtual Shasta

## Risks and Mitigations

Low.  The changes work with 1.0 and 1.2 versions of cloud-init.