### PR TITLE
CASMINST-3587 1.2 : TEST - Fanta - preflight check failed - remove fr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.33 to remove preflight tests
 - Updated cray-nexus to 0.8.0 to add ingress gateways
 - Released csm-testing v1.8.31 for precache image test
 - Released cray-keycloak:2.1.0 for added Bi-CAN gateways

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.32-1.noarch
+    - csm-testing-1.8.33-1.noarch
     - docs-csm-1.12.11-1.noarch
-    - goss-servers-1.8.31-1.noarch
+    - goss-servers-1.8.33-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope
Removes tests that fails as part of the upgrade from 1.0 given that these interfaces are not setup until csm-1.2

## Issues and Related PRs

* Resolves [CASMINST-3587](https://connect.us.cray.com/jira/browse/CASMINST-3587)
* Change will also be needed in main
* Future work required by NA
* Documentation changes required NA
* Merge with/before/after NA

## Testing
NA

## Risks and Mitigations
NA

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable