### PR TITLE
CASMPET-4277: Switch from keycloak-gatekeeper to oauth2-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- oauth2-proxy is now used in place of keycloak-gatekeeper.
 - Updated cray-nexus to 0.8.0 to add ingress gateways
 - Released csm-testing v1.8.31 for precache image test
 - Released cray-keycloak:2.1.0 for added Bi-CAN gateways

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -126,8 +126,6 @@ artifactory.algol60.net/csm-docker/stable:
     - v0.14.1
     quay.io/jetstack/cert-manager-webhook:
     - v0.14.1
-    quay.io/keycloak/keycloak-gatekeeper: # XXX keycloak/keycloak-gatekeeper
-    - 9.0.0
     # k8s.gcr.io images
     k8s.gcr.io/coredns:
     - 1.7.0
@@ -327,7 +325,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 2.6.76
 
     cray-keycloak-setup:
-    - 1.0.0  # cray-keycloak, cray-keycloak-users-localize
+    - 2.0.0  # cray-keycloak, cray-keycloak-users-localize
     - 0.14.4  # keycloak-vcs-user
     cray-meds:
     - 1.17.0
@@ -421,6 +419,8 @@ quay.io:
     - v3.4.0
     skopeo/stable:
     - latest
+    oauth2-proxy/oauth2-proxy:
+    - v7.2.0
 
 k8s.gcr.io:
   images:

