### PR TITLE
CASMNET-967:  Update CSI with ASN and pool name fields

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -7,7 +7,7 @@ http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/x86_64/release/csm-1.0
     - loftsman-1.1.0-20210511145236_2da0507.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.13.7-1.x86_64
+    - cray-site-init-1.14.0-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION

### Summary and Scope

Need to add the PeerASN, MyASN, and MetalLBPoolName to SLS in order to be able to properly upgrade customizations.yaml from 1.0 to 1.2.   For upgrades we are using SLS for the source of truth of the system configuration.   SLS has most of what is needed for MetalLB but it is missing the ASNs and the pool names.     This also cleans things up in CSI for generating customizations.yaml in a fresh install.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y (.version and CHANGELOG.md)

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Work required by CASMINST-3617 and CASMNET-967

### Testing

For testing See: https://github.com/Cray-HPE/hms-sls/pull/34

### Risks and Mitigations

ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No

