### PR TITLE
Add csm-rpms/hpe/stable/noos RPM repo to gen-rpm-index script

### DIFF
--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -34,11 +34,12 @@ docker run --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tool
 -d  http://car.dev.cray.com/artifactory/slingshot-host-software/OFI-CRAY/sle15_sp3_ncn/x86_64/dev/master/                   cray/slingshot/sle-15sp3/x86_64 \
 -d  http://car.dev.cray.com/artifactory/slingshot/SSHOT/sle15_sp2_ncn/x86_64/release/shasta-1.4/                            cray/slingshot/sle-15sp2/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
--d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                         cray/csm/sle-15sp3/x86_64 \
+-d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                              hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \
 -d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP2/x86_64/current/                              hpe/SUSE_LINUX/SLES15-SP2/x86_64/current \
--d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                                       cray/csm/sle-15sp3 \
--d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                                       cray/csm/sle-15sp3 \
+-d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/                                                   cray/csm/noos \
+-d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                              cray/csm/sle-15sp2 \
+-d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                              cray/csm/sle-15sp3 \
     -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/     suse/SLE-Module-Basesystem/15-SP2/x86_64/update \
     -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/     suse/SLE-Module-Basesystem/15-SP3/x86_64/update \
     -d  https://arti.dev.cray.com:443/artifactory/mirror-opensuse-15-3/update/leap/15.3/sle/                            suse/SLE-Module-Basesystem/15-SP3/x86_64/update \


### PR DESCRIPTION
Corresponds to https://github.com/Cray-HPE/csm-shared-library/pull/24, which changes the default RPM repo OS path to `noos`. As RPMs are added to the stable `noos` repo we'll probably also need to add rpm/cray/csm/noos/index.yaml and update release.sh and lib/setup-nexus.sh to package and setup the corresponding repo in Nexus.

Requires https://github.com/Cray-HPE/csm-shared-library/pull/24
Relates to https://github.com/Cray-HPE/csm-rpms/pull/215