### PR TITLE
CASMREL-872: NCN and PIT assets for 1.2.0-alpha.57

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220127142431-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220127142431-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220127142431-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220128200517-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220128200517-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220128200517-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.46/kubernetes-0.2.46.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.46/5.3.18-59.34-default-0.2.46.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.46/initrd.img-0.2.46.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.47/kubernetes-0.2.47.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.47/5.3.18-59.34-default-0.2.47.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.47/initrd.img-0.2.47.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.46/storage-ceph-0.2.46.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.46/5.3.18-59.34-default-0.2.46.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.46/initrd.img-0.2.46.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.47/storage-ceph-0.2.47.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.47/5.3.18-59.34-default-0.2.47.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.47/initrd.img-0.2.47.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

LiveCD:
* CASMINST-3929 (new csi)
* CASMINST-3928 (new canu)

NCNs:
* CASMINST-3928 (new canu)
* CASMINST-3860 (ceph change)
* CASMINST-3799 (ceph change)

