### PR TITLE
CASMNET-1051/CASMNET-1064/CASMNET-995/CASMNET-1076 manifest changes

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -322,7 +322,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-dhcp-kea:
     - 0.7.9
     cray-dns-unbound:
-    - 0.4.9 # update platform.yaml cray-precache-images with this
+    - 0.4.10 # update platform.yaml cray-precache-images with this
     cray-firmware-action:
     - 1.7.21
     cray-hbtd:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -50,8 +50,8 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.4.9
+    version: 0.4.10
     namespace: services
     values:
       global:
-        appVersion: 0.4.9
+        appVersion: 0.4.10

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,7 +220,7 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
-      - dtr.dev.cray.com/cray/cray-dns-unbound:0.4.9
+      - dtr.dev.cray.com/cray/cray-dns-unbound:0.4.10
       - dtr.dev.cray.com/cray/proxyv2:1.7.8-cray1
       - dtr.dev.cray.com/cray/proxyv2:1.7.8-cray2-distroless
       - dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- added preStop to unbound to mitigate dropped requests during pod restart/deploy
- increased granularity of readiness checks for unbound to mitigate dropped request/deploy
- update unbound-manager to use python logger 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves 
  - CASMNET-1051
  - CASMNET-1064
  - CASMNET-995

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Wasp

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

- test results for unbound resilency during deployments.  Testing method:
  - sequential nslookup while rolling restart of unbound deployment every 4 minutes.
  ********
  Thu 09 Dec 2021 06:56:02 PM UTC
  After 100000 sequential lookups.
  Failed lookup count: 1
  Uptime percentage is 99.99900000000000000000%
  Time to do  is 1603s

  ********
  Thu 09 Dec 2021 07:23:13 PM UTC
  After 100000 sequential lookups.
  Failed lookup count: 0
  Uptime percentage is 100.00000000000000000000%
  Time to do  is 1607s

  ********
  Thu 09 Dec 2021 07:51:59 PM UTC
  After 100000 sequential lookups.
  Failed lookup count: 5
  Uptime percentage is 99.99500000000000000000%
  Time to do  is 1615s

  ********
  Fri 10 Dec 2021 12:24:21 AM UTC
  After 1000000 sequential lookups.
  Failed lookup count: 14
  Uptime percentage is 99.99860000000000000000%
  Time to do  is 16056s

  Mon 13 Dec 2021 11:49:46 AM UTC
  After 2000000 sequential lookups.
  Failed lookup count: 39
  Uptime percentage is 99.99805000000000000000%
  Time to do  is 32262s

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

