### PR TITLE
Fixes CASMTRIAGE-2848: use cray-vault-operator 1.1.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -108,7 +108,7 @@ spec:
     namespace: operators
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.1.0
+    version: 1.1.1
     namespace: vault
   - name: cray-vault
     source: csm-algol60


### PR DESCRIPTION
The cray-vault-operator 1.1.0 calls a command that's not in docker-kubectl image. The new 1.1.1 chart uses an equivalent command to replace the missing command.