### PR TITLE
CASMREL-834: NCN assets for csm-1.2

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -9,15 +9,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.26/kubernetes-0.2.26.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.26/5.3.18-59.19-default-0.2.26.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.26/initrd.img-0.2.26.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.27/kubernetes-0.2.27.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.27/5.3.18-59.19-default-0.2.27.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.27/initrd.img-0.2.27.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.26/storage-ceph-0.2.26.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.26/5.3.18-59.19-default-0.2.26.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.26/initrd.img-0.2.26.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.27/storage-ceph-0.2.27.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.27/5.3.18-59.19-default-0.2.27.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.27/initrd.img-0.2.27.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

Fixes:
* CASMINST-3627 (via node-image-build)
* CASMHMS-5205 (via csm-rpms)
