### PR TITLE
CASMPET-3585 Bump the cray-keycloak chart patch version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -178,7 +178,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
This includes the following fix:

CASMPET-3585 Corrects a mistake in the cray-keycloak chart where the nexus client secret environment variable name was incorrect.
( https://github.com/Cray-HPE/keycloak-installer/pull/29 )

