### PR TITLE
CASMINST-3833 main : BREAK/FIX: apiVersion not set chart=cray-sysmgmt-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-sysmgmt-health v1.2.18 to fix license headers
 - Remove pvc-migrator from docker manifest
 - Update cray-sysmgmt-health for ghostunnel sec vulnerability
 - Released goss-servers/csm-testing v1.8.43 for ca cert test fix

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.20.2
+    version: 0.21.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

Clean up license header changes.
* Remove {{ /* \<LICENSE\> */ }} that existed prior to license-check fix
* Change {{- \/* ... \*\/ -}} to {{\/\* ... \*\/}} in existing code where this resulted in the next line being commented out (e.g. #apiVersion, #kind)
* Keep the license header added by the license-check (which uses # to start the line)
* Update the chart version to prepare to release the cray-sysmgmt-health chart for this change

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3833](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3833)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

  * Virtual Shasta

### Test description:

* Reviewed the output from `helm template .` to look for any remaining template rendering issues.

* Deployed to vshasta
```
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.21.1
2022-01-20T18:09:25Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health /workspace/.cache/charts/cray-sysmgmt-health-0.21.1.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=0.21.1 -f /tmp/loftsman-1642702164/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.21.1
2022-01-20T18:11:12Z INF Release "cray-sysmgmt-health" does not exist. Installing it now.
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
NAME: cray-sysmgmt-health
LAST DEPLOYED: Thu Jan 20 18:09:27 2022
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 1
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.21.1
2022-01-20T18:11:12Z INF Ship status: success. Recording status, manifest, and log data to configmap loftsman-mine in namespace loftsman command=ship
loftsman log saved to: /workspace/.cache/loftsman.log
```

* Pods are running
```
C02YP47BLVCG:my_workspace kim.jensen$ kubectl get pods -n sysmgmt-health
NAME                                                           READY   STATUS      RESTARTS   AGE
alertmanager-cray-sysmgmt-health-promet-alertmanager-0         2/2     Running     0          3m23s
cray-sysmgmt-health-grafana-5d65f66b79-bbcnr                   2/2     Running     0          3m31s
cray-sysmgmt-health-grafterm-5976567557-t8z9p                  1/1     Running     0          3m31s
cray-sysmgmt-health-kube-state-metrics-77bf6847bc-ckj9k        1/1     Running     0          3m31s
cray-sysmgmt-health-node-exporter-smartmon-69rf7               1/1     Running     0          3m31s
cray-sysmgmt-health-node-exporter-smartmon-dvx7t               1/1     Running     0          3m30s
cray-sysmgmt-health-node-exporter-smartmon-f95kt               1/1     Running     0          3m31s
cray-sysmgmt-health-node-exporter-smartmon-fttwr               1/1     Running     0          3m31s
cray-sysmgmt-health-patch-nodeexporter-alerts-1-5b6rf          0/1     Completed   0          3m31s
cray-sysmgmt-health-patch-service-monitors-1-8cp6j             0/1     Completed   0          3m31s
cray-sysmgmt-health-promet-operator-5bcdd4494c-ct49j           2/2     Running     0          3m31s
cray-sysmgmt-health-prometheus-node-exporter-4knjq             1/1     Running     0          2m16s
cray-sysmgmt-health-prometheus-node-exporter-bns6x             1/1     Running     0          2m57s
cray-sysmgmt-health-prometheus-node-exporter-lfxh2             1/1     Running     0          2m33s
cray-sysmgmt-health-prometheus-node-exporter-ww4zh             1/1     Running     0          2m44s
cray-sysmgmt-health-prometheus-snmp-exporter-dbd599f47-gw8fd   1/1     Running     0          3m31s
prometheus-cray-sysmgmt-health-promet-prometheus-0             3/3     Running     1          3m13s
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
