### PR TITLE
Move the Nexus web UI's DNS to the ingress gateway.

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -58,7 +58,6 @@ spec:
   proxiedWebAppExternalHostnames:
     customerManagement:
     - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
-    - '{{ kubernetes.services[''cray-nexus''].istio.ingress.hosts.ui.authority }}'
     - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
     - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
     - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].prometheus.prometheusSpec.externalAuthority }}'
@@ -353,7 +352,7 @@ spec:
             istio-ingressgateway-cmn:
               serviceAnnotations:
                 metallb.universe.tf/address-pool: customer-management
-                external-dns.alpha.kubernetes.io/hostname: 'api.cmn.{{ network.dns.external }},auth.cmn.{{ network.dns.external }}'
+                external-dns.alpha.kubernetes.io/hostname: 'api.cmn.{{ network.dns.external }},auth.cmn.{{ network.dns.external }},nexus.cmn.{{ network.dns.external }}'
             istio-ingressgateway-chn:
               serviceAnnotations:
                 metallb.universe.tf/address-pool: customer-high-speed


### PR DESCRIPTION
## Summary and Scope

With the use of the Nexus Keycloak authentication plugin in CSM 1.2 (https://jira-pro.its.hpecorp.net:8443/browse/CASM-2361) Nexus web UI traffic must go to the ingress gateway.  This change will update the DNS record for nexus.cmn.<system> to that of the system's ingress gateway.   

## Issues and Related PRs

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5165

## Testing

### Tested on:

  * Mug and Wasp

### Test description:

It was confirmed that the changes would result in the proper DNS update. 

## Risks and Mitigations

None
