### PR TITLE
CASMPET-5171: Bump Keycloak versions  to pick up CSM 1.2 Release 6

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -327,7 +327,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 2.6.76
 
     cray-keycloak-setup:
-    - 2.0.0  # cray-keycloak, cray-keycloak-users-localize
+    - 3.0.0  # cray-keycloak, cray-keycloak-users-localize
     - 0.14.4  # keycloak-vcs-user
     cray-meds:
     - 1.17.0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -178,11 +178,11 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.0.1
+    version: 3.1.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.9.1
+    version: 1.9.2
     namespace: services
   - name: cray-node-discovery
     source: csm


### PR DESCRIPTION
This picks up the change for:

* CASMPET-5171: keycloak-setup stop creating gatekeeper client

See https://github.com/Cray-HPE/keycloak-installer/releases/tag/v1.2.6
