### PR TITLE
CASMCMS-7754: gitea: Do not pin alpine patch version; Use patched and signed alpine image

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.3.1
+    version: 2.3.4
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
See original PR for details:
https://github.com/Cray-HPE/gitea/pull/13
