### PR TITLE
(CSM 1.2) CASMNET-967: Bump SLS version

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.0.1
+    version: 2.0.2
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Need to add the PeerASN, MyASN, and MetalLBPoolName to SLS in order to be able to properly upgrade customizations.yaml from 1.0 to 1.2.   For upgrades we are using SLS for the source of truth of the system configuration.   SLS has most of what is needed for MetalLB but it is missing the ASNs and the pool names.     This also cleans things up in CSI for generating customizations.yaml in a fresh install.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y (.version and CHANGELOG.md)

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Work required by CASMINST-3617 and CASMNET-967

### Testing

For testing See: https://github.com/Cray-HPE/hms-sls/pull/34

### Risks and Mitigations

ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No


