### PR TITLE
CASMINST-3094 - Remove secret generation commands from meta/init.sh output so it isn't run prematurely

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/docs/NEW-SYSTEM.md
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/docs/NEW-SYSTEM.md
@@ -36,10 +36,6 @@ pit:~ # SITEDIR=/var/www/ephemeral/prep/site-init
     Initialized empty Git repository in $SITEDIR/.git/
 
     **** IMPORTANT: Review and update $SITEDIR/customizations.yaml and introduce custom edits (if applicable). ****
-    When ready to proceed, execute the following commands:
-
-    # $SITEDIR/utils/secrets-reencrypt.sh $SITEDIR/customizations.yaml $SITEDIR/certs/sealed_secrets.key $SITEDIR/certs/sealed_secrets.crt
-    # $SITEDIR/utils/secrets-seed-customizations.sh $SITEDIR/customizations.yaml
     ```
 
 2.  As directed, update `customizations.yaml` content as directed by the

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/docs/UPDATE-SYSTEM.md
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/docs/UPDATE-SYSTEM.md
@@ -55,10 +55,6 @@ pit:~ # SITEDIR=/mnt/pitdata/prep/site-init
     Creating git repo at target (if not already a repo)
 
     **** IMPORTANT: Review and update $SITEDIR/customizations.yaml and introduce custom edits (if applicable). ****
-    When ready to proceed, execute the following commands:
-
-    $SITEDIR/utils/secrets-reencrypt.sh $SITEDIR/customizations.yaml $SITEDIR/certs/sealed_secrets.key $SITEDIR/certs/sealed_secrets.crt
-    $SITEDIR/utils/secrets-seed-customizations.sh $SITEDIR/customizations.yaml
     ```
 
 2.  As directed, update `customizations.yaml` content as directed by the

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/meta/init.sh
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/meta/init.sh
@@ -87,7 +87,3 @@ fi
 
 echo
 echo "**** IMPORTANT: Review and update ${TARGET_DIR}/customizations.yaml and introduce custom edits (if applicable). ****"
-echo "When ready to proceed, execute the following commands:"
-echo
-echo "$TARGET_DIR/utils/secrets-reencrypt.sh $TARGET_DIR/customizations.yaml $TARGET_DIR/certs/sealed_secrets.key $TARGET_DIR/certs/sealed_secrets.crt"
-echo "$TARGET_DIR/utils/secrets-seed-customizations.sh $TARGET_DIR/customizations.yaml"


### PR DESCRIPTION
## Summary and Scope

The [prepare_site_init.md](https://github.com/Cray-HPE/docs-csm/blob/release/1.0/install/prepare_site_init.md#2-create-and-initialize-site-init-directory) procedure has the user run `meta/init.sh` to create a new shasta-cfg directory structure for the install.

The output of `init.sh` immediately invites the user to review and edit customizations.yaml and then run the `secrets-reencrypt.sh` and `secrets-seed-customizations.sh` scripts however it is not appropriate to do so until the remainder of the steps in prepare_site_init.md have been followed.

This PR removes the prompt to run these two commands from the `init.sh` script output and updates the shasta-cfg documentation to reflect the new output.

## Issues and Related PRs

* Resolves [CASMINST-3094](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3094)

## Testing

### Tested on:

  * Local development environment

### Test description:

Ran through prepare_site_init.md steps.

## Risks and Mitigations

Low risk, cosmetic change to script output, no functional changes.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

