### PR TITLE
1.2: CASMINST-3485

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -66,7 +66,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.7-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.1.1-1.x86_64
+    - canu-1.1.3-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.31-1.noarch
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -66,7 +66,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.7-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.1.3-1.x86_64
+    - canu-1.1.4-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.31-1.noarch
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Canu version bump
- Adds canu testing feature
- Fixed canu validate BGP for csm 1.2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

CASMINST-3485

## Testing


### Tested on:

Drax, Hela, vritualEnv

### Test description:

successfully ran CANU on the systems above.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

