### PR TITLE
Backport etcd-operator pod priority change to 1.0.10

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -226,8 +226,6 @@ arti.dev.cray.com/csm-docker-stable-local:
     - 0.40.5
     docker-kubectl: # XXX loftsman/docker-kubectl
     - 0.2.0
-    etcd-operator:
-    - 0.12.1-cray
     loftsman: # XXX loftsman/loftsman
     # cray-product-catalog depends on this as well
     - 0.5.1
@@ -323,6 +321,10 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.7.9
     cray-dns-unbound:
     - 0.4.10 # update platform.yaml cray-precache-images with this
+
+    etcd-operator:
+    - 0.12.2-cray
+
     cray-firmware-action:
     - 1.7.21
     cray-hbtd:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -105,8 +105,8 @@ spec:
     version: 0.13.7
     namespace: opa
   - name: cray-etcd-operator
-    source: csm
-    version: 0.15.1
+    source: csm-algol60
+    version: 0.15.2
     namespace: operators
   - name: cray-vault-operator
     source: csm


### PR DESCRIPTION
## Summary and Scope

Bring in etcd-operator image/chart change that supports pod priorities in 1.0.10.

## Issues and Related PRs

* Resolves [CASMINST-3713](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3713)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Ran the 0.15.2 chart version in vshasta with the later etcd-operator image.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

