### PR TITLE
Fix signing for the goss-servers rpm

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.36-1.noarch
+    - csm-testing-1.8.38-1.noarch
     - docs-csm-1.13.1-1.noarch
-    - goss-servers-1.8.36-1.noarch
+    - goss-servers-1.8.38-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

csm-testing and goss-servers rpms are built at the same time, so
both references are updated here.  The important change in this
version of the RPM is that both will now be signed instead of only
csm-testing.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3679
