### PR TITLE
Casmmon 94 bumping the sysmgmt-health version.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.20.0
+    version: 0.20.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
Made changes to plotform.yaml by bumping the sysmgmt-health version.
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-94

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/46
created release tag

https://github.com/Cray-HPE/cray-sysmgmt-health/releases/tag/v1.2.15

