### PR TITLE
CASMPET-5033: Update image refs for keycloak-installer

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -322,7 +322,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 2.6.76
 
     cray-keycloak-setup:
-    - 2.0.0  # cray-keycloak, cray-keycloak-users-localize
+    - 3.0.0  # cray-keycloak, cray-keycloak-users-localize
     - 0.14.4  # keycloak-vcs-user
     cray-meds:
     - 1.17.0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -178,11 +178,11 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.0.1
+    version: 3.2.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.9.1
+    version: 1.10.0
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
This bumps the versions of the charts that are built by
keycloak-installer to the versions that include the change for:

* CASMPET-5033: Update image refs in Helm charts

The images refs that were changed in the charts are already in
the docker/index.yaml file.
