### PR TITLE
CASMHMS-5312 Update hms-pytest image location for Nexus main

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - goss-servers-1.8.43-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
-    - hms-ct-test-base-1.10.0-1.x86_64
+    - hms-ct-test-base-1.11.0-1.x86_64
     - hms-fas-ct-test-1.13.0-1.x86_64
     - hms-hmcollector-ct-test-2.14.0-1.x86_64
     - hms-hbtd-ct-test-1.13.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change updates the path to the hms-pytest image in Nexus since images are no longer being uploaded to the old location.

### Issues and Related PRs

* Resolves CASMHMS-5312.

### Testing

This change was tested on Mug running csm-1.2.0-alpha.43 by pulling the hms-pytest image from the new location and verifying that the previously failing CT tests began to pass. Also verified with Zach C. that the new path is correct and that the previous location is no longer supported.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk that fixes an out-of-date image path.