### PR TITLE
CASMPET-5216 Bump cray-kafka-operator to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-kafka-operator to 0.4.2 to include CVE-2021-44228 fix
 - Updated cray-keycloak and cray-keycloak-users-localize to pick up security fixes (CVE-2021-3711)
 - Updated cray-drydock to 2.7.1 to increase sonar-jobs-watcher cpu resource limits
 - Updated cray-postgres-operator to 0.10.1 to disable pod disruption policy

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -404,7 +404,7 @@ artifactory.algol60.net/csm-docker/stable:
     - master-17
     spire-tokens:
     - 0.4.1
-    strimzi/operator:
+    quay.io/strimzi/operator:
     - 0.15.0-noJndiLookupClass
 
     update-uas:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -404,6 +404,8 @@ artifactory.algol60.net/csm-docker/stable:
     - master-17
     spire-tokens:
     - 0.4.1
+    strimzi/operator:
+    - 0.15.0-noJndiLookupClass
 
     update-uas:
     - 1.0.14
@@ -413,4 +415,4 @@ quay.io:
     prometheus/node-exporter:
     - v1.2.2
     skopeo/stable:
-    - v1.4.1 
+    - v1.4.1

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -168,7 +168,7 @@ spec:
           docker_image: 'dtr.dev.cray.com/acid/spilo-12:1.6-p3-csm1.0'
   - name: cray-kafka-operator
     source: csm
-    version: 0.4.1
+    version: 0.4.2
     namespace: operators
   - name: spire-intermediate
     source: csm


### PR DESCRIPTION
## Summary and Scope

This bumps cray-kafka-operator to 0.4.2, which includes the CVE-2021-44228 fix.

## Issues and Related PRs


* Resolves [CASMPET-5216](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5216)

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
Were continuous integration tests run? If not, why? N/A
Was upgrade tested? If not, why? Y
Was downgrade tested? If not, why? Y
Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

