### PR TITLE
CASMINST-3603: Bump csm-testing to 1.8.34

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.33-1.noarch
+    - csm-testing-1.8.34-1.noarch
     - docs-csm-1.12.12-1.noarch
-    - goss-servers-1.8.33-1.noarch
+    - goss-servers-1.8.34-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64


### PR DESCRIPTION
This includes the fix for:

* CASMINST-3603: ncnhealthchecks failed for goss k8 monitoring URL test case
