### PR TITLE
CASMTRIAGE-2801 Add support for HPE PDUs to the HSM ComponentEndpoints CT test.

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -341,7 +341,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-sls:
     - 1.12.0
     cray-smd:
-    - 1.37.0
+    - 1.38.0
     cray-sonar:
     - 0.2.0
     cray-tftpd:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,7 +19,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: services
     values:
       cray-service:

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -41,7 +41,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-rts-ct-test-1.15.0-1.x86_64
     - hms-scsd-ct-test-1.8.0-1.x86_64
     - hms-sls-ct-test-1.11.0-1.x86_64
-    - hms-smd-ct-test-1.36.0-1.x86_64
+    - hms-smd-ct-test-1.38.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.6-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change adds support for HPE PDUs to the HSM ComponentEndpoints CT test.

### Issues and Related PRs

* Resolves CASMTRIAGE-2801.

### Testing

This change was tested by deploying the updated HSM ComponentEndpoints CT test to the system Hela which has HPE PDUs, executing the test, and verifying that the previously failing test cases began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.