### PR TITLE
Update kea's pre-cached images to match kea's deployment

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -223,6 +223,8 @@ spec:
       - dtr.dev.cray.com/cray/cray-dns-unbound:0.4.9
       - dtr.dev.cray.com/cray/proxyv2:1.7.8-cray1
       - dtr.dev.cray.com/cray/proxyv2:1.7.8-cray2-distroless
+      - dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless
+      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.7.9
       - k8s.gcr.io/pause:3.2
       # TODO remove the following once fixed to use k8s.gcr.io/pause:3.2:
       - dtr.dev.cray.com/k8s.gcr.io/pause:3.2


### PR DESCRIPTION
## Summary and Scope

Looks like we haven't updated precached images for kea -- adding them.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2717](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2717)

## Testing

not tested, simple cm update adding images

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

N/A

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

