### PR TITLE
CASMHMS-5261 Fix power capping for newer nC firmware

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -279,7 +279,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.8.200
 
     cray-capmc:
-    - 1.30.0
+    - 1.31.0
 
     cray-cfs:
     - 1.8.83

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -24,7 +24,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 2.0.1
+    version: 2.0.2
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

The Shasta 1.5 firmware moved to a new power capping control schema. Fix an issue where trying to power cap more than one control at the same time was hanging.

### Issues and Related PRs

* Resolves CASMHMS-5261

### Testing

Tested on:
* hela

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Manually set power cap values on a single control and multiple controls. Verified via logs that the proper number of controls were attempted and the targets were correct.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y

Firmware currently broken for Mountain nodes with GPUs: SDEVICE-3701 - Controls API timing out occasionally