### PR TITLE
CASMNET-2052 - fix for dhcp-helper support for csm-1.0 bss data

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -301,7 +301,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.3.50
 
     cray-dhcp-kea:
-    - 0.9.11 # update platform.yaml cray-precache-images with this
+    - 0.9.12 # update platform.yaml cray-precache-images with this
 
     cray-dns-powerdns:
     - 0.1.5 # update platform.yaml cray-precache-images with this

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -44,7 +44,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.9.11
+    version: 0.9.12
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -221,7 +221,7 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
-      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.11
+      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.12
       - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.10
       - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.5
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- bugfix in dhcp-helper to append the static mac data for csm-1.0 bss data format

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
- yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
CASMNET-1052

## Testing

_List the environments in which these changes were tested._

### Tested on:

Fanta
Wasp

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? not sure what we have for this other than manual installs
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

no
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

