### PR TITLE
CASMNET-1087 - fix cray-dns-unbound imagehost to point to dtr.

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -322,7 +322,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-dhcp-kea:
     - 0.7.9
     cray-dns-unbound:
-    - 0.4.10 # update platform.yaml cray-precache-images with this
+    - 0.4.11 # update platform.yaml cray-precache-images with this
     cray-firmware-action:
     - 1.7.21
     cray-hbtd:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -50,8 +50,8 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.4.10
+    version: 0.4.11
     namespace: services
     values:
       global:
-        appVersion: 0.4.10
+        appVersion: 0.4.11

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,7 +220,7 @@ spec:
       - docker.io/sonatype/nexus3:3.25.0
       - dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2
       - dtr.dev.cray.com/baseos/busybox:1
-      - dtr.dev.cray.com/cray/cray-dns-unbound:0.4.10
+      - dtr.dev.cray.com/cray/cray-dns-unbound:0.4.11
       - dtr.dev.cray.com/cray/proxyv2:1.7.8-cray1
       - dtr.dev.cray.com/cray/proxyv2:1.7.8-cray2-distroless
       - dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- set imagehost to dtr from algol60 for cray-dns-unbound

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
- yes
## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

[CASMNET-1087](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1087)

### Tested on:

Fanta
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? no, we do not have CI for shasta upgrade
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why?no, priority was upgrading testing
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
bi

## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

