### PR TITLE
CASMUSER-2938 move cray-uas-mgr to 1.18.0: CAST-27468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-uas-mgr to 1.18.0: address CAST-27468
 - Updated cfs services and cli to add Ansible passthrough parameter (CASMCMS-7784)
 - Updated cfs-operator to 1.14.11 to pull in fix for image customization teardown (CASMTRAIGE-2909)
 - Released cray-sysmgmt-health v1.2.18 to fix license headers

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,7 +143,7 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.17.0
+    version: 1.18.0
     namespace: services
   - name: update-uas
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Move cray-uas-mgr to 1.18.0 to resolve CAST-27468.

This change is backward compatible.

## Issues and Related PRs

* Resolves [CASMUSER-2938](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2938)
* Relates to [CAST-27468](https://jira-pro.its.hpecorp.net:8443/browse/CAST-27468)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Deployed this version of the chart to Virtual Shasta and verified that it solves the problem described in CAST-27468.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

There are no known risks or issues known to be associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

