### PR TITLE
CSI update for: CASMTRIAGE-2702, MTL-1568, CASMINST-3410, and CASMNET-1061

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -7,7 +7,7 @@ http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/x86_64/release/csm-1.0
     - loftsman-1.1.0-20210511145236_2da0507.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.13.2-1.x86_64
+    - cray-site-init-1.13.5-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION

## Summary and Scope

* Fixes bug where empty CHN network was created in SLS when chn inputs are not provided to CSI
* Fixes bug where CHN interface was being added to ipam parameters in basecamp
* Handles cabinets-yaml with empty string
* Checks for csm-version input to make sure 1.0 inputs are not used in 1.2 installs

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-2702
* Resolves MTL-1568
* Resolves CASMINST-3410
* Resolves CASMNET-1061

## Testing

### Tested on:

  * `drax`

### Test description:

Tested with various valid and invalid inputs to CSI on drax.  Checked the generated files to make sure they were correct.

## Risks and Mitigations

No known issues


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

