### PR TITLE
CASMINST-3727: Fix nmn/hmn subdomains that should be nmnlb/hmnlb

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -270,6 +270,8 @@ spec:
           - 'chn.{{ network.dns.external }}'
           - 'nmn.{{ network.dns.external }}'
           - 'hmn.{{ network.dns.external }}'
+          - 'nmnlb.{{ network.dns.external }}'
+          - 'hmnlb.{{ network.dns.external }}'
       cray-dns-unbound:
         domain_name: '{{ network.dns.external }}'
         forwardZones:
@@ -329,6 +331,8 @@ spec:
             - '*.chn.{{ network.dns.external }}'
             - '*.nmn.{{ network.dns.external }}'
             - '*.hmn.{{ network.dns.external }}'
+            - '*.nmnlb.{{ network.dns.external }}'
+            - '*.hmnlb.{{ network.dns.external }}'
             - '*.{{ network.dns.external }}'
           commonName: '{{ network.dns.external }}'
         authn:
@@ -341,12 +345,12 @@ spec:
               loadBalancerIP: '{{ network.netstaticips.nmn_api_gw }}'
               serviceAnnotations:
                 metallb.universe.tf/address-pool: node-management
-                external-dns.alpha.kubernetes.io/hostname: 'api.nmn.{{ network.dns.external }},auth.nmn.{{ network.dns.external }}'
+                external-dns.alpha.kubernetes.io/hostname: 'api.nmnlb.{{ network.dns.external }},auth.nmnlb.{{ network.dns.external }}'
             istio-ingressgateway-hmn:
               loadBalancerIP: '{{ network.netstaticips.hmn_api_gw }}'
               serviceAnnotations:
                 metallb.universe.tf/address-pool: hardware-management
-                external-dns.alpha.kubernetes.io/hostname: 'hmcollector.hmn.{{ network.dns.external }}'
+                external-dns.alpha.kubernetes.io/hostname: 'hmcollector.hmnlb.{{ network.dns.external }}'
             istio-ingressgateway-can:
               serviceAnnotations:
                 metallb.universe.tf/address-pool: customer-access
@@ -701,8 +705,8 @@ spec:
             issuers:
               shasta-cmn: https://api.cmn.{{ network.dns.external }}/keycloak/realms/shasta
               keycloak-cmn: https://auth.cmn.{{ network.dns.external }}/keycloak/realms/shasta
-              shasta-nmn: https://api.nmn.{{ network.dns.external }}/keycloak/realms/shasta
-              keycloak-nmn: https://auth.nmn.{{ network.dns.external }}/keycloak/realms/shasta
+              shasta-nmn: https://api.nmnlb.{{ network.dns.external }}/keycloak/realms/shasta
+              keycloak-nmn: https://auth.nmnlb.{{ network.dns.external }}/keycloak/realms/shasta
           ingressgateway-customer-admin:
             issuers:
               shasta-cmn: https://api.cmn.{{ network.dns.external }}/keycloak/realms/shasta


### PR DESCRIPTION
## Summary and Scope

The FQDNs that are on NMN or HMN are on a separate load-balancer subnet than the actually NMN/HMN subnets so they need to have a different subdomain:  nmnlb and hmnlb.

This adds those subdomains to the domain filter and the ingressgateway cert.  It also fixes some of the FQDNs specified in customizations for auth, api, hmcollector, etc.

## Issues and Related PRs

* Resolves CASMINST-3727
* Merge with https://github.com/Cray-HPE/docs-csm/pull/757

## Testing

### Tested on:

  * `drax`

### Test description:

Ran the update-customizations.sh and verified that the FQDNs are added/changed correctly.

## Risks and Mitigations

No risks.  It is broken the way that it is now.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

