### PR TITLE
Fixes CASMPET-5202: use latest pgbouncer image

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -115,7 +115,7 @@ spec:
     version: 1.0.5
     namespace: vault
   - name: trustedcerts-operator
-    source: csm
+    source: csm-algol60
     version: 0.1.1
     namespace: pki-operator
   - name: cray-certmanager
@@ -173,8 +173,8 @@ spec:
     version: 0.4.1
     namespace: operators
   - name: spire-intermediate
-    source: csm
-    version: 0.3.0
+    source: csm-algol60
+    version: 0.4.0
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,5 +159,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.5.0
+    version: 2.0.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Update image refs and pull in the latest pgbouncer image for CVE remediation.

## Issues and Related PRs

* Resolves [CASMPET-5202]
* Change will also be needed in `master`

## Testing

### Tested on:

  * `wasp`

### Test description:

Tested the new chart on wasp, and verified that the spire-postgres-pooler pods successfully
pulled the latest pgbouncer image. Pod logs showed no errors after being up for more than
30 minutes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

