### PR TITLE
CASMPET-5187 Disable xname validation by default

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.3.0
+    version: 1.5.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,5 +159,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.3.0
+    version: 1.4.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This disabled the xname workloads and validation by default. We won't be enabling them by default until we're sure it will work without a performance hit.

## Issues and Related PRs

* Resolves [CASMPET-5187](https://connect.us.cray.com/jira/browse/CASMINST-5187)
