### PR TITLE
CASMPET-5158: Update keycloak charts for keycloak-setup image

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -329,7 +329,8 @@ artifactory.algol60.net/csm-docker/stable:
     - 2.6.76
 
     cray-keycloak-setup:
-    - 0.14.4  # cray-keycloak, cray-keycloak-users-localize, keycloak-vcs-user
+    - 1.0.0  # cray-keycloak, cray-keycloak-users-localize
+    - 0.14.4  # keycloak-vcs-user
     cray-meds:
     - 1.17.0
     cray-powerdns-manager:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -178,11 +178,11 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 1.13.0
+    version: 2.0.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.8.1
+    version: 1.9.0
     namespace: services
   - name: cray-node-discovery
     source: csm

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -55,6 +55,18 @@ spec:
       # If there is ever a local (i.e. 'nmn_supernet') route
       # destination in this list, it should be removed.
       routes: []
+  proxiedWebAppExternalHostnames:
+  - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
+  - '{{ kubernetes.services[''cray-nexus''].istio.ingress.hosts.ui.authority }}'
+  - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
+  - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
+  - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].prometheus.prometheusSpec.externalAuthority }}'
+  - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].alertmanager.alertmanagerSpec.externalAuthority }}'
+  - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].grafana.externalAuthority }}'
+  - '{{ kubernetes.services.gitea.externalHostname }}'
+  - sma-grafana.cmn.{{ network.dns.external }}
+  - sma-kibana.cmn.{{network.dns.external}}
+  - csms.cmn.{{ network.dns.external }}
   kubernetes:
     # These are sealed secrets that HPE WILL overwrite during migrations.
     # Customer changes will be lost.
@@ -326,7 +338,9 @@ spec:
           keycloak:
             customerAccessUrl: https://auth.cmn.{{ network.dns.external }}/keycloak
             gatekeeper:
-              proxiedHosts: '{{ kubernetes.services[''cray-keycloak-gatekeeper''].hosts | list }}'
+              proxiedHosts: '{{ proxiedWebAppExternalHostnames }}'
+            oauth2Proxy:
+              proxiedHosts: '{{ proxiedWebAppExternalHostnames }}'
             service: keycloak.services
             clusterGw:
               route: /keycloak
@@ -337,18 +351,7 @@ spec:
           - ip: '{{ network.netstaticips.nmn_api_gw }}'
             hostnames:
               - 'auth.cmn.{{ network.dns.external }}'
-        hosts:
-          - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
-          - '{{ kubernetes.services[''cray-nexus''].istio.ingress.hosts.ui.authority }}'
-          - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
-          - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
-          - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].prometheus.prometheusSpec.externalAuthority }}'
-          - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].alertmanager.alertmanagerSpec.externalAuthority }}'
-          - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].grafana.externalAuthority }}'
-          - '{{ kubernetes.services.gitea.externalHostname }}'
-          - sma-grafana.cmn.{{ network.dns.external }}
-          - sma-kibana.cmn.{{network.dns.external}}
-          - csms.cmn.{{ network.dns.external }}
+        hosts: '{{ proxiedWebAppExternalHostnames }}'
       cray-kiali:
         externalAuthority: kiali-istio.cmn.{{ network.dns.external }}
         kiali-operator:


### PR DESCRIPTION
This includes the following changes:

* CASMPET-4299: Configure new nexus Keycloak client and K8s secret
* CASMPET-4714: keycloak-setup create oauth2-proxy client and Secret

This also requires a change to the customizations.yaml to pass the
proxiedHosts list for the new oauth2-proxy client to the
cray-keycloak chart.

The proxied hosts list in cray-keycloak was referenced from the
cray-keycloak-gatekeeper config. Since the cray-keycloak-gatekeeper
is going away soon, I pulled the list from cray-keycloak-gatekeeper
to a new variable in the `spec` section.
