### PR TITLE
CASMTRIAGE-2650 Update FAS tests new error fields csm-1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -311,7 +311,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.6.9 # update platform.yaml cray-precache-images with this
 
     cray-firmware-action:
-    - 1.11.0
+    - 1.13.0
     cray-hbtd:
     - 1.14.0
     cray-hmnfd:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -28,7 +28,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 1.11.0
+    version: 1.13.0
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64
-    - hms-fas-ct-test-1.11.0-1.x86_64
+    - hms-fas-ct-test-1.13.0-1.x86_64
     - hms-hmcollector-ct-test-2.14.0-1.x86_64
     - hms-hbtd-ct-test-1.13.0-1.x86_64
     - hms-hmnfd-ct-test-1.10.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change pulls in updates to the FAS CT tests for new expected "errors" fields in the /actions and /snapshots API responses.

### Issues and Related PRs

* Resolves CASMTRIAGE-2650.

### Testing

This change was tested by deploying the updated CT tests to Wasp running csm-1.2.0-alpha.16, executing them, and verifying that the previously failing test cases due to unexpected "errors" fields began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

Low risk that impacts FAS CT testing only.