### PR TITLE
(main) CASMINST-3831: Bump CSI version

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -7,7 +7,7 @@ http://car.dev.cray.com/artifactory/csm/CSM/sle15_sp2_ncn/x86_64/release/csm-1.0
     - loftsman-1.1.0-20210511145236_2da0507.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.14.4-1.x86_64
+    - cray-site-init-1.14.6-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.6.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Regenerate the the BSS host_records metadata using data from SLS during CSM 1.2 upgrade

https://github.com/Cray-HPE/cray-site-init/pull/117

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-3831

## Testing

_List the environments in which these changes were tested._
For Testing see: https://github.com/Cray-HPE/cray-site-init/pull/117

## Risks and Mitigations
Requires additional end to end testing on Baremetal during a CSM 1.2 upgrade. But all of the changes made to a system are contained within the Global boot parameters in BSS, which currently contains incorrect host record data after a CSM 1.2 upgrade.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable