### PR TITLE
CASMTRIAGE-2802 Bump cray-opa to 1.6.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

cray-opa 1.6.0 disables xname validation in opa. This was supposed to go into a previous PR, but was incorrectly pushed as 1.5.0.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-2802](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2802)

## Testing


### Tested on:

  * hela

### Test description:

Validated cfs-state-reporter started working after updating the chart.