### PR TITLE
CASMCMS-7783

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -67,7 +67,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.4.1
+    version: 1.4.4
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -1,7 +1,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.94-1.x86_64
+    - cfs-trust-1.4.4-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.45.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - ilorest-3.2.3-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.94-1.x86_64
+    - cfs-trust-1.4.4-1.x86_64
     - cray-cmstools-crayctldeploy-1.2.116-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,4 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
-    - cfs-trust-1.3.94-1.x86_64
+    - cfs-trust-1.4.4-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -3,7 +3,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cray-cmstools-crayctldeploy-1.2.116-1.x86_64
-    - cfs-trust-1.3.94-1.x86_64
+    - cfs-trust-1.4.4-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - metal-ipxe-2.1.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

This is an update to the cfs-trust deployment that changes its certificate population behavior from a PUT to a PATCH operation; this is desirable because it does not remove any existing content and thereby makes it safer to deploy during an upgrade scenario.

Additionally, this service now periodically heals BSS metadata service of missing certificate information, should it go missing for whatever reason.

## Issues and Related PRs

* Resolves CASMCMS-7783 (https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7783)
* Changes already promoted to corresponding master branch.

## Testing
### Tested on:

  * wasp
 
### Test description:

Tested by modifying existing running cfs-trust on odin with updated functions, first by backing up existing bss metadata.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
