### PR TITLE
CASMINST-3811: update csm-config to v1.9.14

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,7 +118,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.12
+    version: 1.9.14
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Backport CASMINST-3664's addition of loftsman to the csm-config list of RPMs to install from CSM 1.0.10.

## Issues and Related PRs

* Resolves CASMINST-3811

## Testing

See https://github.com/Cray-HPE/csm-config/pull/36.

## Risks and Mitigations

None