### PR TITLE
Load images baked into the NCN images into disribution

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -4,6 +4,28 @@ quay.io:
       - v1.4.1
       - latest
 
+docker.io:
+  images:
+    nfvpe/multus:
+      - v3.7
+    weaveworks/weave-kube:
+      - 2.8.1
+    weaveworks/weave-npc:
+      - 2.8.1
+
+k8s.gcr.io:
+  images:
+    coredns:
+      - 1.7.0
+    kube-apiserver:
+      - v1.20.13
+    kube-controller-manager:
+      - v1.20.13
+    kube-proxy:
+      - v1.20.13
+    kube-scheduler:
+      - v1.20.13
+
 arti.dev.cray.com/internal-docker-stable-local:
   images:
     packaging-tools: # Provides various packaging tools


### PR DESCRIPTION
## Summary and Scope

Pull 1.2 images that are baked into the NCN image for K8S into distribution.

## Issues and Related PRs

* Resolves [CASMINST-3799](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3799)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

