### PR TITLE
CASMINST-3775: fix kiali image repo path

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -122,11 +122,7 @@ artifactory.algol60.net/csm-docker/stable:
     k8s.gcr.io/kube-scheduler:
       - v1.19.9
 
-    # XXX Kiali is not installed with Istio anymore, how is it being deployed?
-    quay.io/kiali/kiali:
-      - v1.28.1
-
-    # XXX Pgbounder image is weird -- it's in the cray-service base chart at
+    # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21
     # XXX but it is not extracted from any charts?
     registry.opensource.zalan.do/acid/pgbouncer:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -136,7 +136,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.2.0
+    version: 0.2.1
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

cray-kiali was using upstream kiali repo, but we should use algol60 repo and the rebuilt kiali images.

## Issues and Related PRs

* Resolves [CASMINST-3775]
* Change will also be needed in `main`

## Testing

### Tested on:

  * `wasp`

### Test description:

Redeployed the new cray-kiali chart, and verified the images were pulled from algol60 repo, and kiali pods were restarted successfully with no errors from pod logs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. Only image repo path changes.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

