### PR TITLE
CASMPET-5160 1.2 : Release csm-testing for CASMPET-5003 and CASMINST-3526

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.28 for improvements to velero failed backup and monitoring tests
 - Updated cray-opa to 1.2.0 to add policy check for xforward as used by oauth2-proxy
 - Updated three new tests to only run after PIT has been rebooted
 - Updated cray-site-init to 1.9.12 to add CHN network

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.26-1.noarch
+    - csm-testing-1.8.28-1.noarch
     - docs-csm-1.12.10-1.noarch
-    - goss-servers-1.8.26-1.noarch
+    - goss-servers-1.8.28-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64


### PR DESCRIPTION
…3526

## Summary and Scope

Releases csm-testing which includes changes for csm-1.2
* CASMPET-5003 : AUTOMATION: Refactor goss-k8s-monitoring-url.yaml for Bi-CAN
* CASMINST-3526 : Drax: Velero backup failed during automated goss test in k8 nodes

## Issues and Related PRs

* Resolves [CASMPET-5003](https://connect.us.cray.com/jira/browse/CASMPET-5003)
* Resolves [CASMINST-3526](https://connect.us.cray.com/jira/browse/CASMINST-3526)
* Change will also be needed in main

## Testing
Verified test changes work as expected in 1.2 environment

### Tested on:

  * wasp (1.2)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ NA


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

