### PR TITLE
CASMISNT-4569 - pulling in new ceph check into goss

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -32,12 +32,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/:
     - csm-install-workarounds-1.10.1-1.noarch
     - cray-cmstools-crayctldeploy-1.0.22-1.x86_64
     - cray-site-init-1.6.11-1.x86_64
-    - csm-testing-1.6.40-1.noarch
+    - csm-testing-1.6.43-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
     - docs-csm-1.10.55-1.noarch
-    - goss-servers-1.6.39-1.noarch
+    - goss-servers-1.6.43-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
-    - platform-utils-0.2.6-1.noarch
+    - platform-utils-0.2.7-1.noarch
 http://car.dev.cray.com/artifactory/csm/SPET/sle15_sp2_ncn/x86_64/release/csm-1.0/:
   rpms:
     - cray-nexus-0.9.1-2.20210628130311_91df64a.x86_64


### PR DESCRIPTION
Summary and Scope

This updates and fixes the ceph service check
Issues and Related PRs

    Resolves CASMINST-4569, CASMINST-4570

Testing

manually run on mug and fanta then verified the expected results
Tested on:

    mug/fanta

Test description:

Verified the pdsh entry in known hosts no longer happens and verified clean runs w/ expected results

    Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? n/a
    Were continuous integration tests run? If not, why? n/a
    Was upgrade tested? If not, why? n/a
    Was downgrade tested? If not, why? n/a
    Were new tests (or test issues/Jiras) created for this change? n/a

Risks and Mitigations
Pull Request Checklist

Version number(s) incremented, if applicable
Copyrights updated
License file intact
Target branch correct
CHANGELOG.md updated
Testing is appropriate and complete, if applicable
HPC Product Announcement prepared, if applicable