### PR TITLE
Assets for 2021-11-12

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,21 +3,21 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211110185445-ge4aceb1.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211110185445-ge4aceb1.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211110185445-ge4aceb1.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211112200748-ge4aceb1.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211112200748-ge4aceb1.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.7/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.7-20211112200748-ge4aceb1.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.17/kubernetes-0.2.17.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.17/5.3.18-59.19-default-0.2.17.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.17/initrd.img-0.2.17.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.18/kubernetes-0.2.18.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.18/5.3.18-59.19-default-0.2.18.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.18/initrd.img-0.2.18.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.17/storage-ceph-0.2.17.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.17/5.3.18-59.19-default-0.2.17.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.17/initrd.img-0.2.17.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.18/storage-ceph-0.2.18.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.18/5.3.18-59.19-default-0.2.18.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.18/initrd.img-0.2.18.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.10.0-1.x86_64
+    - cray-site-init-1.10.2-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

PIT ISO, NCNs, and nexus update for:

* MTL-1555 - k8s routes for NCNs
* CASMINST-3538 - (re)add package-utils rpm to list that gets updated on NCN rebuild
* CASMINST-3539 - only wait 5min for spire on m001