### PR TITLE
CASMINST-3770 Update spire to 2.1.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -41,11 +41,11 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.0.0 
+    version: 2.0.0
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60
-    version: 2.0.0 
+    version: 2.0.0
     namespace: services
 
   # CMS
@@ -153,5 +153,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.0.0
+    version: 2.1.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This updates spire to 2.1.0, which fixes an issue where it was requesting the wrong pgbouncer image.

## Issues and Related PRs

* Resolves [CASMINST-3770](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3770)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated spire worked and used the correct image

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

None


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

