### PR TITLE
CASMINST-3544 bios-baseline timeout

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.34-1.noarch
+    - csm-testing-1.8.35-1.noarch
     - docs-csm-1.12.12-1.noarch
-    - goss-servers-1.8.34-1.noarch
+    - goss-servers-1.8.35-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.9.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Change timeout from 1000ms to 5000ms to wait longer for output to
return. In many cases output will emit before 1000ms, but it can take
slightly longer. 5000ms would cover most if not all cases.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3544](https://connect.us.cray.com/jira/browse/CASMINST-3544)
* Change will also be needed in `release/csm-1.2`
* Merge with https://github.com/Cray-HPE/csm/pull/201

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

If a system's networking is bogged or non-optimal, 5000ms might not be enough. However in those cases there would seem to be larger problems afoot, and this test should be disregarded until those larger problems are fixed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

