### PR TITLE
CASMPET-3940 Bump cray-opa to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-opa v1.3.0 to Add BOS entries and fix xname validation
 - Released csm-testing v1.8.29 for ncn-kubernetes-checks pit fix
 - Released cray-s3:1.0.0 to move service endpoint to CMN for Bi-CAN
 - Istio is updated to version 1.8.6, Kiali to 1.28.1

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.2.0
+    version: 1.3.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Releasing cray-opa version 1.3.0 for CSM 1.2

## Issues and Related PRs

* Resolves [CASMCMS-7355](https://connect.us.cray.com/jira/browse/CASMCMS-7355)
* Resolves [CASMPET-3940](https://connect.us.cray.com/jira/browse/CASMPET-3940)
* Resolves [CASMPET-5141](https://connect.us.cray.com/jira/browse/CASMPET-5141)
* Resolves [CASMPET-5150](https://connect.us.cray.com/jira/browse/CASMPET-5150)
* Resolves [PE-37952](https://connect.us.cray.com/jira/browse/PE-37952)