### PR TITLE
CASMPET-5231: Update cray-precache-images with new proxyv2 image tag

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -92,7 +92,7 @@ spec:
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.26.3
+    version: 1.26.3   # Update cray-precache-images below on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -212,7 +212,7 @@ spec:
       # Kubernetes
       - k8s.gcr.io/pause:3.2
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS


### PR DESCRIPTION
cray-istio-deploy recently changed to use a new tag for the
proxyv2 image but the reference to the image in the precached
images config wasn't updated. This updates the reference.
