### PR TITLE
CASMMON-57: Bump version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.17.0
+    version: 0.18.0
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
Made changes to plotform.yaml by bumping the sysmgmt-health version.
https://connect.us.cray.com/jira/browse/CASMMON-57

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/43

created release tag

https://github.com/Cray-HPE/cray-sysmgmt-health/releases/tag/v1.2.12