### PR TITLE
Update HSM manifest

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -341,7 +341,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-sls:
     - 1.11.0
     cray-smd:
-    - 1.32.0
+    - 1.33.0
     cray-sonar:
     - 0.2.0
     cray-tftpd:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,7 +19,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 1.32.0
+    version: 1.33.0
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This updates the HSM manifest for:
CASMHMS-5239 - HSM now kicks off re-discovery for nodeBMCs when a power on redfish event is received for its slot. This will automate re-discovery of node components when power is restored to a slot.

CASMHMS-5233 - HSM would silently error out on kicking off manual re-discovery of a component list that contained duplicates. This mod changes HSM to ignore the duplicates.

## Issues and Related PRs

* Resolves [CASMHMS-5239](https://connect.us.cray.com/jira/browse/CASMHMS-5239)
* Resolves [CASMHMS-5233](https://connect.us.cray.com/jira/browse/CASMHMS-5233)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/56

## Risks and Mitigations

Low risk
