### PR TITLE
CASMPET-5234 1.2 : SECURITY: fix vulnerabilities in pvc-migrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Remove pvc-migrator from docker manifest
 - Update cray-sysmgmt-health for ghostunnel sec vulnerability
 - Update Kafka strimzi operator to 0.27.0
 - Removed unused craycli docker image from docker manifest

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -11,12 +11,6 @@ arti.dev.cray.com/internal-docker-stable-local:
     rpm-tools: # Provides createrepo and reposync tools
       - 1.0.0
 
-# XXX Not sure if this is used in a chart or only facilitates backup/recovery
-arti.dev.cray.com/analytics-docker-stable-local:
-  images:
-    pvc-migrator:
-      - 0.1.0
-
 artifactory.algol60.net/csm-docker/stable:
   images:
     # XXX update-uas v1.3.2 should include these


### PR DESCRIPTION
## Summary and Scope

Image created and used only by analytics and not part of any CASM chart.
HAL-2498 opened for any needed work by analytics.
Removing the reference from CASM docker manifest.

## Issues and Related PRs

* Resolves [CASMPET-5234](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5234)
* Change will also be needed in `main`
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable