### PR TITLE
FAS chart version to 2.0.4 for v1.16.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -25,11 +25,11 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.4
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.0.0 
+    version: 2.0.0
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60


### PR DESCRIPTION
FAS chart version to 2.0.4 for v1.16.0