### PR TITLE
Added pod affinity to misc. HMS services.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -17,11 +17,11 @@ spec:
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.4
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.4
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
@@ -29,19 +29,19 @@ spec:
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.0.0
+    version: 2.0.2
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 2.0.0
+    version: 2.0.2
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.2
+    version: 2.15.3
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.0.0 
+    version: 2.0.1
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

The following service charts have been modified to add pod anti-affinity:

BSS
CAPMC
HBTD
HMNFD
SCSD
HMCollector

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMINST-3910 (BSS)
* Resolves CASMINST-3918 (CAPMC)
* Resolves CASMINST-3920 (HBTD)
* Resolves CASMINST-3921 (HMNFD)
* Resolves CASMINST-3922 (HMCollector)
* Resolves CASMINST-3923 (SCSD)

### Testing

Tested on:

* wasp

Was a fresh Install tested? N   Not needed
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
Was a CT test run?          Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

Installed new chart and upgraded to it. Verified anti-affinity by looking at the
nodes the different pods run on before and after. Downgraded when finished.

### Risks and Mitigations

Low risk, no actual chart functional changes were made.

