### PR TITLE
CASMTRIAGE-2836: update index to pull in v1.8.40 released version of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.40 for recent test changes
 - Update cfs-operator to 1.14.9 to pull in latest alpine/git image (CASMCMS-7725)
 - Update cfs-operator to 1.14.6 to pull in fresh aee image (CASMTRIAGE-2853)
 - Updated cray-uas-mgr to pick up the following:

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.39-1.noarch
+    - csm-testing-1.8.40-1.noarch
     - docs-csm-1.13.1-1.noarch
-    - goss-servers-1.8.39-1.noarch
+    - goss-servers-1.8.40-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.8.40 released version of csm-testing and goss-servers
Update changelog: - Released csm-testing v1.8.40 for recent test changes
This pulls in changes for:
* CASMTRIAGE-2836

### Summary and Scope
CASMTRIAGE-2836: Fix etcd_backups_check.sh script

When the etcd_backups_check.sh' script was executed within goss, an incorrect date string was being returned. 
In the etcd_backups_check.sh's script check_backup_within_day() function, replaced ${backup: -20}
with ${backup##*_} to always return the correct sub-string. Fixed problem.

Tested on hela (1.2.0-alpha.31).

### Issues and Related PRs
CASMTRIAGE-2836

### Testing
Tested on hela, 1.2.0-alpha.31 installed.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A

