### PR TITLE
CASMPET-5217 Update kafka charts to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update Kafka strimzi operator to 0.27.0
 - Removed unused craycli docker image from docker manifest
 - Released goss-servers/csm-testing v1.8.43 for ca cert test fix
 - Released csm-testing v1.8.40 for recent test changes

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 0.7.1
+    version: 1.0.0
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
@@ -188,7 +188,7 @@ spec:
     namespace: gatekeeper-system
   - name: cray-shared-kafka
     source: csm-algol60
-    version: 0.6.0
+    version: 1.0.0
     namespace: services
   - name: cray-sts
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the Strimzi operator to 0.27.0, which fixes a number of CVEs including CVE-2021-44228.

## Issues and Related PRs

* Resolves [CASMPET-5217](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5217) 


## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that the strimzi operator worked properly and that the shared Kafka cluster started as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? N, no tests available.
- Was upgrade tested? If not, why? N, needs further testing on bare metal to validate that Kafka can deal properly with upgrades.
- Was downgrade tested? If not, why? N, needs further testing on bare metal to validate that Kafka can deal properly with downgrades.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This updates the Strimzi operator to 0.27.0, which changes the strimzi CRD api from kafka.strimzi.io/v1alpha1 to kafka.strimzi.io/v1beta2, requiring chart changes. It also updates the minimum Kafka version from 2.2.1 to 2.8.0, which needs to be further tested by users of Kafka.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

