### PR TITLE
CASMHMS-5205 Reorder HMS CT smoke test execution csm-1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -344,7 +344,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-sls:
     - 1.12.0
     cray-smd:
-    - 1.33.0
+    - 1.36.0
     cray-sonar:
     - 0.2.0
     cray-tftpd:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,7 +19,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 1.36.0
+    version: 2.0.1
     namespace: services
     values:
       cray-service:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,7 +19,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 1.33.0
+    version: 1.36.0
     namespace: services
     values:
       cray-service:

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - goss-servers-1.8.34-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
-    - hms-ct-test-base-1.9.0-1.x86_64
+    - hms-ct-test-base-1.10.0-1.x86_64
     - hms-fas-ct-test-1.13.0-1.x86_64
     - hms-hmcollector-ct-test-2.14.0-1.x86_64
     - hms-hbtd-ct-test-1.13.0-1.x86_64
@@ -41,7 +41,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-rts-ct-test-1.15.0-1.x86_64
     - hms-scsd-ct-test-1.8.0-1.x86_64
     - hms-sls-ct-test-1.11.0-1.x86_64
-    - hms-smd-ct-test-1.32.0-1.x86_64
+    - hms-smd-ct-test-1.36.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.4-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change updates the HMS CT smoke tests to execute the HSM tests first to more easily and clearly identify discovery-related problems.

### Issues and Related PRs

* Resolves CASMHMS-5205 in csm-1.2

### Testing

This change was tested by deploying the updated smoke tests and wrapper script to Wasp, executing them, and verifying that the HSM tests ran first. Failures of the HSM smoke tests were also verified to stop execution of the wrapper script as expected.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.