### PR TITLE
CASMCMS-7785/CASMCMS-7655: cray-crus: Update slurm and munge versions

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.1
+    version: 1.9.5
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
Updates the versions of the slurm RPM and munge docker image. The former is to match the slurm version the WLM team is using for this release. The latter is to fix a security issue. No changes to CRUS itself are made.

See the original PR for details:
https://github.com/Cray-HPE/cray-crus/pull/12
