### PR TITLE
CASMNET-1059: Bump CANU version to 1.0.0

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -45,6 +45,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.4-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-0.0.6-1.x86_64
+    - canu-1.0.0-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.29-1.noarch


### PR DESCRIPTION
## Summary and Scope

CANU has been updated to feature complete as of the 1.0.0 release and needs to be included in CSM 1.2 build.

## Issues and Related PRs


* Resolves CASMNET-1059
* Merge with `https://github.com/Cray-HPE/csm-rpms/pull/149`

### Tested on:

  * `wasp`
  * Local development environment


### Test description:

* Tested upgrade from 0.0.5 and 0.0.6 to 1.0.0.
* On system testing of SHCD validate, configuration generation and validation and cabling checks.

- Were continuous integration tests run? **YES**
- Was upgrade tested? **YES**
- Was downgrade tested? **NO** as downgrade to 0.0.6 or lower will not be useful on CSM 1.2 systems.

## Risks and Mitigations
None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

