### PR TITLE
CASMNET-946,CASMNET-877,CASMTRIAGE-2615,CASMNET-947,CASMNET-706,CASMN…

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -301,7 +301,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.3.50
 
     cray-dhcp-kea:
-    - 0.9.8
+    - 0.9.10 # update platform.yaml cray-precache-images with this
 
     cray-dns-powerdns:
     - 0.1.5 # update platform.yaml cray-precache-images with this

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -44,7 +44,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.9.8
+    version: 0.9.10
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,6 +220,7 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
+      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.10
       - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.9
       - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.5
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- add feature to dhcp-helper.py in kea to create dhcp reservations for static ips from cloud-init data
- automation script to update DHCP/DNS/HMS data after hardware swap
- fixed scenario where time server lookup created malformed string
- add dhcp-helper.py feature in kea to handle multiple dhcp reservations per MAC in different subnets
- add global reservation duplicate checking when reading from SMD ethernet table
- Kea should reserve NCN IPs (including NCNs that are added or replaced post-install)
- Refactor dhcp-helper and improve performance 
- add python logger to scripts in cray-dhcp-kea
- 
_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
yes to all releases shasta-1.4 and newer

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves
- CASMNET-946 
- CASMNET-877
- CASMTRIAGE-2615 
- CASMNET-947 
- CASMNET-706 
- CASMNET-1006
- CASMNET-758
- CASMNET-994

## Testing

Wasp
### Tested on:

wasp
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? todo
- Were continuous integration tests run? If not, why?we have those?
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change? yes

## Risks and Mitigations

none


## Pull Request Checklist

- [ x] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [ x] License file intact
- [ x] Target branch correct
- [x ] CHANGELOG.md updated
- [ x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

