### PR TITLE
CASMINST-3427 - "LoadBalancer Services Have External IP" goss test failure on system with no CHN

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,7 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.23-1.noarch
+    - csm-testing-1.8.32-1.noarch
     - docs-csm-1.12.8-1.noarch
     - goss-servers-1.8.23-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

In CSM 1.2 if a system is not configured for CHN then the istio-ingressgateway-chn will be pending waiting for an IP address because the customer-high-speed MetalLB pool will not exist.

This will cause the original implementation of the "k8s_all_loadbalancers_have_external_ips" Goss test to always fail on a system without CHN even though it is in the expected state.

This update to the test determines whether CHN is configured by checking for the presence of the customer-high-speed pool and then filtering the list of LoadBalancers appropriately.

## Issues and Related PRs

* Resolves [CASMINST-3427](https://connect.us.cray.com/jira/browse/CASMINST-3427)

## Testing

### Tested on:

  * wasp
  * drax

### Test description:

#### wasp - system has CHN

| Test | Expected outcome | Actual outcome | 
| --- | --- | --- |
| Normal run | Test pass | Test pass |
| Run with pending istio-ingressgateway-chn LB | Test failure | Test failure | 
| Run with pending cray-dns-powerdns-hmn-tcp LB | Test failure | Test failure | 

#### drax - system does not have CHN

| Test | Expected outcome | Actual outcome | 
| --- | --- | --- |
| Normal run (istio-ingressgateway-chn LB will be pending due to no CHN | Test pass | Test pass |
| Run with pending cray-dns-powerdns-hmn-tcp LB | Test failure | Test failure | 

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
