### PR TITLE
Update hmcollector manifest version for HPE PDU support 1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -371,7 +371,7 @@ artifactory.algol60.net/csm-docker/stable:
     hms-discovery:
     - 1.9.0
     hms-hmcollector:
-    - 2.14.0
+    - 2.15.1
     hms-pytest:
     - 2.0.0
     hms-redfish-translation-service:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -371,7 +371,7 @@ artifactory.algol60.net/csm-docker/stable:
     hms-discovery:
     - 1.9.0
     hms-hmcollector:
-    - 2.15.1
+    - 2.15.0
     hms-pytest:
     - 2.0.0
     hms-redfish-translation-service:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.14.0
+    version: 2.15.1
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the hmcollector manifest version for HPE PDU support.

## Issues and Related PRs

* Resolves [CASMHMS-5268](https://connect.us.cray.com/jira/browse/CASMHMS-5268)

## Testing

For testing see https://github.com/Cray-HPE/hms-hmcollector/pull/32

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

