### PR TITLE
CASMINST-3732: Use latest csm-1.0 RPM that is signed

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -29,10 +29,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-site-init-1.6.11-1.x86_64
     - csm-install-workarounds-1.10.1-1.noarch
     - csm-testing-1.6.41-1.noarch
-    - docs-csm-1.10.59-1.noarch 
+    - docs-csm-1.10.59-1.noarch
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
-    - goss-servers-1.6.41-1.noarch
+    - csm-testing-1.6.45-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
     - ilorest-3.2.3-1.x86_64
     - metal-basecamp-1.1.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Use the latest signed csm-1.0 goss-servers RPM.  When we fixed the signing issue for 1.0.1 we did not update the CSM manifest.  This was due to the fact that 1.0.1 was created by hand and not the pipeline.