### PR TITLE
CASMTRIAGE-2823 1.2 : TESTS: CSM validation metal.no-wipe check failing on storage nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.37 for recent test changes
 - Released platform-utils-1.2.5 to fix etcd restore script
 - Released csm-testing v1.8.33 to remove preflight tests
 - Updated craycli to 0.41.11 to add support for new SCSD subcommand

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.36-1.noarch
+    - csm-testing-1.8.37-1.noarch
     - docs-csm-1.12.15-1.noarch
-    - goss-servers-1.8.36-1.noarch
+    - goss-servers-1.8.37-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
CASMTRIAGE-2823: Add get_client_secret() function to check_no_wipe_flag.sh script
### Summary and Scope

The kubectl command is not available/functioning on all storage nodes. The
check_no_wipe_ flag.sh script needs to execute the kubectl command to obtain the
Client Secret.

Added get_client_secret() function to check_no_wipe_ flag.sh script. If executing on any
storage node, locates an active functioning Kubernetes NCN node (master or worker) where
to execute the kubectl command to obtain the Client Secret.

Tested on hela (1.2.0-alpha.31).

### Issues and Related PRs
CASMTRIAGE-2823

### Testing
Tested on hela, 1.2.0-alpha.31 installed.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A