### PR TITLE
Fixes for precache goss test and fix for unused proxyv2 image

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -212,7 +212,6 @@ spec:
       # Kubernetes
       - k8s.gcr.io/pause:3.2
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.7.8-cray2-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
       # OPA
       - docker.io/openpolicyagent/opa:0.24.0-envoy-1

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.38-1.noarch
+    - csm-testing-1.8.39-1.noarch
     - docs-csm-1.13.1-1.noarch
-    - goss-servers-1.8.38-1.noarch
+    - goss-servers-1.8.39-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Bring in fixed goss test for precache images, removed unused proxyv2 image.

## Issues and Related PRs

* Resolves [CASMINST-3693](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3693)

## Testing

hela

### Tested on:

  * `hela`

### Test description:

Hand edited the test and config map to test.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

