### PR TITLE
MTL-1558 bundle HFP firmware in csm release tarball

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -20,6 +20,10 @@ STORAGE_CEPH_ASSETS=(
     https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.109/initrd.img-0.1.109.xz
 )
 
+HFP_FIRMWARE_ASSETS=(
+    https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/HFP-firmware/HFP-firmware-2.0.111516-0.tar.gz
+)
+
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
 
 set -exo pipefail
@@ -57,4 +61,5 @@ function cmd_retry
 for url in "${PIT_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
 for url in "${KUBERNETES_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
 for url in "${STORAGE_CEPH_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
+for url in "${HFP_FIRMWARE_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
 cmd_retry curl -sfSLI "$HPE_SIGNING_KEY"

--- a/release.sh
+++ b/release.sh
@@ -250,6 +250,13 @@ EOF
     createrepo "${BUILDDIR}/rpm/embedded"
 fi
 
+# Download HFP firmware assets
+(
+    mkdir -p "${BUILDDIR}/HFP"
+    cd "${BUILDDIR}/HFP"
+    for url in "${HFP_FIRMWARE_ASSETS[@]}"; do cmd_retry curl -sfSLOR "$url"; done
+)
+
 # Download HPE GPG signing key (for verifying signed RPMs)
 cmd_retry curl -sfSLRo "${BUILDDIR}/hpe-signing-key.asc" "$HPE_SIGNING_KEY"
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Includes the HFP firmware package in the release.

## Issues and Related PRs=

* Resolves MTL-1558
* Merge with https://github.com/Cray-HPE/cray-pre-install-toolkit/pull/26
* Merge with `docs PR`

## Testing

None.

### Tested on:

None.

### Test description:

None.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

