### PR TITLE
CASMINST-3917, CASMINST-3919, CASMPET-5266: Update postgres-operator …

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 0.12.1
+    version: 0.13.0
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,5 +153,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.2.0
+    version: 2.3.0
     namespace: spire


### PR DESCRIPTION
…and spire

This picks up cray-postgres-operator release v1.2.3[0] and
cray-spire v1.2.8[1].
These releases include the following fixes:

* CASMPET-5266: Stop deploying postgres-operator-ui
* CASMINST-3919: postgres-operator set podAntiAffinity on the pooler
* CASMPET-5266: Rebuild postgres-operator to pick up newer base image
* CASMINST-3917: Set pod anti-affinity for spire-jwks.
* CASMINST-3919: Add post-upgrade hook to set pooler pod antiaffinity
* spire cray-service subchart is updated to 8.1.1

[0] https://github.com/Cray-HPE/cray-postgres-operator/releases/tag/v1.2.3
[1] https://github.com/Cray-HPE/cray-postgres-operator/releases/tag/v1.2.3

(cherry picked from commit 7f08511cfff08b8f632dfeaa18d83aaf6eac2847)
