### PR TITLE
CASMINST-3741 update craycli to 0.40.20 in RPM manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli to 0.40.20 in RPM manifests
 - Update cray-kafka-operator to 0.4.2 to include CVE-2021-44228 fix
 - Updated cray-keycloak and cray-keycloak-users-localize to pick up security fixes (CVE-2021-3711)
 - Updated cray-drydock to 2.7.1 to increase sonar-jobs-watcher cpu resource limits

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -1,6 +1,3 @@
-http://car.dev.cray.com/artifactory/csm/CLOUD/sle15_sp2_cn/x86_64/release/csm-1.0/:
-  rpms:
-  - craycli-0.40.19-20210517151806_c1fa76f.x86_64
 http://car.dev.cray.com/artifactory/csm/SCMS/sle15_sp2_cn/x86_64/release/csm-1.0/:
   rpms:
   - cfs-state-reporter-1.5.10-20210611142824_e6f5026.x86_64
@@ -9,3 +6,6 @@ http://car.dev.cray.com/artifactory/csm/UAS/sle15_sp2_cn/x86_64/release/csm-1.0/
   rpms:
   - cray-switchboard-1.2.2-20210615160128_b7454e2.x86_64
   - cray-uai-util-1.0.11-20210518075246_fb9d9c8.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
+  rpms:
+  - craycli-0.40.20-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,6 +1,5 @@
 http://car.dev.cray.com/artifactory/csm/CLOUD/sle15_sp2_ncn/x86_64/release/csm-1.0/:
   rpms:
-    - craycli-0.40.19-20210517151806_c1fa76f.x86_64
     - manifestgen-1.3.2-20210628125752_1f628f7.x86_64
 http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/noarch/release/csm-1.0/:
   rpms:
@@ -25,6 +24,7 @@ http://car.dev.cray.com/artifactory/csm/SCMS/sle15_sp2_ncn/x86_64/release/csm-1.
     - shasta-authorization-module-1.4.6-20210611143046_2ef0782.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
+    - craycli-0.40.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.0.22-1.x86_64
     - cray-site-init-1.6.11-1.x86_64
     - csm-install-workarounds-1.10.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update craycli to 0.40.20 in RPM manifests to match what is installed in node images.

This change is backward complatible.

## Issues and Related PRs

* Resolves [CASMINST-3741](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3741)

## Testing

N/A

### Tested on:

N/A

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_ N/A

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [  N/A ] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ N/A ] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

