### PR TITLE
CASMTRIAGE-2648: don't specify a vlan for UAI/macvlan

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -47,7 +47,6 @@ spec:
       nmn_subnet: ~FIXME~ e.g., 10.252.2.0/23
       nmn_supernet: ~FIXME~ e.g., 10.252.0.0/17
       nmn_supernet_gateway: ~FIXME~ e.g., 10.252.0.1
-      nmn_vlan: ~FIXME~ e.g., vlan002
       nmn_reservation_start: ~FIXME~ e.g., 10.252.2.10
       nmn_reservation_end: ~FIXME~ e.g., 10.252.3.254
       # The following should be filled in by CSI generated routes to


### PR DESCRIPTION
## Summary and Scope

This is an outdated construct.  The macvlan vlan should always
be the NMN vlan.  As such, there is no need to provide it as a
configuration input value.

Requires https://github.com/Cray-HPE/cray-site-init/pull/100