### PR TITLE
New metallb chart and docker images, relying on customizations for config

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -360,6 +360,9 @@ artifactory.algol60.net/csm-docker/stable:
     csm-ssh-keys:
     - 1.3.79
 
+    docker-kubectl:
+    - 1.19.15
+
     etcd-operator:
     - 0.12.2-cray
 
@@ -419,6 +422,10 @@ quay.io:
   images:
     cephcsi/cephcsi:
     - v3.4.0
+    metallb/controller:
+    - v0.11.0
+    metallb/speaker:
+    - v0.11.0
     skopeo/stable:
     - latest
 

--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,6 @@ if [[ ! -d "$SYSCONFDIR" ]]; then
     echo >&2 "warning: no such directory: SYSCONFDIR: $SYSCONFDIR"
 fi
 
-: "${METALLB_YAML:="${SYSCONFDIR}/metallb.yaml"}"
-if [[ ! -f "$METALLB_YAML" ]]; then
-    echo >&2 "error: no such file: METALLB_YAML: $METALLB_YAML"
-    exit 1
-fi
-
 : "${SLS_INPUT_FILE:="${SYSCONFDIR}/sls_input_file.json"}"
 if [[ ! -f "$SLS_INPUT_FILE" ]]; then
     echo >&2 "error: no such file: SLS_INPUT_FILE: $SLS_INPUT_FILE"
@@ -54,9 +48,6 @@ function deploy() {
 deploy "${BUILDDIR}/manifests/storage.yaml"
 deploy "${BUILDDIR}/manifests/platform.yaml"
 deploy "${BUILDDIR}/manifests/keycloak-gatekeeper.yaml"
-
-# TODO Deploy metal-lb configuration
-kubectl apply -f "$METALLB_YAML"
 
 # Create secret with HPE signing key
 if [[ -f "${ROOTDIR}/hpe-signing-key.asc" ]]; then

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -239,7 +239,7 @@ spec:
       - quay.io/cephcsi/cephcsi:v3.4.0
   - name: cray-metallb
     source: csm-algol60
-    version: 0.13.0
+    version: 1.0.0
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm


### PR DESCRIPTION
## Summary and Scope

Update cray-metallb chart (1.0.0) to use upstream chart from metallb.io

## Issues and Related PRs

This change is dependent on csi change coming to generate metallb config for customizations.yaml

* Resolves [CASMPET-3521](https://connect.us.cray.com/jira/browse/CASMPET-3521)

## Testing

vshasta

### Tested on:

  * Virtual Shasta

### Test description:

Validated fresh install and upgrade from previous version.

## Risks and Mitigations

None known yet.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
