### PR TITLE
Bring in csm-testing v1.8.31 for precache image test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.31 for precache image test
 - Added no_wipe test to ncn-healthcheck suites
 - Updated spire health storage suite to only run after the PIT has been rebooted
 - Automated goss test improvements and additions

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.23-1.noarch
+    - csm-testing-1.8.31-1.noarch
     - docs-csm-1.12.8-1.noarch
-    - goss-servers-1.8.23-1.noarch
+    - goss-servers-1.8.31-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

New goss test to detect when precached images aren't being pulled on workers

## Issues and Related PRs

* Resolves [CASMPET-4862](https://connect.us.cray.com/jira/browse/CASMPET-4862)

## Testing

vshasa

### Tested on:

  * Virtual Shasta

### Test description:

Ran success/failure tests

## Risks and Mitigations

N/A


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable