### PR TITLE
Added v2 API including xname-based subscriptions.

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -313,7 +313,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-hbtd:
     - 1.14.0
     cray-hmnfd:
-    - 1.11.0
+    - 1.12.0
 
     cray-ims-kiwi-ng-opensuse-x86_64-builder:
     - 1.2.54

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 1.11.0
+    version: 1.12.0
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Added v2 API for HMNFD which includes easily filterable
subscriptions endpoints.  This is to satisfy a security
requirement related to OPA filtering.

Once this is committed it will be possible to fine tune
the OPA filtering for HMNFD to prevent malfeasance with
the subscription API.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Resolves CASMHMS-5230

### Testing

Tested on:

* wasp
* Local machine

Was a fresh Install tested? N   No need
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
Was a CT test run?          Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

Ran on wasp.  Installed container with new HMNFD.  Manually
exercised the v2 and v1 APIs and verified correct behavior.
Note that this system as no OPA filtering in place for the v2
API.

### Risks and Mitigations

This mod is at least a moderate risk.  The HMNFD code
had to be modified somewhat extensively.

