### PR TITLE
CASMCMS-7758 Update CSM Barebones to v1.4.7

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -127,13 +127,13 @@ spec:
             tag: 1.3.1
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.4.5
+    version: 1.4.7
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.4.5
+            tag: 1.4.7
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Update CSM Barebones to v1.4.7. This moves the CSM Barebones recipe and image to be based off of SLES15SP3 instead of SLES15SP2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7758](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7758)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Hela`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Installed new helm chart. Verified that the new recipe and image were added to IMS. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

