### PR TITLE
CASMPET-5225: fix vulnerabilities in node-discovery

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -180,7 +180,7 @@ spec:
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
-    version: 0.9.0
+    version: 1.2.0
     namespace: services
   - name: gatekeeper-policy-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The current node-discovery chart was based on an old alpine image 3.12.6, with many critical and high CVEs. This PR changes the chart to use a new rebuilt image based on alpine image 3.14.3, which shows no known CVEs.

## Issues and Related PRs

* Resolves [CASMPET-5225]
* Change will also be needed in `main`

## Testing

### Tested on:

  * `hela`

### Test description:

Re-deployed the new node-discovery chart, and verified that the new pods successfully pulled the new image with no errors in log. I also ran the node-discovery smoke tests and verified that the tests completed successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. Only base OS were upgraded with no functionality changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

