### PR TITLE
Bugfix/casminst 3477/CASMNET-1053/CASMNET-1054/CASMNET-1055 -  csm 1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -301,7 +301,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.3.50
 
     cray-dhcp-kea:
-    - 0.9.11 # update platform.yaml cray-precache-images with this
+    - 0.9.13 # update platform.yaml cray-precache-images with this
 
     cray-dns-powerdns:
     - 0.2.2 # update platform.yaml cray-precache-images with this

--- a/lib/wait-for-unbound.sh
+++ b/lib/wait-for-unbound.sh
@@ -4,8 +4,9 @@
 
 set -exo pipefail
 
-# Clean-up unbound-manager jobs
-clean_up_unbound_manager_jobs()
+# Clean-up unbound-manager jobs that didn't finish before validating unbound
+clean_up_unbound_manager_jobs
+
 # Wait for SLS init load job to complete
 kubectl wait -n services job cray-sls-init-load --for=condition=complete --timeout=20m
 
@@ -64,7 +65,8 @@ function verify() {
 }
 
 function clean_up_unbound_manager_jobs() {
-unbound_manager_jobs=$(kubectl get jobs -n services |awk '{ print $1 }'|grep unbound-manager)
+
+    unbound_manager_jobs=$(kubectl get jobs -n services |awk '{ print $1 }'|grep unbound-manager)
 
     for job in $unbound_manager_jobs; do
         job_entry=$(kubectl get jobs -n services $job|sed 1d)
@@ -73,14 +75,14 @@ unbound_manager_jobs=$(kubectl get jobs -n services |awk '{ print $1 }'|grep unb
             echo $job_id
             job_status=$(echo $job_entry| awk '{ print $2 }')
             echo $job_status
-    #	if [[ "$job_status" -eq "0/1" ]];then
-        if [[ "$job_status" -eq "1/1" ]];then
-                echo "delete stale job"
-    #		kubectl delete jobs -n services $job_id
+    	if [[ "$job_status" -eq "0/1" ]];then
+            echo "deleting stale job"
+    		kubectl delete jobs -n services $job_id
             echo "kubectl delete jobs -n services $job_id"
         fi
     done
 }
+
 ingress_ip="$(kubectl get -n istio-system service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
 
 # Verify Unbound is can resolve the expected addresses

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -44,7 +44,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.9.11
+    version: 0.9.13
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -221,7 +221,7 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
-      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.11
+      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.13
       - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.10
       - dtr.dev.cray.com/cray/cray-dns-powerdns:0.2.2
       - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -221,10 +221,10 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
-      - dtr.dev.cray.com/cray/cray-dhcp-kea:0.9.13
-      - dtr.dev.cray.com/cray/cray-dns-unbound:0.6.10
-      - dtr.dev.cray.com/cray/cray-dns-powerdns:0.2.2
-      - dtr.dev.cray.com/cray/cray-powerdns-manager:0.3.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.9.13
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.6.10
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.2
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.3.2
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.7.8-cray2-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
       - k8s.gcr.io/pause:3.2


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- error handling when query bss data if data is returned that is not expected
- make sure dhcp-helper does not patch in an IP when there is already an IP outside of loading BSS data
- make sure xname is used when trying to repair SMD data after node move
- csm-service-upgrade.sh "hangs" at cray-dns-unbound-manager section

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves
CASMNET-1053
CASMNET-1054
CSAMNET-1055
CASMINST-3477

## Testing

_List the environments in which these changes were tested._

### Tested on:

Fanta 
Wasp

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?yes
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable