### PR TITLE
CASMINST-3536 Update spire version in helm index

### DIFF
--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -149,4 +149,4 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-sysmgmt-health:
     - 0.12.6
     spire:
-    - 0.8.21
+    - 0.8.23


### PR DESCRIPTION
## Summary and Scope

The version of the spire chart in the manifest doesn't match the version in the helm index. This updates the helm index to match the version in the manifest

## Issues and Related PRs

* Resolves [CASMINST-3536](https://connect.us.cray.com/jira/browse/CASMINST-3536)
