### PR TITLE
CASMPET-5296: upgrade XDS v2 to v3 API in EnvoyFilter

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -100,7 +100,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.6.0
+    version: 1.8.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Use new cray-opa chart to upgrade XDS v2 to v3 API in EnvoyFilter in preparation for istio upgrade.

## Issues and Related PRs

* Resolves [CASMPET-5296]
* Change will also be needed in `release/1.2`

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Deployed the new cray-opa chart with upgraded EnvoyFilter XDS, and verified that we can still call capmc api get_node_rules with the new EnvoyFilter.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. The upgrade simply replaces v2 with equivalent v3 phrases with no functionality changes, and we can also easily back off the changes if unexpected things happen.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

