### PR TITLE
New version of csm-testing

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.43-1.noarch
+    - csm-testing-1.8.44-1.noarch
     - docs-csm-1.13.2-1.noarch
-    - goss-servers-1.8.43-1.noarch
+    - goss-servers-1.8.44-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.10.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

New version of csm-testing to fix goss test to remove blank lines from file system cert before comparing to the one in metadata

## Issues and Related PRs

* Resolves [CASMINST-3796](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3796)

## Testing

Tested this in place on mug:

```
ncn-m002:~ # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-platform-ca-certs-match-cloud-init.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
.

Total Duration: 0.061s
Count: 1, Failed: 0, Skipped: 0
```

### Tested on:

  * `mug`

### Test description:

Tested in place.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
