### PR TITLE
CASMTRIAGE-2849: Update gatekeeper to 1.5.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -21,7 +21,7 @@ spec:
     namespace: loftsman
   - name: gatekeeper
     source: csm-algol60
-    version: 1.5.0
+    version: 1.5.1
     namespace: gatekeeper-system
     timeout: 20m
     values:


### PR DESCRIPTION
There was a problem with gatekeeper 1.5.0 that caused the chart
to fail to deploy because the image used in the hook didn't have
the command that was executed (curl). 1.5.1 fixes this problem.
