### PR TITLE
CASMINST-3803 Validate node image component versions against Nexus (1.2)

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -78,3 +78,37 @@ for url in "${PIT_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
 for url in "${KUBERNETES_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
 for url in "${STORAGE_CEPH_ASSETS[@]}"; do cmd_retry curl -sfSLI "$url"; done
 cmd_retry curl -sfSLI "$HPE_SIGNING_KEY"
+
+# Verify that kubernetes and other supplementary images, shipped with node-image, are
+# present in manifest (and, cnsequently, in Nexus). Versions, shipped with node image,
+# are exposed as image file properties in Artifactory.
+ROOTDIR=$(dirname $0)
+KUBERNETES_VERSIONS_JSON="$(mktemp)"
+trap "rm -f '${KUBERNETES_VERSIONS_JSON}'" EXIT
+shopt -s expand_aliases
+alias yq="${ROOTDIR}/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
+cmd_retry curl -sSL -o "${KUBERNETES_VERSIONS_JSON}" "${KUBERNETES_ASSETS[0]/artifactory\/csm-images/artifactory\/api\/storage\/csm-images}?properties"
+declare -A KUBERNETES_IMAGES=(
+    [KUBERNETES_VERSION]="k8s.gcr.io/kube-apiserver k8s.gcr.io/kube-controller-manager k8s.gcr.io/kube-proxy k8s.gcr.io/kube-scheduler"
+    [WEAVE_VERSION]="docker.io/weaveworks/weave-kube docker.io/weaveworks/weave-npc"
+    [MULTUS_VERSION]="docker.io/nfvpe/multus"
+    [COREDNS_VERSION]="k8s.gcr.io/coredns"
+)
+error=0
+for KEY in "${!KUBERNETES_IMAGES[@]}"; do
+    for IMAGE_TAG in $(jq -r ".properties.\"csm.versions.${KEY}\"[]?" "${KUBERNETES_VERSIONS_JSON}"); do
+        for IMAGE_NAME in ${KUBERNETES_IMAGES[${KEY}]}; do
+            if yq read "${ROOTDIR}/docker/index.yaml" "\"artifactory.algol60.net/csm-docker/stable\".images.\"${IMAGE_NAME}\".[*]" | grep -F -x -q "${IMAGE_TAG}"; then
+                echo "INFO: Image ${IMAGE_NAME}:${IMAGE_TAG} is found in manifest."
+            else
+                echo "ERROR: Image ${IMAGE_NAME}:${IMAGE_TAG} is not found in manifest."
+                error=1
+            fi
+        done
+    done
+done
+if [ $error -eq 1 ]; then
+    echo "ERROR: Assets components image validation failed. Not all container images for components, shipped with node image,"
+    echo "ERROR: are listed in manifest (see above). Add missing container images to docker/images.yaml, or use different node image."
+    exit 1
+fi


### PR DESCRIPTION
## Summary and Scope

Kubernetes node image comes pre-populated with Kubernetes (and some supplementary) container images. Sometimes during install/upgrade, these images need to be re-downloaded from Nexus. For this purpose, Nexus should also be populated with the same versions of images. This change adds a validation step to assets.sh script, which ensures that same version are being shipped with node image and installed in Nexus.

This change is dependent on https://github.com/Cray-HPE/node-image-build/pull/155. Node image needs to expose component versions. Change is backwards compatible: if https://github.com/Cray-HPE/node-image-build/pull/155 is not yet merged, validation in `assets.sh` script is not performed. However, with current state of manifest and latest node image, validation will fail (as manifest still refers to Kubernetes `v1.19.9` and node images are already at `1.20.13`). Other mages (weave, multus, codedns) are out of date too - it is subject of [CASMINST-3799](https://github.com/Cray-HPE/node-image-build/pull/155)).

## Issues and Related PRs

* Resolves [CASMINST-3803](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3803)
* Relates to [CASMINST-3799](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3799)

## Testing

Tested locally with modified node image. For non-modified node image, testing is performed as part of Jenkins build:
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm/detail/CASMINST-3803/2/pipeline/30

### Tested on:

  * Local development environment
  * Jenkins

### Test description:

For node image build, not exposing versions of it's components, validation is not performed. This is tested by Jenkins build. For modified node image, which does expose versions, a local test of `assets.sh` script was conducted.

## Risks and Mitigations

If merged before fix for [CASMINST-3799](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3799), validation will fail the build (this is what this validation is added for). To have successful build, fix for [CASMINST-3799](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3799) (update of kubernetes, weave and multus versions in `docker/index.yaml`) has to be merged first.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

