### PR TITLE
Create the Nexus nx-anonymous role

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -172,11 +172,11 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.2.0
+    version: 3.3.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.10.0
+    version: 1.11.0
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
This manifest update will add:

CASMPET-5200 Create the Nexus nx-anonymous role as part of the keycloak-installer process.
Cray-HPE/keycloak-installer#33