### PR TITLE
CASMREL-843 New 1.5.8-20211214220847-ga02c80b LiveCD and 0.2.33 NCN Images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,21 +3,21 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211213183331-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211213183331-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211213183331-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211214220847-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211214220847-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211214220847-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.32/kubernetes-0.2.32.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.32/5.3.18-59.19-default-0.2.32.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.32/initrd.img-0.2.32.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.33/kubernetes-0.2.33.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.33/5.3.18-59.19-default-0.2.33.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.33/initrd.img-0.2.33.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.32/storage-ceph-0.2.32.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.32/5.3.18-59.19-default-0.2.32.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.32/initrd.img-0.2.32.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.33/storage-ceph-0.2.33.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.33/5.3.18-59.19-default-0.2.33.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.33/initrd.img-0.2.33.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
New 0.2.33 NCN Images and a LiveCD.

NCN Changes: https://github.com/Cray-HPE/node-image-build/pull/136
LiveCD Changes:
- https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3695