### PR TITLE
kea and unbound updates for CASMNET-941, CASMNET-943, CASMNET-1024, C…

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -301,12 +301,12 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.3.50
 
     cray-dhcp-kea:
-    - 0.9.10 # update platform.yaml cray-precache-images with this
+    - 0.9.11 # update platform.yaml cray-precache-images with this
 
     cray-dns-powerdns:
     - 0.1.5 # update platform.yaml cray-precache-images with this
     cray-dns-unbound:
-    - 0.6.9 # update platform.yaml cray-precache-images with this
+    - 0.6.10 # update platform.yaml cray-precache-images with this
 
     cray-firmware-action:
     - 1.13.0

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -44,13 +44,13 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.9.10
+    version: 0.9.11
     namespace: services
 
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.6.9
+    version: 0.6.10
     namespace: services
     values:
       global:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -221,8 +221,8 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
-      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.10
-      - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.9
+      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.11
+      - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.10
       - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.5
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.7.8-cray2-distroless


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- recovery of Unbound PID during warm reload of configs
- post and patch in Kea dhcp-helper
- removal of dtr references in Kea and Unbound
- fix false postive in Kea dhcp-helper error log
- automate repair of SMD ethernet interface table data after hardware swap in Kea dhcp-helper


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves
  - CASMNET-941
  - CASMNET-943
  - CASMNET-1024
  - CASMTRIAGE-2729
  - CASMNET-1037
  - CASMNET-1049


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Wasp

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- tested on wasp with various data loads and discovery wipes

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? 
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

