### PR TITLE
Casmpet 5237 and CASMPET-5269 image version change

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -38,7 +38,8 @@ artifactory.algol60.net/csm-docker/stable:
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.56
-
+    cray-grafterm:
+      - 1.0.1
     # XXX Are these HMS images missing from a chart or are they used to
     # XXX facilitate install/upgrade?
     hms-pytest:
@@ -114,6 +115,8 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.19.9
     k8s.gcr.io/kube-scheduler:
       - v1.19.9
+    quay.io/galexrt/node-exporter-smartmon:
+      - v0.1.1
 
     # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.1
+    version: 0.21.3
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
added node-exporter-smartmon path for Casmpet 5237

added graftterm image path CASMPET-5269

https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5237

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/52
Cray-HPE/container-images#384

https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5269

https://github.com/Cray-HPE/container-images/pull/383
https://github.com/Cray-HPE/cray-grafterm/pull/2

created release tag

https://github.com/Cray-HPE/cray-sysmgmt-health/releases/tag/v1.2.19
