### PR TITLE
CASMCMS-7691: Fix broken IMS signing keys test

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -19,7 +19,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
-    - cray-cmstools-crayctldeploy-1.2.105-1.x86_64
+    - cray-cmstools-crayctldeploy-1.2.114-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-1.0.13-1.x86_64
     - craycli-0.41.11-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -2,7 +2,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cray-cmstools-crayctldeploy-1.2.107-1.x86_64
+    - cray-cmstools-crayctldeploy-1.2.114-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
This fixes the test which is causing the CMS part of the CSM health check procedure to fail on every 1.2 install.

See original PR for details:
https://github.com/Cray-HPE/cms-tools/pull/20

This is ready to be merged, pending approvals.