### PR TITLE
MTL-1576 Add DNSMASQ back in (new LiveCD)

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,9 +3,9 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211201194311-geddda8a.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211201194311-geddda8a.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211201194311-geddda8a.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211203183315-geddda8a.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211203183315-geddda8a.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211203183315-geddda8a.verified
 )
 
 KUBERNETES_ASSETS=(


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This change removed dnsmasq as a dependency to metal-ipxe, and since it is not explicitly installed by csm-rpms the package is now missing. This is a critical package necessary for the PIT, it provides DHCP, DNS, and netbooting capabilities.

[Build Log](https://jenkins.algol60.net/job/Cray-HPE/job/cray-pre-install-toolkit/view/tags/job/v1.5.8/6/console):
```bash
[ DEBUG   ]: 18:42:21 | (182/217) Installing: dnsmasq-2.78-7.6.1.x86_64 [............done]
[ DEBUG   ]: 18:42:21 | Additional rpm output:
[ DEBUG   ]: 18:42:21 | warning: /etc/dnsmasq.conf created as /etc/dnsmasq.conf.rpmnew
[ DEBUG   ]: 18:42:21 | Running in chroot, ignoring command 'daemon-reload'
```


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1576](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1576)
* Change will also be needed in `main`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

