### PR TITLE
CASMTRIAGE-2848: use cray-vault-operator 1.1.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -108,7 +108,7 @@ spec:
     namespace: operators
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.1.0
+    version: 1.1.1
     namespace: vault
   - name: cray-vault
     source: csm-algol60


### PR DESCRIPTION
The existing cray-vault-operator 1.1.0 uses a command that's not available in docker-kubectl image. This is to use cray-vault-operator 1.1.1 chart to use an equivalent command to check pod readiness.