### PR TITLE
CASMHMS-5317 Add new error field placeholders to FAS actions and snapshots CT tests

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64
-    - hms-fas-ct-test-1.13.0-1.x86_64
+    - hms-fas-ct-test-1.17.0-1.x86_64
     - hms-hmcollector-ct-test-2.14.0-1.x86_64
     - hms-hbtd-ct-test-1.13.0-1.x86_64
     - hms-hmnfd-ct-test-1.10.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change updates the FAS actions and snapshots CT tests with new expected "error" field placeholders for the API responses. Without this change the FAS tests don't expect the new empty "error" fields in the API responses and flag them as failures.

### Issues and Related PRs

* Resolves CASMHMS-5317.

### Testing

This change was tested by deploying the updated FAS CT tests onto Mug running 1.2.0-alpha.43, executing them, and verifying that the previously failing test cases began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.