### PR TITLE
Update cray-crus to 1.9.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -60,7 +60,7 @@ arti.dev.cray.com/analytics-docker-stable-local:
     pvc-migrator:
     - 0.1.0
 
-# dtr.dev.cray.com/cray
+# arti.dev.cray.com/wlm-slurm-docker-stable-local
 arti.dev.cray.com/wlm-slurm-docker-stable-local:
   tls-verify: true
   images:
@@ -286,7 +286,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 1.3.1
 
     cray-crus:
-    - 1.8.75
+    - 1.9.1
     cray-csm-sles15sp2-barebones-recipe:
     - 1.4.1
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.8.75
+    version: 1.9.1
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
This bumps the versions of the cray-crus chart to the versions that include the change for:

[CASMPET-5033](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7708): Update image refs in charts: cray-crus

See original source PR for details:
https://github.com/Cray-HPE/cray-crus/pull/9