### PR TITLE
updated SHCD parser image for CASMHMS-5303

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -57,7 +57,7 @@ artifactory.algol60.net/csm-docker/stable:
     hms-pytest:
       - 2.0.0
     hms-shcd-parser:
-      - 1.7.0
+      - 1.8.0
     hms-trs-worker-http-v1:
       - 1.6.0
 


### PR DESCRIPTION
## Summary and Scope

Resolves CVE issue in SHCD parser. 
Rebuild resolved the issue. No further testing required. 

## Issues and Related PRs


* Resolves CASMHMS-5303

