### PR TITLE
CASMINST-3525: update csm-config for gitea import issues

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -371,7 +371,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-uas-mgr:
     - 1.12.1-release-1
     csm-config:
-    - 1.6.14
+    - 1.6.20
     csm-ssh-keys:
     - 1.1.18
     docker.io/gitea/gitea:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -121,7 +121,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.6.14
+    version: 1.6.20
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Fix gitea import when upgrading a Cray EX product (like CSM) but the gitea import version of csm-config has not changed.

## Issues and Related PRs

* Resolves [CASMINST-3525](https://connect.us.cray.com/jira/browse/CASMINST-3525)
* Merge after https://github.com/Cray-HPE/csm-config/pull/25

## Testing

See testing description in https://github.com/Cray-HPE/csm-config/pull/25

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

