### PR TITLE
Update HSM manifest version for CASMHMS-5348

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.6
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Update HSM manifest version for CASMHMS-5348 - Fixed NULL value issue with POST /v2/Inventory/EthernetInterfaces

## Issues and Related PRs

* Resolves [CASMHMS-5348](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5348)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/67

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

