### PR TITLE
CASMCMS-7760: BOS needs to use BOA >= v1.2.80

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -110,7 +110,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 1.10.13
+    version: 1.10.15
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60


### PR DESCRIPTION
Pull in fix for [CASMCMS-7753](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7753) into csm-1.2

See original PR for details:
https://github.com/Cray-HPE/bos/pull/26