### PR TITLE
CASMINST-3692 - Update zmq_curve generator to use image shipped in CSM tarball

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils/generators/zmq_curve
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils/generators/zmq_curve
@@ -5,7 +5,7 @@ ARGS=${1}
 YQ=${2}
 TEMP_DIR=${3}
 OUT_FILE=${4}
-ZEROMQ_IMAGE=arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5
+ZEROMQ_IMAGE=artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5
 : ${USE_CONTAINER:="yes"}  # Override in ENV to force native execution
 
 # EXPECTED ARGS:


### PR DESCRIPTION
## Summary and Scope

Update zmq_curve generator to use algol60 pathed image to match what is shipped in the CSM tarball.

## Issues and Related PRs

* Resolves [CASMINST-3692](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3692)
* Change will also be needed in `csm` to update the generator
* Merge with `https://github.com/Cray-HPE/docs-csm/pull/661`

## Testing

### Tested on:

  * `surtur`

### Test description:

New documentation followed, updated generator used to generate PALs SealedSecret.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

