### PR TITLE
CASMINST-3859: Move cfs-state-reporter check from cmsdev tool into goss NCN healthcheck suite

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -39,16 +39,16 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
-    - cray-cmstools-crayctldeploy-1.2.116-1.x86_64
+    - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.45.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.9.0-1.noarch
+    - csm-testing-1.10.1-1.noarch
     - docs-csm-1.13.4-1.noarch
-    - goss-servers-1.9.0-1.noarch
+    - goss-servers-1.10.1-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -2,7 +2,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cray-cmstools-crayctldeploy-1.2.116-1.x86_64
+    - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
Also pulls in fix for CASMINST-3485