### PR TITLE
CASMCLOUD-1202 Remove unused craycli docker image from manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Removed unused craycli docker image from docker manifest
 - Released csm-testing v1.8.40 for recent test changes
 - Update cfs-operator to 1.14.9 to pull in latest alpine/git image (CASMCMS-7725)
 - Update cfs-operator to 1.14.6 to pull in fresh aee image (CASMTRIAGE-2853)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -11,12 +11,6 @@ arti.dev.cray.com/internal-docker-stable-local:
     rpm-tools: # Provides createrepo and reposync tools
       - 1.0.0
 
-# XXX Where is this image used?
-arti.dev.cray.com/csm-docker-stable-local:
-  images:
-    craycli:
-      - 0.40.5
-
 # XXX Not sure if this is used in a chart or only facilitates backup/recovery
 arti.dev.cray.com/analytics-docker-stable-local:
   images:


### PR DESCRIPTION
## Summary and Scope

Remove unused craycli docker image from docker manifest

This change is backward compatible as it removes a docker image that has never been used and is no longer built.

## Issues and Related PRs

* Resolves [CASMCLOUD-1202](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1202)

## Testing

N/A

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks or issues with this change.


## Pull Request Checklist

- [ N/A ] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ N/A ] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

