### PR TITLE
(main) CASMPET-3996: New versions of goss-servers and csm-testing

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.8.45-1.noarch
+    - csm-testing-1.9.0-1.noarch
     - docs-csm-1.13.2-1.noarch
-    - goss-servers-1.8.45-1.noarch
+    - goss-servers-1.9.0-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Removed hardcoded passwords from variables-livecd.yaml, and require user to provide the password for the admin user on the management switches via the SW_ADMIN_PASSWORD environment variable when running the LiveCD preflight checks and ncn-healthcheck test suites.

Removed unused/deprecated Goss tests that depended on switch_aruba.password and switch_mellanox.password Goss variables.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
 backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-3996](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-3996)
* Related Documentation change PR (merge with): https://github.com/Cray-HPE/docs-csm/pull/791

## Testing

_List the environments in which these changes were tested._

For testing see: https://github.com/Cray-HPE/csm-testing/pull/175

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
These changes allow for a non-hard coded password to be supplied to the Goss tests that interact with management switches, and the BGP Neighbors and Switch MTU Goss tests are currently broken due to [CASMINST-3485](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3485) and [CASMINST-3297](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3297).

Perhaps at a later time the possibility of storing the management switch admin passwords in sealed secrets/vault should be explored.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

