### PR TITLE
CASMTRIAGE-2909: Update cfs-operator to pull in fix for image teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cfs-operator to 1.14.11 to pull in fix for image customization teardown (CASMTRAIGE-2909)
 - Released cray-sysmgmt-health v1.2.18 to fix license headers
 - Remove pvc-migrator from docker manifest
 - Update cray-sysmgmt-health for ghostunnel sec vulnerability

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -55,7 +55,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.14.9
+    version: 1.14.11
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the cfs-operator to pull in a fix for an issue triggering IMS to finish image customization. 

## Issues and Related PRs

* Resolves CASMTRIAGE-2909

## Testing

### Tested on:

  * Hela

### Test description:

The changes were deployed and CFS was successfully run against both live nodes and images.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

