### PR TITLE
CASMTRIAGE-2543 - set-ncns-to-unbound.sh did not configure DNS correctly

### DIFF
--- a/lib/set-ncns-to-unbound.sh
+++ b/lib/set-ncns-to-unbound.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-set -exo pipefail
+set -eo pipefail
 
 ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
 
@@ -11,5 +11,5 @@ unbound_ip="$(kubectl get -n services service cray-dns-unbound-udp-nmn -o jsonpa
 "${ROOTDIR}/lib/list-ncns.sh" | while read ncn; do
     echo >&2 "+ Updating ${ncn}"
     ssh -n -o "StrictHostKeyChecking=no" "root@${ncn}" \
-        "sed -e 's/^\(NETCONFIG_DNS_STATIC_SERVERS\)=.*$/\1=\"${unbound_ip}\"/' -i /etc/sysconfig/network/config; netconfig update -f; grep nameserver /etc/resolv.conf | sed -e 's/^/${ncn}: /'"
+        "sed -e '"/^nameserver/{/^nameserver.*${unbound_ip}/!d}"' -i /etc/resolv.conf; grep nameserver /etc/resolv.conf | sed -e 's/^/${ncn}: /'"
 done


### PR DESCRIPTION
## Summary and Scope

CSM 1.2 now uses `cloud-init` to manage `resolv.conf` rather than SUSE `netconfig`. The current implementation of this script resulted in no changes occurring when run due to the netconfig DNS policy being disabled.

* Resolves [CASMTRIAGE-2543](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2543)

## Testing

### Tested on:

  * wasp

### Test description:

Script was run and it was confirmed that the PIT nameserver entry had been removed from `/etc/resolv.conf` on all NCNs.

This test was repeated multiple times.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

