### PR TITLE
CASMPET-4873:  Generate metallb config in customizations.yaml

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -7,7 +7,7 @@ http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/x86_64/release/csm-1.0
     - loftsman-1.1.0-20210511145236_2da0507.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.10.2-1.x86_64
+    - cray-site-init-1.10.3-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

Generates the metalLB config in the customizations.yaml so the config map can get rendered into the new metallb chart.
This will still generate the metallb.yaml as well until we confirm that the config map within the chart is fully working.

I will remove the generation of the metallb.yaml once we determine that the new metallb chart is stable.

## Issues and Related PRs

* Resolves [CASMPET-4873](https://connect.us.cray.com/jira/browse/CASMPET-4873)
* Requires https://github.com/Cray-HPE/csm/pull/121

### Tested on:

  * surtur

### Test description:

Generated files with CSI and verified that both the metallb.yaml and customizations.yaml look correct.
I tested both with and without the CHN network defined.
 
 
## Risks and Mitigations
 
Low risk since we are still generating the metallb.yaml as well.  That can be a fallback.

