### PR TITLE
   CASMINST-3857 - upgrade to ceph csi 3.5.1 to support rolling ugprades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-ceph-csi-rbd to support rolling upgrade strategy.  CASMINST-3857
+- Update cray-ceph-csi-cephfs to support rolling upgrade strategy.  CASMINST-3857
 - Update cray-psp to 0.3.0: remove obsolete CluterRoleBinding from CAST-27468
 - Update cfs-api to 1.9.5 to add pod anti-affinity: CASMINST-3913
 - Update cray-uas-mgr to 1.18.0: address CAST-27468

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -230,20 +230,21 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
-      # replace the ones below once new ceph csi charts merge:
+      # Remove old CSI provisioners in csm release 1.3
+      ## Start 1.0 CSI provisioners
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.4.0
       - k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
       - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
       - k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
       - k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
       - k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
-      # with these:
-      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
-      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
-      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
-      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
-      # - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-      # - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
+      ## End 1.0 CSI provisioners:
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.0

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -10,9 +10,9 @@ spec:
   charts:
   - name: cray-ceph-csi-rbd
     source: csm-algol60
-    namespace: default
-    version: 3.4.0
+    namespace: ceph-rbd
+    version: 3.5.1
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
-    namespace: default
-    version: 3.4.0
+    namespace: ceph-cephfs
+    version: 3.5.1

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -53,11 +53,17 @@ function unbound_psp_check() {
 }
 
 # Ceph CSI upgrade will require an outage to remove the deployments to move them to namespaces from the default namespace.
+
+echo "Removing current ceph csi provisioners.  This will cause PVC movement between nodes to be inactive for approx 5 minutes."
+sleep 10
+
 undeploy cray-ceph-csi-rbd
 undeploy cray-ceph-csi-cepfs
 
 # Deploy services critical for Nexus to run
+echo "Deploying new ceph csi provisioners"
 deploy "${BUILDDIR}/manifests/storage.yaml"
+echo "Deployment of new ceph csi provisioners is complete.  PVC movement will resume when all ceph csi pods are finished starting"
 deploy "${BUILDDIR}/manifests/platform.yaml"
 deploy "${BUILDDIR}/manifests/keycloak-gatekeeper.yaml"
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -52,6 +52,10 @@ function unbound_psp_check() {
     echo "cray-unbound-coredns-psp check Done"
 }
 
+# Ceph CSI upgrade will require an outage to remove the deployments to move them to namespaces from the default namespace.
+undeploy cray-ceph-csi-rbd
+undeploy cray-ceph-csi-cepfs
+
 # Deploy services critical for Nexus to run
 deploy "${BUILDDIR}/manifests/storage.yaml"
 deploy "${BUILDDIR}/manifests/platform.yaml"


### PR DESCRIPTION
## Summary and Scope

    The current ceph-csi charts do not allow for a modification to the rolling update
    strategy.  This causes upgrades on 3 node systems to not complete as the deployment
    assumes the default of allowing 25% unavailability which will only work with a min of 4
    nodes.

    This also requires an outage of the provisioners to remove the deployments and move them
    into separate namespaces.  This means that we will not be able to provision or re-map
    PVCs until the upgrade is complete.  All previously created/mapped PVCs will function normally
    during the provisioner outage.

## Issues and Related PRs

* Resolves CASMINST-3857
* Documentation changes required in CASMINST-3857

## Testing

### Tested on:

  * this change needs tested on metal.  all other components tested on vshasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? 
- Was downgrade tested? If not, why? 
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

