### PR TITLE
CASMPET-3855 Bump cray-opa to 1.7.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.6.0
+    version: 1.7.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates cray-opa to 1.7.0, which adds cfs-state-reporter access for storage nodes.

## Issues and Related PRs

* Resolves [CASMPET-3855](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-3855)

## Testing

### Tested on:

  * surtur

### Test description:

Validated that cfs-state-reporter ran successfully after chart was updated
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, change didn't require downgrade testing
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

