### PR TITLE
CASMNET-859 - Run PowerDNS as non-privileged user

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -304,7 +304,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.9.11 # update platform.yaml cray-precache-images with this
 
     cray-dns-powerdns:
-    - 0.1.5 # update platform.yaml cray-precache-images with this
+    - 0.2.2 # update platform.yaml cray-precache-images with this
     cray-dns-unbound:
     - 0.6.10 # update platform.yaml cray-precache-images with this
 

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -59,11 +59,11 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.1.5
+    version: 0.2.2
     namespace: services
     values:
       global:
-        appVersion: 0.1.5
+        appVersion: 0.2.2
 
   - name: cray-powerdns-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -223,7 +223,7 @@ spec:
       - dtr.dev.cray.com/baseos/busybox:1
       - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.11
       - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.10
-      - dtr.dev.cray.com/cray/cray-dns-powerdns:0.1.5
+      - dtr.dev.cray.com/cray/cray-dns-powerdns:0.2.2
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.7.8-cray2-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless


### PR DESCRIPTION
## Summary and Scope

Run PowerDNS as a non-root user

## Issues and Related PRs

* Resolves [CASMNET-859](https://connect.us.cray.com/jira/browse/CASMNET-859)

## Testing

### Tested on:

  * `wasp`
  * Local development environment

### Test description:

Release was installed on wasp and it was verified the processes were running as the correct user
```
# kubectl -n services exec -it cray-dns-powerdns-6647d4c5fd-hg95m -c cray-dns-powerdns -- sh
/ $ id
uid=100(pdns) gid=101(pdns)
/ $ ps -ef
PID   USER     TIME  COMMAND
    1 pdns      0:00 {powerdns} /bin/bash /bin/powerdns
   86 pdns      0:00 pdns_server
   88 pdns      0:04 pdns_server-instance
 1068 pdns      0:00 sh
 1075 pdns      0:00 ps -ef
```
ExternalDNS functionality was verified by testing access to several web services (Grafana and Gitea).

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

