### PR TITLE
fix hmnfd hbtd version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -29,11 +29,11 @@ spec:
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.0.0
+    version: 2.0.1
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 2.0.0
+    version: 2.0.1
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

resolves CASMINST-3771 and CASMINST-3772 which updates the version to be pointed to 2.0.1 for HBTD and HMNFD.

