### PR TITLE
Break/fix/casminst 3706 csm 1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -38,12 +38,6 @@ artifactory.algol60.net/csm-docker/stable:
     cray-uai-broker:
       - 1.3.1
 
-    # XXX Fixed by CASMNET-941
-    cray-dhcp-kea:
-      - 0.9.13
-    # XXX Fixed by CASMNET-943
-    cray-dns-unbound:
-      - 0.6.10
 
     # XXX Missing from cray-istio chart?
     istio/operator:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,22 +41,22 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.9.13
+    version: 0.10.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.6.10
+    version: 0.7.1 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.6.10
+        appVersion: 0.7.1
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.2.2
+    version: 0.2.2 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -216,9 +216,6 @@ spec:
       # OPA
       - docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - docker.io/sonatype/nexus3:3.25.0
-      - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
-      - dtr.dev.cray.com/baseos/busybox:1
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.2

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -216,8 +216,11 @@ spec:
       # OPA
       - docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.9.13
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.6.10
+      - docker.io/sonatype/nexus3:3.25.0
+      - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
+      - dtr.dev.cray.com/baseos/busybox:1
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.2
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.2
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- added preStop to unbound to mitigate dropped requests during pod restart/deploy
- increased granuality of readiness checks for unbound to mitigate dropped request/deploy
- updated kubectl binary for unbound-manager 
- update unbound-manager to use python logger
- fix wait-for-unbound.sh script in csm-1.2
- helm v2 api and removal of dtr references for unbound and kea

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves 
  - CASMNET-1051
  - CASMNET-1064
  - CASMNET-995
  - CASMNET-1076
  - CASMINST-3706
  - CASMNET-941
  - CASMNET-943

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Wasp

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

- test results for unbound resilency during deployments.  Testing method:
  - sequential nslookup while rolling restart of unbound deployment every 4 minutes.
  ********
  Thu 09 Dec 2021 06:56:02 PM UTC
  After 100000 sequential lookups.
  Failed lookup count: 1
  Uptime percentage is 99.99900000000000000000%
  Time to do  is 1603s

  ********
  Thu 09 Dec 2021 07:23:13 PM UTC
  After 100000 sequential lookups.
  Failed lookup count: 0
  Uptime percentage is 100.00000000000000000000%
  Time to do  is 1607s

  ********
  Thu 09 Dec 2021 07:51:59 PM UTC
  After 100000 sequential lookups.
  Failed lookup count: 5
  Uptime percentage is 99.99500000000000000000%
  Time to do  is 1615s

  ********
  Fri 10 Dec 2021 12:24:21 AM UTC
  After 1000000 sequential lookups.
  Failed lookup count: 14
  Uptime percentage is 99.99860000000000000000%
  Time to do  is 16056s

  Mon 13 Dec 2021 11:49:46 AM UTC
  After 2000000 sequential lookups.
  Failed lookup count: 39
  Uptime percentage is 99.99805000000000000000%
  Time to do  is 32262s

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

