### PR TITLE
bugfix/CASMINST-3957-csm-1.2 - bump version of csm-testing rpm for fix to CASMINST-3957

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -46,7 +46,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.10.3-1.noarch
+    - csm-testing-1.10.4-1.noarch
     - docs-csm-1.13.6-1.noarch
     - goss-servers-1.10.3-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope
- fix false positive for goss test check_ncn_uan_ip_dns.py
- update wording to out of test to reference python version instead of bash version

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- fix false positive
- update reference to script to be python version instead of bash version
_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
yes
## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

CASMINST-3957

## Testing

_List the environments in which these changes were tested._

### Tested on:

drax
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?yes
- Were continuous integration tests run? If not, why?no
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?no
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
no

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

