### PR TITLE
CASMPET-5031: Updates to cray-drydock for casm-2670

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -336,7 +336,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-smd:
     - 1.33.0
     cray-sonar:
-    - 0.2.0
+    - 0.2.1
     cray-tftpd:
     - 1.7.1
 

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -17,7 +17,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.11.0
+    version: 2.12.0
     namespace: loftsman
   - name: gatekeeper
     source: csm-algol60


### PR DESCRIPTION
Updating cray-drydock to CSM 1.2 Release 3, see
https://github.com/Cray-HPE/cray-drydock/releases/tag/v1.2.3
