### PR TITLE
CASMHMS-5310 Remove duplicate CabinetPDUController output from verify_hsm_discovery

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -48,4 +48,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-1.0.0-1.x86_64
     - yapl-0.1.1-1.x86_64
-    - hpe-csm-scripts-0.0.29-1.noarch
+    - hpe-csm-scripts-0.0.31-1.noarch


### PR DESCRIPTION
### Summary and Scope

This change removes a duplicated code block from verify_hsm_discovery.py which stops it from running and printing the checks for CabinetPDUControllers twice instead of once. The extra output was causing confusion during installs while troubleshooting discovery failures.

### Issues and Related PRs

* Resolves CASMHMS-5310.

### Testing

This change was tested on Mug running csm-1.2.0-alpha.43 by copying the new version of the script onto the NCN, running it, and verifying that the duplicated output from the original script was no longer present in the updated version.

Previous (two identical "CabinetPDUControllers" entries per cabinet):

```
<snip>
River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: FAIL
    - x3000c0r24b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  CabinetPDUControllers: PASS
  ChassisBMCs/CMCs: FAIL
    - x3000c0s19b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  CabinetPDUControllers: PASS
x3001
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CabinetPDUControllers: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS
<snip>
```

New (one "CabinetPDUControllers" entry per cabinet):

```
<snip>
River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: FAIL
    - x3000c0r24b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  ChassisBMCs/CMCs: FAIL
    - x3000c0s19b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  CabinetPDUControllers: PASS
x3001
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS
<snip>
```

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.