### PR TITLE
CASMTRIAGE-2771 - Correct cray-dns-unbound image version

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -54,7 +54,7 @@ spec:
     namespace: services
     values:
       global:
-        appVersion: 0.6.9
+        appVersion: 0.6.10
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns


### PR DESCRIPTION
## Summary and Scope

The appVersion for cray-dns-unbound doesn't match the image specified in the docker index.yaml file.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2771](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2771)

## Testing

### Tested on:

  * `surtur`

### Test description:

Updated manifest and deployed using standard install automation.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

