### PR TITLE
CASMPET-5254 main : SECURITY: fix vulnerabilities in bitnami/minideb (no references found)

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -50,10 +50,6 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Rebuilt third-party images below
 
-    # XXX Not sure where this is used, but should probably be deprecated
-    docker.io/bitnami/minideb:
-      - bullseye
-
     # Required by ceph
     docker.io/ceph/ceph:
       - v15.2.8


### PR DESCRIPTION
## Summary and Scope

Unable to find any charts that use this image on a csm 1.0 or 1.2 system.
Reviewed with PET team members as well. 
Removing the bitnami/minideb:bullseye image from the docker index.

## Issues and Related PRs

* Resolves [CASMPET-5254](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5254)
* Change will also be needed in `main`
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable