### PR TITLE
CASMNET-865 cray-uas-mgr to 1.17.0 / add needed customizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cray-uas-mgr to pick up the following:
+  - BiCAN support for UAS/UAI
+  - External DNS support for public facing UAIs
+  - Multi-Replica UAI support in UAS
+  - UAI Timeout configuration in UAI Classes (automatic UAI termination)
+  - Various bug fixes
 - Released platform-utils-1.2.5 to fix etcd restore script
 - Released csm-testing v1.8.33 to remove preflight tests
 - Updated craycli to 0.41.11 to add support for new SCSD subcommand

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,7 +143,7 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.16.3
+    version: 1.17.0
     namespace: services
   - name: update-uas
     source: csm-algol60

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -532,6 +532,8 @@ spec:
           uai_macvlan_range_end: '{{ wlm.macvlansetup.nmn_reservation_end }}'
           uai_macvlan_routes: '{{ wlm.macvlansetup.routes }}'
           uas_ssh_lb_pool: customer-access
+          require_bican: false
+          dns_domain: '{{ network.dns.external }}'
           images:
             images:
               - cray/cray-uai-sles15sp1:latest


### PR DESCRIPTION
## Summary and Scope

Move cray-uas-mgr to version 1.17.0 to bring in BiCAN and External DNS changes as well as most of the cray-uas-mgr NERSC Phase 2 changes.  Update customizations.yaml to provide BiCAN and External DNS required configuration for cray-uas-mgr.

This is backward compatible.

## Issues and Related PRs

* Resolves [CASMNET-856](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-865)

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

No known risks or issues from this PR

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [ N/A ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ N/A ] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

