### PR TITLE
CASMCMS-7786/CASMTRIAGE-2915: Fix console ssh key permissions and CVEs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -82,11 +82,11 @@ spec:
         tag: 0.14.4
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.3.3
+    version: 1.3.5
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.3.3
+    version: 1.3.7
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
Updates cray-console-node and cray-console-operator to pull in the following fixes:
[CASMTRIAGE-2915](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2915) Fix console ssh key permissions
[CASMCMS-7786](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7786) CVEs in cray-console-node
[CASM-2794](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2794) / [CASMCMS-7787](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7787) CVE in cray-console-node