### PR TITLE
CASMINST-3866 - Check target directory exists before attempting to copy image artifacts

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/noarch/release/csm-1.0
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.14.3-1.x86_64
+    - cray-site-init-1.14.4-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.2-1.noarch


### PR DESCRIPTION
## Summary and Scope

When copying the node images csi does not verify the existence of the target directory resulting in a somewhat confusing error message should it not exist.

## Issues and Related PRs

* Resolves [CASMINST-3866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3866)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/798

## Testing

### Tested on:

  * `hela`
  * Local development environment

### Test description:

Old behaviour
```
ncn-m001:~ # csi pit populate pitdata "${CSM_RELEASE}/images/kubernetes/" /mnt/pitdata/data/k8s/ -kiK
5.3.18-59.34-default-0.2.43.kernel----------------> /mnt/pitdata/data/k8s/...Failed "open /mnt/pitdata/data/k8s/5.3.18-59.34-default-0.2.43.kernel: no such file or directory"
initrd.img-0.2.43.xz------------------------------> /mnt/pitdata/data/k8s/...Failed "open /mnt/pitdata/data/k8s/initrd.img-0.2.43.xz: no such file or directory"
kubernetes-0.2.43.squashfs------------------------> /mnt/pitdata/data/k8s/...Failed "open /mnt/pitdata/data/k8s/kubernetes-0.2.43.squashfs: no such file or directory"
```

New behaviour
```
ncn-m001:~ # csi pit populate pitdata "${CSM_RELEASE}/images/kubernetes/" /mnt/pitdata/data/k8s/ -kiK
2022/01/27 10:47:16 Error: target directory /mnt/pitdata/data/k8s/ does not exist
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

