### PR TITLE
Casmpet 5231 1.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -19,16 +19,6 @@ artifactory.algol60.net/csm-docker/stable:
     cray-uai-broker:
       - 1.3.1
 
-
-    # XXX Missing from cray-istio chart?
-    istio/operator:
-      - 1.8.6-cray1  # includes tools to help with debugging
-    istio/pilot:
-      - 1.8.6-cray1-distroless
-      - 1.8.6-cray1  # includes tools to help with debugging
-    istio/proxyv2:
-      - 1.8.6-cray1  # includes tools to help with debugging
-
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.56

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -132,7 +132,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.4.4
+    version: 2.5.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,11 +88,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.23.1
+    version: 1.23.2
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.26.2
+    version: 1.26.3
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -132,7 +132,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.4.3
+    version: 2.4.4
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -92,7 +92,7 @@ spec:
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.26.3
+    version: 1.26.3   # Update cray-precache-images below on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -212,7 +212,7 @@ spec:
       # Kubernetes
       - k8s.gcr.io/pause:3.2
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -136,7 +136,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.2.1
+    version: 0.2.2
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION

Cherry-picked the changes from main for:

* https://github.com/Cray-HPE/csm/pull/384
* https://github.com/Cray-HPE/csm/pull/386
* https://github.com/Cray-HPE/csm/pull/380

Includes the changes for:

* CASMPET-5231: Switch to 1.8.6-cray2 images
* CASMINST-3852: Fix hmn istio label to allow for seamless upgrades from older versions of the chart
* CASMINST-3848: Add kiali image to annotation
