### PR TITLE
CASMTRIAGE-2732 - Fix barebones image boot test script.

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -19,7 +19,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
-    - cray-cmstools-crayctldeploy-1.2.105-1.x86_64
+    - cray-cmstools-crayctldeploy-1.2.109-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-1.0.13-1.x86_64
     - craycli-0.41.11-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -2,7 +2,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cray-cmstools-crayctldeploy-1.2.107-1.x86_64
+    - cray-cmstools-crayctldeploy-1.2.109-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
## Summary and Scope
This fixes a bug in the barebones image boot test script where the user input for which compute node to use for the test was being ignored.  Without this fix a random compute node was always used, with this fix the user may specify which node to use.

## Issues and Related PRs
Code PR: https://github.com/Cray-HPE/cms-tools/pull/18

* Resolves [CASMTRIAGE-2732](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2732)

## Testing
### Tested on:
  * `Wasp`

### Test description:

I loaded the modified script on wasp and disabled that portion of the script that actually initiates the boot, but kept the argument processing and finding a compute node to use for the test. I verified that when a node is specified on the command line it now flows through to the function that looks for an available node. I also tested scenarios where there is nothing passed in and where an incorrect node xname is used.

Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
Were continuous integration tests run? If not, why? N - this is a test script
Was upgrade tested? If not, why? N - this is a test script installed via rpm.
Was downgrade tested? If not, why? N - this is a test script installed via rpm.
Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

This is a low risk change - it just modifies handling an optional input argument to a test script. It will not impact any running system.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
