### PR TITLE
New version of csm-config chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,7 +118,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.8
+    version: 1.9.12
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Fixes:

CASMINST-3792: BREAK/FIX: cronjob-kicker is missing
CASMINST-3757: FIX/BREAK: master node - missing dir for rebuild automation

## Issues and Related PRs

* Resolves [CASMINST-3757](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3757)
* Resolves [CASMINST-3792](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3792)

## Testing

Limited testing of new ansible code in isolation

### Tested on:

  * `craystack`

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable

