### PR TITLE
CASMPET-4660 1.2 : Automate check for Postgres pod backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.8.42 for recent test changes
 - Released csm-testing v1.8.40 for recent test changes
 - Update cfs-operator to 1.14.9 to pull in latest alpine/git image (CASMCMS-7725)
 - Update cfs-operator to 1.14.6 to pull in fresh aee image (CASMTRIAGE-2853)

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.40-1.noarch
+    - csm-testing-1.8.42-1.noarch
     - docs-csm-1.13.1-1.noarch
-    - goss-servers-1.8.40-1.noarch
+    - goss-servers-1.8.42-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
Added goss test and script to automate check for postgres pod backups (work done by Lindsay)

## Summary and Scope

This is a new automation feature. It is a goss test that ensures that recent PostgreSQL pod backups exist for specific clusters.

Change a new feature, it is backwards compatible.

## Issues and Related PRs

* Part of the 'Automation: Validate CSM Health (PET)' epic. CASM-2592
* CASMPET-4660 : Automate check for Postgres pod backups
* CASMPET-5145 : Add multiple tries to goss-k8s-postgres-replication-lag (this was merged to master a few weeks back and was just noted as missing from 1.2)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp
  * Hela
 
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

This is a read only script that will report PASS or FAIL status.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable