### PR TITLE
CASMPET-4953 1.2 : BI-CAN: Update keycloak to use the new API Gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak:2.1.0 for added Bi-CAN gateways
 - Released cray-opa v1.3.0 to Add BOS entries and fix xname validation
 - Released csm-testing v1.8.29 for ncn-kubernetes-checks pit fix
 - Released cray-s3:1.0.0 to move service endpoint to CMN for Bi-CAN

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -178,7 +178,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 2.0.0
+    version: 2.1.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bi-CAN : Update the virtual service ingress cray-keycloak gateways to also include customer-admin-gateway and customer-user-gateway.

backward compatible since the service-gateway still remains as an ingress gatgeway.

## Issues and Related PRs

* Resolves [CASMPET-4953](BI-CAN: Update keycloak to use the new API Gateways)
* Change will also be needed in NA
* Future work required - Release cray-keycloak for csm-1.2
* Documentation changes required NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:
 before
 ```
$ kubectl get vs -A | grep keycloak
services            keycloak                           ["services-gateway"]            ["*"]                             6h2m
 ```
 after
 ```
$ kubectl get vs -A | grep keycloak
services            keycloak                           ["services-gateway","customer-admin-gateway","customer-user-gateway"]   ["*"]                             6h9m
 ```

### Test description:

Verified that the expected change to cray-keycloak gateways was visible after upgrading.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ NA


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

