### PR TITLE
CASMPET-5231: Update cray-istio to CSM 1.2 Release 9

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -19,16 +19,6 @@ artifactory.algol60.net/csm-docker/stable:
     cray-uai-broker:
       - 1.3.1
 
-
-    # XXX Missing from cray-istio chart?
-    istio/operator:
-      - 1.8.6-cray1  # includes tools to help with debugging
-    istio/pilot:
-      - 1.8.6-cray1-distroless
-      - 1.8.6-cray1  # includes tools to help with debugging
-    istio/proxyv2:
-      - 1.8.6-cray1  # includes tools to help with debugging
-
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.56

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -132,7 +132,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.4.4
+    version: 2.5.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,11 +88,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.23.1
+    version: 1.23.2
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.26.2
+    version: 1.26.3
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -132,7 +132,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.4.3
+    version: 2.4.4
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60


### PR DESCRIPTION
Picks up the changes for cray-istio release "CSM 1.2 Release 9" and "CSM 1.2 Release 10".

https://github.com/Cray-HPE/cray-istio/releases/tag/v1.2.9
\https://github.com/Cray-HPE/cray-istio/releases/tag/v1.2.10

This includes the change for:

* CASMPET-5231: Switch to 1.8.6-cray2 images
* CASMINST-3852: Fix hmn istio label to allow for seamless upgrades from older versions of the chart

Note that these charts have the images annotation set so the
images are no longer needed in the docker index.
