### PR TITLE
Latest CSI

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -7,7 +7,7 @@ http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/x86_64/release/csm-1.0
     - loftsman-1.1.0-20210511145236_2da0507.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.12.2-1.x86_64
+    - cray-site-init-1.13.2-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
This updates `assets.sh` with the most recent cray-site-init _and_ a matching LiveCD.

This bumps cray-site-init from 1.12.2 to 1.13.2.