### PR TITLE
CASMPET-5216 Bump cray-kafka-operator to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-kafka-operator 0.4.2 to mitigate CVE-2021-44228
 - Enable PSP admission controller
 - Updated resource limits for spire postgresql and spire-wait-for-postgres
 - Added prometheus alerts for monitoring replication lag across postgres clusters

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -23,6 +23,8 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.12.2-csm0.9
     spire-tokens:
     - 0.4.1
+    quay.io/strimzi/operator:
+    - 0.15.0-noJndiLookupClass
     cray-bss-ipxe:
     - 1.5.19
     cray-dns-unbound:
@@ -377,4 +379,4 @@ arti.dev.cray.com/internal-docker-stable-local:
 quay.io:
   images:
     skopeo/stable:
-    - v1.4.1 
+    - v1.4.1

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,7 +111,7 @@ spec:
           # not in containerd's registry mirror configuration
           docker_image: 'dtr.dev.cray.com/acid/spilo-12:1.6-p3-csm0.9'
   - name: cray-kafka-operator
-    version: 0.4.1
+    version: 0.4.2
     namespace: operators
   - name: spire-intermediate
     version: 0.2.2


### PR DESCRIPTION
## Summary and Scope

This bumps cray-kafka-operator to 0.4.2, which includes the CVE-2021-44228 fix.

## Issues and Related PRs


* Resolves [CASMPET-5216](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5216)

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
Were continuous integration tests run? If not, why? N/A
Was upgrade tested? If not, why? Y
Was downgrade tested? If not, why? Y
Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

