### PR TITLE
CASMPET-5150 Add opa image to image cache

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -217,6 +217,7 @@ spec:
     values:
       cacheRefreshSeconds: "120"
       cacheImages:
+      - docker.io/openpolicyagent/opa:0.24.0-envoy-1
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1


### PR DESCRIPTION
This adds the opa image to the image cache so that cray-opa can come up if nexus is not responding.