### PR TITLE
CASMPET-5173 swap-in pit-nexus for cray-nexus

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,9 +3,9 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211130204022-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211130204022-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211130204022-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211201170630-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211201170630-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211201170630-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -15,6 +15,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - metal-ipxe-2.0.9-1.noarch
     - metal-net-scripts-0.0.2-1.noarch
     - pit-init-1.2.12-1.noarch
+    - pit-nexus-1.1.0-1.1.x86_64
     - ilorest-3.2.3-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
@@ -44,7 +45,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-smd-ct-test-1.32.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.4-1.noarch
-    - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-0.0.6-1.x86_64
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

**LiveCD is included in `assets.sh`**.

This swaps the old cray-nexus RPM for the new [pit-nexus RPM ](https://github.com/Cray-HPE/pit-nexus), this work is tagged with the recent bugfix for pit-nexus [CASMPET-5173](https://connect.us.cray.com/jira/browse/CASMPET-5173).

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5173](https://connect.us.cray.com/jira/browse/CASMPET-5173)
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `redbull`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Purging cray-nexus and installing pit-nexus resulted in a 🟢 good smoke-test of an NCN deployment; all NCNs deployed, k8s and ceph included. No CSM install was done.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

None.
