### PR TITLE
CASMPET-5202: use pgbouncer master-19 image

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -142,7 +142,7 @@ artifactory.algol60.net/csm-docker/stable:
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21
     # XXX but it is not extracted from any charts?
     registry.opensource.zalan.do/acid/pgbouncer:
-      - master-17
+      - master-19
 
     # XXX Spilo-12 is not properly extracted from cray-postgres-operator, see
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,5 +153,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 1.6.0
+    version: 2.0.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Use the latest pgbouncer master-19 image, which has 0 critical and only 1 high CVE, compared to 2 critical
and 3 high CVEs in the current pgbouncer master-17 image.

## Issues and Related PRs

* Resolves [CASMPET-5202]
* Change will also be needed in `release/1.2`

## Testing

### Tested on:

  * `wasp`
 
### Test description:

Tested the new chart on wasp, and verified that the spire-postgres-pooler pods successfully
pulled the latest pgbouncer image. Pod logs showed no errors after being up for more than
30 minutes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. pgbouncer upgrade is a minor version upgrade.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

