### PR TITLE
Bump version CASMINST-3537 CASMINST-3591

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.15.6
+    version: 0.16.0
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.16.0
+    version: 0.16.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
Made changes to plotform.yaml by bumping the sysmgmt-health version.
https://connect.us.cray.com/jira/browse/CASMINST-3537


https://connect.us.cray.com/jira/browse/CASMINST-3591

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/40

created release tag

https://github.com/Cray-HPE/cray-sysmgmt-health/releases/tag/v1.2.10
