### PR TITLE
CASMCMS-7806: Update cfs-api for api validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cfs-api to 1.10.1 to add api validation and remove v1 api (CASMCMS-7806)
 - Update cray-psp to 0.3.0: remove obsolete CluterRoleBinding from CAST-27468
 - Update cfs-api to 1.9.5 to add pod anti-affinity: CASMINST-3913
 - Update cray-uas-mgr to 1.18.0: address CAST-27468

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -59,7 +59,7 @@ spec:
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.9.5
+    version: 1.10.1
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the cfs-api to add validation to several api fields to prevent code injection. This also removes the deprecated v1 api to avoid any security vulnerabilities in that api.

## Issues and Related PRs

* Resolves CASMCMS-7806
* Resolves CASMCMS-7287

## Testing

### Tested on:

  * Hela

### Test description:

Tested several valid and invalid configurations, as well as session creation to validate code affected by the v1 api removal.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

