### PR TITLE
CASMINST-3650: lts/csm-1.0 storage image with fix for CASMINST-3650

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -9,15 +9,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.1.109/kubernetes-0.1.109.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.1.109/5.3.18-24.75-default-0.1.109.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.1.109/initrd.img-0.1.109.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.1.111/kubernetes-0.1.111.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.1.111/5.3.18-24.75-default-0.1.111.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.1.111/initrd.img-0.1.111.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.109/storage-ceph-0.1.109.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.109/5.3.18-24.75-default-0.1.109.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.109/initrd.img-0.1.109.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.111/storage-ceph-0.1.111.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.111/5.3.18-24.75-default-0.1.111.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.1.111/initrd.img-0.1.111.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

Note:
* Tag 0.1.110 was for a CI/CD change.  No node image code has changed since 0.1.109 except for the code that is for CASMINST-3650.
* The pipeline builds k8s and ceph images at the same time.  We _could_ just take the ceph image here and leave k8s at 0.1.109.