### PR TITLE
Publish Snyk reports and trends in Jenkins

### DIFF
--- a/Jenkinsfile.snyk
+++ b/Jenkinsfile.snyk
@@ -1,4 +1,5 @@
-@Library('csm-shared-library') _
+//@Library('csm-shared-library') _
+@Library('csm-shared-library@feature/publish-snyk-reports') __
 
 pipeline {
     agent {
@@ -11,7 +12,7 @@ pipeline {
 
     options {
         timeout(time: 240, unit: 'MINUTES')
-        buildDiscarder(logRotator(numToKeepStr: '5'))
+        buildDiscarder(logRotator(numToKeepStr: '30'))
         timestamps()
         disableConcurrentBuilds()
     }
@@ -20,6 +21,8 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
+                    sh "git pull --tags"
+                    currentBuild.description = sh(script: './version.sh', returnStdout: true).trim() + " (#${currentBuild.number})"
                     sh """
                         command -v parallel >/dev/null 2>&1 || {
                             echo >&2 "error: parallel: command not found"
@@ -54,13 +57,13 @@ pipeline {
                 script {
                     sh """
                         . build/.env/bin/activate
-                        make -C build/snyk
+                        make -C build/snyk html
                     """
                 }
             }
             post {
                 success {
-                    archiveArtifacts artifacts: 'build/snyk/docker/**'
+                    publishSnykReports()
                 }
             }
         }


### PR DESCRIPTION
## Summary and Scope

Generate some additional HTML reports (count vulnerabilities for each image and by severity level), and publish them in Jenkins as HTML reports:
https://jenkins.algol60.net/job/Snyk/job/csm/job/feature%252Ftest-snyk-reports/Snyk_20Scan_20Results/

Also, create a plot outlining vulnerability trends:
https://jenkins.algol60.net/job/Snyk/job/csm/job/feature%252Ftest-snyk-reports/plot/

## Issues and Related PRs
Requires https://github.com/Cray-HPE/csm-shared-library/pull/22. After it is merged, this PR needs to be updated (feature branch name removed from `@Library` annotation).

## Testing
Navigate to https://jenkins.algol60.net/job/Snyk/job/csm/job/feature%252Ftest-snyk-reports/
Try "Snyk Scan Results" and "Plots" links
