### PR TITLE
Release cray-istio 2.4.3 with horizontal autoscalers fix

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -132,7 +132,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.4.2
+    version: 2.4.3
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

cray-istio chart was missing horizontal autoscalers

## Issues and Related PRs

* Resolves [CASMINST-3406](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3406)

## Testing

Releasing on behalf of Jeanne

### Tested on:

### Test description:

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable