### PR TITLE
CASMCMS-7784: Update CFS to add Ansible passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cfs services and cli to add Ansible passthrough parameter (CASMCMS-7784)
 - Updated cfs-operator to 1.14.11 to pull in fix for image customization teardown (CASMTRAIGE-2909)
 - Released cray-sysmgmt-health v1.2.18 to fix license headers
 - Remove pvc-migrator from docker manifest

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -55,11 +55,11 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.14.11
+    version: 1.14.13
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.9.1
+    version: 1.9.3
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -4,4 +4,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.45.0-1.x86_64
+    - craycli-0.46.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,7 +42,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.45.0-1.x86_64
+    - craycli-0.46.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
## Summary and Scope

Adds a parameter to CFS to allow sessions to be created with arbitrary arguments passed to Ansible

## Issues and Related PRs

* Resolves CASMCMS-7784

## Testing

### Tested on:

  * Wasp

### Test description:

Ran CFS sessions without passthrough parameters, and with different combinations of parameters.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

