### PR TITLE
CASMINST-3848: Update cray-kiali to 0.2.2

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -136,7 +136,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.2.1
+    version: 0.2.2
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
This release includes the following change:

* CASMINST-3848: Add kiali image to annotation
