### PR TITLE
CASMPET-5117: Update to cray-nexus 0.10.0

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -10,12 +10,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.9.1
+    version: 0.10.0
     namespace: nexus
-    values:
-      sonatype-nexus:
-        nexus:
-          resources:
-            requests:
-              cpu: 500m
-              memory: 12Gi

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -229,8 +229,8 @@ spec:
       - k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
       - k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-1
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.5.3
+      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.0
   - name: cray-metallb
     source: csm-algol60
     version: 1.1.0

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -92,6 +92,24 @@ undeploy -n services cray-conman
 # Deploy remaining system management applications
 deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 
+# Ensure updated pre-cache images have been pulled on each NCN worker,
+# otherwise the Nexus upgrade may not be successful. This should be relatively
+# quick since the daemon-set should have run since the platform manifest was
+# deployed above and already pulled these images.
+echo >&2 -n "Ensuring pre-cached images are pulled on NCN workers before upgrading Nexus..."
+images=$(kubectl get configmap -n nexus cray-precache-images -o json | jq -r '.data.images_to_cache')
+export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+output=$(pdsh -b -S -w $(grep -oP 'ncn-w\w\d+' /etc/hosts | sort -u | tr -t '\n' ',') 'for image in '$images'; do crictl pull $image; done' 2>&1)
+if [[ "$output" == *"failed"* ]]; then
+    echo >&2 "FAIL"
+    echo >&2 "$output"
+    echo >&2""
+    echo >&2 "Verify the images which failed in the output above are available in Nexus."
+    exit 1
+else
+    echo >&2 "OK"
+fi
+
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
 

--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -5,7 +5,7 @@
 : "${PACKAGING_TOOLS_IMAGE:=arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0}"
 : "${RPM_TOOLS_IMAGE:=arti.dev.cray.com/internal-docker-stable-local/rpm-tools:1.0.0}"
 : "${SKOPEO_IMAGE:=quay.io/skopeo/stable:v1.4.1}"
-: "${CRAY_NEXUS_SETUP_IMAGE:=arti.dev.cray.com/csm-docker-stable-local/cray-nexus-setup:0.5.2}"
+: "${CRAY_NEXUS_SETUP_IMAGE:=arti.dev.cray.com/csm-docker-stable-local/cray-nexus-setup:0.6.0}"
 
 # Prefer to use docker, but for environments with podman
 if [[ "${USE_PODMAN_NOT_DOCKER:-"no"}" == "yes" ]]; then

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -165,6 +165,18 @@ spec:
                 int_days: 3650
                 root_cn: Platform CA
                 int_cn: Platform CA - L1
+      nexus-admin-credential:
+        generate:
+          name: nexus-admin-credential
+          data:
+            - type: static
+              args:
+                name: username
+                value: admin
+            - type: randstr
+              args:
+                name: password
+                length: 32
       pals:
         generate:
           name: pals-config
@@ -418,6 +430,8 @@ spec:
               ui:
                 enabled: true
                 authority: nexus.cmn.{{ network.dns.external }}
+        sealedSecrets:
+          - '{{ kubernetes.sealed_secrets[''nexus-admin-credential''] | toYaml }}'
       cray-node-discovery:
         networks:
           node_management:


### PR DESCRIPTION
## Summary

* Adds `nexus-admin-credential` sealed secret to customizations.yaml, which will randomize the Nexus admin password.
* Upgrade script ensures required pre-cached images are pulled on each NCN worker prior to deploying Nexus, otherwise required images might be unavailable causing Nexus not to start.

## Testing

Changes manually tested on wasp.
