### PR TITLE
Load images baked into the NCN images into distribution

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -77,6 +77,7 @@ artifactory.algol60.net/csm-docker/stable:
     # Multus required by platform
     docker.io/nfvpe/multus:
       - v3.1
+      - v3.7
 
     # XXX Not sure where this is used?
     docker.io/openapitools/openapi-generator-cli:
@@ -89,8 +90,10 @@ artifactory.algol60.net/csm-docker/stable:
     # Weave images required by platform
     docker.io/weaveworks/weave-kube:
       - 2.8.0
+      - 2.8.1
     docker.io/weaveworks/weave-npc:
       - 2.8.0
+      - 2.8.1
 
     # Zeromq used by sealed secrets tooling to facilitate installs/upgrades
     docker.io/zeromq/zeromq:
@@ -108,12 +111,18 @@ artifactory.algol60.net/csm-docker/stable:
     # Kube images required by platform
     k8s.gcr.io/kube-apiserver:
       - v1.19.9
+      - v1.20.13
     k8s.gcr.io/kube-controller-manager:
       - v1.19.9
+      - v1.20.13
     k8s.gcr.io/kube-proxy:
       - v1.19.9
+      - v1.20.13
     k8s.gcr.io/kube-scheduler:
       - v1.19.9
+      - v1.20.13
+    k8s.gcr.io/pause:
+      - 3.2
 
     # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -210,7 +210,15 @@ spec:
       cacheRefreshSeconds: "120"
       cacheImages:
       # Kubernetes
-      - k8s.gcr.io/pause:3.2
+      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
       # OPA
@@ -222,12 +230,20 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.2
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      # replace the ones below once new ceph csi charts merge:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.4.0
       - k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
       - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
       - k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
       - k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
       - k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+      # with these:
+      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
+      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+      # - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.5.3


### PR DESCRIPTION
#### Summary and Scope

Use locally built K8S images that match what's being populated in nexus.

- Fixes https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3799

##### Issue Type

- Bugfix Pull Request

Brings alignment between K8S images in nexus and what's being used at bootstrap time.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on craystak (if yes, please include results or a description of the test)

```
ncn-m003:/etc/cray/kubernetes # ls -l join*
-rwx------ 1 root root 318 Jan 26 21:37 join.sh
```

```
ncn-m002:/etc/cray/kubernetes # ls -l join*
-rwx------ 1 root root 177 Jan 26 21:37 join-command
-rwx------ 1 root root 276 Jan 26 21:37 join-command-control-plane
```
```
ncn-m002:~ # kubectl get pods --all-namespaces -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq
artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
```

#### Idempotency

N/A

#### Risks and Mitigations

Low