### PR TITLE
CASMINST-3546 1.2 : csi pit validate for k8s has failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.29 for ncn-kubernetes-checks pit fix
 - Istio is updated to version 1.8.6, Kiali to 1.28.1
 - Released csm-testing v1.8.28 for improvements to velero failed backup and monitoring tests
 - Updated cray-opa to 1.2.0 to add policy check for xforward as used by oauth2-proxy

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.28-1.noarch
+    - csm-testing-1.8.29-1.noarch
     - docs-csm-1.12.10-1.noarch
-    - goss-servers-1.8.28-1.noarch
+    - goss-servers-1.8.29-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64


### PR DESCRIPTION
Resolves
* CASMINST-3546 :  csi pit validate for k8s has failed