### PR TITLE
CASMPET-5212: use the recent rebuilt external-dns image

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -139,8 +139,8 @@ spec:
     version: 0.2.0
     namespace: operators
   - name: cray-externaldns
-    source: csm
-    version: 1.0.0
+    source: csm-algol60
+    version: 1.4.0
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Use the recent rebuilt external-dns image for CVE remediation (31 critical & high -> 13)

## Issues and Related PRs

* Resolves [CASMPET-5212]
* Change will also be needed in `release/1.2`

## Testing

### Tested on:

  * `wasp`

### Test description:

Chris re-installed powerdns and re-deployed the externaldns chart, and verified that powerdns records were repopulated correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. Can always revert back to the original chart if unexpected issues arise.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

