### PR TITLE
Update hpe-csm-scripts repo version

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -64,7 +64,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-1.1.4-1.x86_64
     - yapl-0.1.1-1.x86_64
-    - hpe-csm-scripts-0.0.31-1.noarch
+    - hpe-csm-scripts-0.0.32-1.noarch
     - loftsman-1.2.0-1.x86_64
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch


### PR DESCRIPTION
## Summary and Scope

Update hpe-csm-scripts repo version for CASMHMS-5346 - Change lock_management_nodes.py to lock nodeBMCs of management nodes

## Issues and Related PRs

* Resolves [CASMHMS-5346](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5346)

## Testing

For testing, see https://github.com/Cray-HPE/hpe-csm-scripts/pull/9

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

