### PR TITLE
Made the generated password for the crayvcs user URL safe by default.

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -150,6 +150,7 @@ spec:
                 name: vcs_password
                 length: 32
                 url_safe: yes
+                encoding: base64
             - type: static
               args:
                 name: vcs_username

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -149,6 +149,7 @@ spec:
               args:
                 name: vcs_password
                 length: 32
+                url_safe: yes
             - type: static
               args:
                 name: vcs_username


### PR DESCRIPTION
## Summary and Scope

It was found that the password generated for the `crayvcs` user account for Gitea could sometimes have illegal characters that would cause HTTP repo cloning break. This mod enables the `url_safe` for the Gitea secret generation to prevent this.

## Issues and Related PRs

CASMINST-3602

## Testing

Tested locally and on Fanta, verified that passwords weren't generated with any illegal characters. 

### Test description:

Made the change and ran `secrets-seed-customizations.sh` a bunch.

## Risks and Mitigations

Should be no risk.


