### PR TITLE
Update CAPMC for CVE fix

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -21,7 +21,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Alpine target being used had several CVEs. Updated which artifactory the docker file was pulling from and included an apk upgrade to help resolve current and future CVE  issues.

### Issues and Related PRs

* Resolves [CASMHMS-5302](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5302)

### Testing

No additional testing required.

Verified snyk tests did not find anymore vulnerabilities.

[Snyk run from build with CVEs](https://jenkins.algol60.net/job/Cray-HPE/job/hms-capmc/job/v1.31.0/3/artifact/2022-01-05T15-22-54-093531Z_snyk_report.html)
[Snyk run for this change](https://jenkins.algol60.net/job/Cray-HPE/job/hms-capmc/job/fix-cve/5/artifact/2022-01-07T17-22-52-287318Z_snyk_report.html)

### Risks and Mitigations

No known risks