### PR TITLE
New csm-testing and goss-servers rpm for ca-cert test fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released goss-servers/csm-testing v1.8.43 for ca cert test fix
 - Update cfs-operator to 1.14.9 to pull in latest alpine/git image (CASMCMS-7725)
 - Update cfs-operator to 1.14.6 to pull in fresh aee image (CASMTRIAGE-2853)
 - Updated cray-uas-mgr to pick up the following:

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.39-1.noarch
+    - csm-testing-1.8.43-1.noarch
     - docs-csm-1.13.1-1.noarch
-    - goss-servers-1.8.39-1.noarch
+    - goss-servers-1.8.43-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

New goss-servers rpm to fix ca-cert test to allow for certs in different order, depending if they come from the file system or from metadata curl call.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2837](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2837)

## Testing

Tested fix on hela

### Tested on:

  * `hela`

### Test description:

```
ncn-m001:/opt/cray/tests/install/ncn/tests # goss -g /opt/cray/tests/install/ncn/tests/goss-platform-ca-certs-match-cloud-init-brad.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml v
.

Total Duration: 0.058s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m002:~ # goss -g /opt/cray/tests/install/ncn/tests/goss-platform-ca-certs-match-cloud-init-brad.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml v
.

Total Duration: 0.059s
Count: 1, Failed: 0, Skipped: 0
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable