### PR TITLE
CASMTRIAGE-2791 - Bump spire to 1.5.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,5 +159,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.4.0
+    version: 1.5.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This fixes an issue where the spire-agent pod failed to start correctly, causing the API gateway to fail to validate spire JWTs.


## Issues and Related PRs

* Resolves [CASMTRIAGE-2791](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2791)


## Testing


### Tested on:

  * hela
  * Virtual Shasta

### Test description:

Validated spire-agent worked correctly and spire-jwks returned keys.

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
