### PR TITLE
CASMPET-5178 Bump spire to 1.3.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,5 +159,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.2.1
+    version: 1.3.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This changes all spire containers to run as nobody instead of root.

## Issues and Related PRs

* Resolves [CASMPET-5178](https://connect.us.cray.com/jira/browse/CASMPET-5178)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated running containers in the spire namespace no longer ran as root.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/.A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y 
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

None
