### PR TITLE
CASMTRIAGE-2730 Fix access-spire network policy

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -17,7 +17,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.10.0
+    version: 2.11.0
     namespace: loftsman
   - name: gatekeeper
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,5 +159,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.2.0
+    version: 1.2.1
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

- cray-drydock is updated to 2.11.0 in order to add name label to all namespaces
- cray-spire is updated to 1.2.1 in order to fix access-spire network policy

## Issues and Related PRs

* Resolves - [CASMPET-4344](https://connect.us.cray.com/jira/browse/CASMPET-4344)

## Testing

### Tested on:

  * wasp
  * Virtual Shasta