### PR TITLE
(main) CASMHMS-5296: Update cray-hms-hmcollector chart to resolve CVE

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.1
+    version: 2.15.2
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Update cray-hms-hmcollector chart to v2.15.2 with application version v2.16.0 to resolve CVE-2021-3520 in lz4.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible bugfix.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5296](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5296)

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Wasp
### Test description:

For testing see: https://github.com/Cray-HPE/hms-hmcollector/pull/33

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

