### PR TITLE
FAS to version 1.7.21 for release 1.0

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -324,7 +324,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-dns-unbound:
     - 0.4.9 # update platform.yaml cray-precache-images with this
     cray-firmware-action:
-    - 1.7.20
+    - 1.7.21
     cray-hbtd:
     - 1.10.6
     cray-hmnfd:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -28,7 +28,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 1.7.20
+    version: 1.7.21
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60


### PR DESCRIPTION
Update FAS version to 1.7.21 to fix snapshots bug returning empty results.
CASMHMS-5258