### PR TITLE
CASMTRIAGE-2794 Add algol60 busybox image

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -171,6 +171,8 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.5.16-debian-9-r8
     docker.io/bitnami/minideb: # minideb/stretch replacement
     - bullseye
+    docker.io/library/busybox:
+    - 1.28.0-glibc  # Used by EtcdClusters
     # FIXME Someone is using e.g., registry.local/docker.io/centos:7 instead of
     # FIXME dtr.dev.cray.com/baseos/centos:7
     docker.io/library/centos:


### PR DESCRIPTION
## Summary and Scope

the docker/index.yaml is missing artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc, causing cray-fas-etcd to fail to start.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2794](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2794)

## Testing

### Tested on:

  * hela
### Test description:

Manually copied over the image and verified that the cray-fas-etcd pods started to work

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

