### PR TITLE
Fix an opa an nexus precache image reference issue

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -214,7 +214,7 @@ spec:
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
       # OPA
-      - docker.io/openpolicyagent/opa:0.24.0-envoy-1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.1
@@ -229,7 +229,7 @@ spec:
       - k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
       - k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0
+      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.5.3
   - name: cray-metallb
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fix a couple of precache image references that were wrong or have recently changed.

## Issues and Related PRs

* Resolves [CASMINST-3784](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3784)

## Testing

surtur

### Tested on:

  * `surtur`

### Test description:

Edited the configmap and test now passes:

```
ncn-m002:/opt/cray/tests/install/ncn/tests # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-precache-images-health.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 0.169s
Count: 2, Failed: 0, Skipped: 0
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable