### PR TITLE
CASMREL-846: LiveCD and NCN images for CSM 1.2 alpha 41

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -3,21 +3,21 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211216191909-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211216191909-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211216191909-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220104200342-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220104200342-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220104200342-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.33/kubernetes-0.2.33.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.33/5.3.18-59.19-default-0.2.33.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.33/initrd.img-0.2.33.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.35/kubernetes-0.2.35.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.35/5.3.18-59.19-default-0.2.35.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.35/initrd.img-0.2.35.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.33/storage-ceph-0.2.33.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.33/5.3.18-59.19-default-0.2.33.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.33/initrd.img-0.2.33.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.35/storage-ceph-0.2.35.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.35/5.3.18-59.19-default-0.2.35.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.35/initrd.img-0.2.35.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

LiveCD:
* CASMINST-3701 - Fix empty string generated for hmn_api_gw
* CASMUSER-2812 - update craycli with new hard and soft timeouts
* MTL-1586 - Pull AMSD, Mellanox, and firmware RPMs from the new HPE mirror in algol60

NCNs:
* CASMPET-5208 - Add read-only ceph client
* CASMUSER-2812 - update craycli with new hard and soft timeouts
* MTL-1407 - Remove false postive warnings about missing LUKS keystores on worker nodes
* MTL-1540 - net-init.sh fails nicely on missing metadata
* MTL-1586 - Pull AMSD, Mellanox, and firmware RPMs from the new HPE mirror in algol60
* MTL-1588 - Cease `mc reset cold` on HPE servers; prevent crashing the iLO/BMC
* MTL-1590 - Fix squashFS download timeout in dracut when MLAG/STP block is active