### PR TITLE
Remove rpm-tools and packaging-tools images from manifets and nexus (main)

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -31,8 +31,6 @@ arti.dev.cray.com/internal-docker-stable-local:
   images:
     packaging-tools: # Provides various packaging tools
       - 0.11.0
-    rpm-tools: # Provides createrepo and reposync tools
-      - 1.0.0
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 quay.io:
   images:
     skopeo/stable:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -27,11 +27,6 @@ quay.io:
       - v1.4.1
       - latest
 
-arti.dev.cray.com/internal-docker-stable-local:
-  images:
-    packaging-tools: # Provides various packaging tools
-      - 0.11.0
-
 artifactory.algol60.net/csm-docker/stable:
   images:
     # XXX update-uas v1.3.2 should include these


### PR DESCRIPTION
## Summary and Scope

The following images are part of build/release framework. Therefore we don;t need them in `docker/index.yaml` and, consequently, on Nexus target environments.

## Issues and Related PRs

* Resolves [CASMPET-5265](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5265)
* Resolves [CASMPET-5267](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5267)

## Testing

### Tested on:

  * Jenkins

### Test description:

Should be tested as part of Jenkins build. There's no way to test this on a target environment, because these images are not used on target environments.

## Risks and Mitigations

In case if there's some undocumented usage of these images, we'll have to rollback this commit.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

