### PR TITLE
CASMMON-72, CASMMON-101, CASMMON-100 : Enable SMART metrics, alerts and grafana dashboard for k8s nodes

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -226,7 +226,7 @@ artifactory.algol60.net/csm-docker/stable:
     - v0.18.0
     docker.io/prom/snmp-exporter:
     - v0.20.0
-    docker.io/prom/node-exporter-smartmon
+    docker.io/prom/node-exporter-smartmon:
     - v0.1.0
     docker.io/library/redis: # XXX library/redis
     - 5.0-alpine3.12

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -226,6 +226,8 @@ artifactory.algol60.net/csm-docker/stable:
     - v0.18.0
     docker.io/prom/snmp-exporter:
     - v0.20.0
+    docker.io/prom/node-exporter-smartmon
+    - v0.1.0
     docker.io/library/redis: # XXX library/redis
     - 5.0-alpine3.12
     - 5.0-alpine


### PR DESCRIPTION
added node-exporter-smartmon path for 

https://connect.us.cray.com/jira/browse/CASMMON-72
https://connect.us.cray.com/jira/browse/CASMMON-101
https://connect.us.cray.com/jira/browse/CASMMON-100

container images:

https://github.com/Cray-HPE/container-images/pull/345

cray-sysmgmt-health:
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/38