### PR TITLE
CASMPET-5260: Pick up keycloak-installer release v1.2.9

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -172,11 +172,11 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.3.0
+    version: 3.3.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.0
+    version: 1.11.1
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
This picks up keycloak-installer release v1.2.9:
https://github.com/Cray-HPE/keycloak-installer/releases/tag/v1.2.9

This includes the following change:

* CASMPET-5260: Update constraints to pick up security fixes

(cherry picked from commit 9d6aeffce294faef25ccb0649f3033840405131d)
