### PR TITLE
CASMMON-72, CASMMON-101, CASMMON-100 : Enable SMART metrics, alerts and grafana dashboard for k8s nodes

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.15.4
+    version: 0.15.5
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
Made changes to plotform.yaml by bumping the sysmgmt-health version.
PR

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/38

Resolves

https://connect.us.cray.com/jira/browse/CASMMON-72
https://connect.us.cray.com/jira/browse/CASMMON-101
https://connect.us.cray.com/jira/browse/CASMMON-100

created release tag

https://github.com/Cray-HPE/cray-sysmgmt-health/releases/tag/v1.2.9