### PR TITLE
CASMUSER-2942 Update cray-psp to 0.3.0: remove obsolete CRB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-psp to 0.3.0: remove obsolete CluterRoleBinding from CAST-27468
 - Update cray-uas-mgr to 1.18.0: address CAST-27468
 - Updated cfs services and cli to add Ansible passthrough parameter (CASMCMS-7784)
 - Updated cfs-operator to 1.14.11 to pull in fix for image customization teardown (CASMTRAIGE-2909)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -72,7 +72,7 @@ spec:
           profile: dryrun
   - name: cray-psp
     source: csm-algol60
-    version: 0.2.0
+    version: 0.3.0
     namespace: services
   - name: cray-velero
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update `cray-psp` chart to 0.3.0 which cleans up an obsolete (and broken) ClusterRoleBinding that was part of the cause of CAST-27468.

This change is backward compatible.

## Issues and Related PRs

* Resolves [CASMUSER-2942](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2942)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Deployed vshasta with 0.3.0 chart and verified that the CRB was gone and that Broker UAIs worked as expected.  Downgraded from 0.3.0 to 0.2.0 and verified that even though the CRB came back, Broker UAIs continued to work as expected.  Upgraded from 0.2.0 to 0.3.0 and verified that the CRB went away again and Broker UAIs continued to work as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

There are no known risks or issues with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