--- a/docker/transform.sh
+++ b/docker/transform.sh
@@ -85,7 +85,6 @@ DISTDIR=$1
     mv -v quay.io/bitnami/* bitnami/
     mv -v quay.io/coreos coreos/
     mv -v quay.io/jetstack jetstack/
-    mv -v quay.io/keycloak/ keycloak/
     mv -v quay.io/prometheus/ prometheus/
     mv -v quay.io/sighup/ sighup/
     mv -v registry.opensource.zalan.do/acid/ acid/

--- a/manifests/keycloak-gatekeeper.yaml
+++ b/manifests/keycloak-gatekeeper.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: cray-keycloak-gatekeeper
     source: csm-algol60
-    version: 1.0.0
+    version: 2.0.0
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -178,11 +178,11 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 2.1.0
+    version: 3.0.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.9.0
+    version: 1.9.1
     namespace: services
   - name: cray-node-discovery
     source: csm
@@ -248,4 +248,8 @@ spec:
   - name: cray-node-labels
     source: csm-algol60
     version: 0.4.0
+    namespace: services
+  - name: cray-oauth2-proxies
+    source: csm-algol60
+    version: 0.1.1
     namespace: services

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -56,17 +56,22 @@ spec:
       # destination in this list, it should be removed.
       routes: []
   proxiedWebAppExternalHostnames:
-  - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
-  - '{{ kubernetes.services[''cray-nexus''].istio.ingress.hosts.ui.authority }}'
-  - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
-  - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
-  - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].prometheus.prometheusSpec.externalAuthority }}'
-  - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].alertmanager.alertmanagerSpec.externalAuthority }}'
-  - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].grafana.externalAuthority }}'
-  - '{{ kubernetes.services.gitea.externalHostname }}'
-  - sma-grafana.cmn.{{ network.dns.external }}
-  - sma-kibana.cmn.{{network.dns.external}}
-  - csms.cmn.{{ network.dns.external }}
+    customerManagement:
+    - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
+    - '{{ kubernetes.services[''cray-nexus''].istio.ingress.hosts.ui.authority }}'
+    - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
+    - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
+    - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].prometheus.prometheusSpec.externalAuthority }}'
+    - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].alertmanager.alertmanagerSpec.externalAuthority }}'
+    - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].grafana.externalAuthority }}'
+    - '{{ kubernetes.services.gitea.externalHostname }}'
+    - sma-grafana.cmn.{{ network.dns.external }}
+    - sma-kibana.cmn.{{network.dns.external}}
+    - csms.cmn.{{ network.dns.external }}
+    customerAccess:
+    - capsules.can.{{ network.dns.external }}
+    customerHighSpeed:
+    - capsules.chn.{{ network.dns.external }}
   kubernetes:
     # These are sealed secrets that HPE WILL overwrite during migrations.
     # Customer changes will be lost.
@@ -223,6 +228,36 @@ spec:
               args:
                 name: ldap_connection_url
                 value: ""
+      cray-oauth2-proxy-customer-management:
+        generate:
+          name: cray-oauth2-proxy-customer-management
+          data:
+          - type: randstr
+            args:
+              name: cookie-secret
+              length: 32
+              encoding: base64
+              url_safe: yes
+      cray-oauth2-proxy-customer-access:
+        generate:
+          name: cray-oauth2-proxy-customer-access
+          data:
+          - type: randstr
+            args:
+              name: cookie-secret
+              length: 32
+              encoding: base64
+              url_safe: yes
+      cray-oauth2-proxy-customer-high-speed:
+        generate:
+          name: cray-oauth2-proxy-customer-high-speed
+          data:
+          - type: randstr
+            args:
+              name: cookie-secret
+              length: 32
+              encoding: base64
+              url_safe: yes
     services:
       # Strive for readability. Keep services lexicographically sorted by chart
       # name. Seperate chart customizations by a blank line.
@@ -338,20 +373,19 @@ spec:
           keycloak:
             customerAccessUrl: https://auth.cmn.{{ network.dns.external }}/keycloak
             gatekeeper:
-              proxiedHosts: '{{ proxiedWebAppExternalHostnames }}'
-            oauth2Proxy:
-              proxiedHosts: '{{ proxiedWebAppExternalHostnames }}'
+              proxiedHosts: '{{ proxiedWebAppExternalHostnames.customerManagement }}'
+            clients:
+              oauth2-proxy-customer-management:
+                proxiedHosts: '{{ proxiedWebAppExternalHostnames.customerManagement }}'
+              oauth2-proxy-customer-access:
+                proxiedHosts: '{{ proxiedWebAppExternalHostnames.customerAccess }}'
+              oauth2-proxy-customer-high-speed:
+                proxiedHosts: '{{ proxiedWebAppExternalHostnames.customerHighSpeed }}'
             service: keycloak.services
             clusterGw:
               route: /keycloak
               dnsName: '{{ network.dns.internal_api }}'
         internalTokenUrl: https://{{ network.dns.internal_api }}/keycloak/realms/master/protocol/openid-connect/token
-      cray-keycloak-gatekeeper:
-        hostAliases:
-          - ip: '{{ network.netstaticips.nmn_api_gw }}'
-            hostnames:
-              - 'auth.cmn.{{ network.dns.external }}'
-        hosts: '{{ proxiedWebAppExternalHostnames }}'
       cray-kiali:
         externalAuthority: kiali-istio.cmn.{{ network.dns.external }}
         kiali-operator:
@@ -387,6 +421,31 @@ spec:
               ipv4:
                 - label: river
                   network: '{{ network.hmn }}'
+      cray-oauth2-proxies:
+        customer-management:
+          sealedSecrets:
+          - '{{ kubernetes.sealed_secrets[''cray-oauth2-proxy-customer-management''] | toYaml }}'
+          hostAliases:
+          - ip: '{{ network.netstaticips.nmn_api_gw }}'
+            hostnames:
+            - 'auth.cmn.{{ network.dns.external }}'
+          hosts: '{{ proxiedWebAppExternalHostnames.customerManagement }}'
+        customer-access:
+          sealedSecrets:
+          - '{{ kubernetes.sealed_secrets[''cray-oauth2-proxy-customer-access''] | toYaml }}'
+          hostAliases:
+          - ip: '{{ network.netstaticips.nmn_api_gw }}'
+            hostnames:
+            - 'auth.cmn.{{ network.dns.external }}'
+          hosts: '{{ proxiedWebAppExternalHostnames.customerAccess }}'
+        customer-high-speed:
+          sealedSecrets:
+          - '{{ kubernetes.sealed_secrets[''cray-oauth2-proxy-customer-high-speed''] | toYaml }}'
+          hostAliases:
+          - ip: '{{ network.netstaticips.nmn_api_gw }}'
+            hostnames:
+            - 'auth.cmn.{{ network.dns.external }}'
+          hosts: '{{ proxiedWebAppExternalHostnames.customerHighSpeed }}'
       cray-powerdns-manager:
         manager:
           primary_server: "{{ network.dns.primary_server_name }}/{{ network.netstaticips.site_to_system_lookups }}"

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/docs/SEALED-SECRETS.md
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/docs/SEALED-SECRETS.md
@@ -121,7 +121,10 @@ The source for generators can be found in `utils/generators`.
 
 ## Random String
 
-This uses `openssl rand -hex` to generate a random string of given length
+This uses `openssl rand -hex` to generate a random string of given length if
+the encoding is `hex` or `openssl rand -base64` if the encoding is `base64`.
+If `url_safe` is true "*" and "/" characters in the base-64 encoded value are
+translated to "-" and "_".
 
 Usage:
 
@@ -129,7 +132,9 @@ Usage:
     - type: randstr
       args:
         name: {field name} # Required
-        length: {length of string in int} # Required
+        length: {length of string in int} # Optional, defaults to 32
+        encoding: {hex or base64} # Optional, defaults to hex
+        url_safe: {no or yes} # Optional, defaults to no
 ```
 
 Returns:

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils/generators/randstr
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils/generators/randstr
@@ -1,5 +1,26 @@
 #!/bin/bash
-# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+
+# MIT License
+#
+# (C) Copyright [2021] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 
 ARGS=${1}
 YQ=${2}
@@ -11,13 +32,32 @@ OUT_FILE=${4}
 # length - length of random string
 
 LENGTH=$(echo $ARGS | $YQ r - 'length')
+ENCODING=$(echo $ARGS | $YQ r - 'encoding')
+URL_SAFE=$(echo $ARGS | $YQ r - 'url_safe')
 
 if [[ -z "LENGTH" ]]; then
     LENGTH="32"
 fi
 
+if [[ -z "ENCODING" ]]; then
+    ENCODING="hex"
+fi
+
+if [[ -z "URL_SAFE" ]]; then
+    URL_SAFE="no"
+fi
+
 # Note: Wrap keys in [] to allow for periods.
 KEY="data[$(echo $ARGS | $YQ r - 'name')]"
-VALUE=$(openssl rand -hex $LENGTH)
+
+if [[ $ENCODING == "hex" ]]; then
+  VALUE=$(openssl rand -hex $LENGTH)
+else
+  VALUE=$(openssl rand -base64 $LENGTH)
+fi
+
+if [[ $URL_SAFE == "yes" ]]; then
+  VALUE=$(echo -n $VALUE | tr -- '+/' '-_')
+fi
 
 $YQ w -i "$OUT_FILE" "$KEY" "$(echo -n "$VALUE" | base64)"


### PR DESCRIPTION
This commit includes the following JIRAs:

* CASMPET-4714: Update keycloak-installer to reflect new chart setup. (keycloak-setup creates the oauth2-proxy client)
* CASMPET-5158: Release keycloak-installer for CSM 1.2 (Releases CASMPET-4714 so the oauth2-proxy client will exist)
* CASMPET-5156: Stop deploying keycloak-gatekeeper objects (switch to this version of cray-keycloak-gatekeeeper in csm manifest)
* CASMPET-5154: Generate cookie secret and pass to oauth2-proxy
* CASMPET-5155: Another oauth2-proxy-ingress for another interface (oauth2-proxy bi-can)
* CASMPET-5169: oauth2-proxy v7.1.3 image has several vulnerabilites

While there's still a cray-keycloak-gatekeeper chart it doesn't deploy
any K8s objects anymore. Helm cleans the up the objects on upgrade to
make room for the oauth2-proxy objects. The keycloak-gatekeeper image
is no longer used.

The randstr generator is enhanced to allow it to generate a cookie
value that's valid for the oauth2-proxy.
See https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/ ,
"Generating a Cookie Secret" in the "Bash" tab. This is used to
generate SealedSecrets used by the cray-oauth2-proxies chart.

the cray-keycloak chart no longer creates the oauth2-proxy client
(added recently to 1.2 only), it now creates 3 oauth2-proxy-*
clients, one for each interface (this is to support Bi-CAN).
