### PR TITLE
Casmsmf 6685 move rsyslog-aggregator-can services to CMN

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -619,7 +619,7 @@ spec:
             resources:
               requests:
                 storage: 16Gi
-        rsyslogAggregatorCan:
+        rsyslogAggregatorCmn:
           externalHostname: rsyslog.cmn.{{ network.dns.external }}
         rsyslogAggregatorHmn:
           service:
@@ -634,7 +634,7 @@ spec:
             resources:
               requests:
                 storage: 16Gi
-        rsyslogAggregatorCan:
+        rsyslogAggregatorCmn:
           externalHostname: rsyslog.cmn.{{ network.dns.external }}
         rsyslogAggregatorUdpHmn:
           service:


### PR DESCRIPTION
Resolves CASMSMF-6685
https://github.hpe.com/hpe/hpc-car-sma-rsyslog/pull/133
updated customizations.yaml can to cmn