### PR TITLE
CASMTRIAGE-2815 Bump csm-config to 1.9.8 for new HMS test RPMs in CFS csm-1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -355,7 +355,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-uas-mgr:
     - 1.13.3
     csm-config:
-    - 1.8.19
+    - 1.9.8
     csm-ssh-keys:
     - 1.3.79
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -121,7 +121,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.8.19
+    version: 1.9.8
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
### Summary and Scope

This change bumps csm-config to version 1.9.8 which includes the new HMS CT test RPMs in the list of Ansible CSM packages for CFS.

### Issues and Related PRs

* Resolves CASMTRIAGE-2815 in csm-1.2.

### Testing

Not sure how to test this, fixing "No provider of hms-ct-test-crayctldeploy" errors reported in CASMTRIAGE-2815 by the ansible-0 log as part of the CFS session.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, fixes something that is currently broken.