### PR TITLE
CASMCMS-7793 - remove polkit from console-node image.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -86,7 +86,7 @@ spec:
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.3.7
+    version: 1.3.9
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Remove the 'polkit' package from the published image. This package is installed as part of the 'vi' zypper install but is not required by any of the basic functions of the services. Furthermore it frequently has CVE vulnerabilities that require patching. In an effort to improve the long term security of this service, this package is being deliberately removed from the image. As it is not required, it has no impact on the running of this service.

Code PR:
https://github.com/Cray-HPE/console-node/pull/37

## Issues and Related PRs
* Resolves [CASMCMS-7793](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7793)

## Testing
### Tested on:
  * Mug

### Test description:

I did a Helm install/upgrade of the new image on Mug. When the new version was up and running I confirmed the basic operations of the service (interactive console access and logging) was working correctly. I then did a Helm rollback to restore the original installed version of cray-console-node and insured all was again working correctly.

- Were the install/upgrade-based validation checks/tests run: N - manually verified and tests are basic.
- Were continuous integration tests run? If not, why? N - not covered
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? N - no new functionality added.

## Risks and Mitigations
As this package was not added in support of any required functionality, removal should not impact the functioning of this service. This should have very minimal risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

