### PR TITLE
Update snyk aggregation report to breakdown fixable by severity

### DIFF
--- a/build/images/Makefile
+++ b/build/images/Makefile
@@ -7,7 +7,7 @@ export HELM_CACHE_HOME HELM_CONFIG_HOME
 
 SHELL=/usr/bin/env bash -euo pipefail
 
-all: index.txt
+all: index.txt chartmap
 
 index.txt: $(manifests_images) docker/index.txt
 	cat $^ | sort -u | parallel -j 75% --retries 5 --halt-on-error soon,fail=100% ./inspect.sh | sort -u > $@
@@ -20,7 +20,14 @@ docker/index.txt: ../../docker/index.yaml
 	@mkdir -p $(@D)
 	../../hack/list-images.py $< | sort -u > $@
 
+.PHONY: chartmap
+
+chartmap:
+	@echo "manifest,chart,image" >> chartmap.csv
+	@tac chartmap.csv > chartmap-tac.csv
+	@mv chartmap-tac.csv chartmap.csv
+
 .PHONY: clean
 
 clean:
-	$(RM) index.txt $(manifests_images) docker/index.txt
+	$(RM) index.txt $(manifests_images) docker/index.txt chartmap.csv

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2022 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -euo pipefail
 set -o xtrace
 

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 
 set -euo pipefail
 set -o xtrace

--- a/release.sh
+++ b/release.sh
@@ -266,7 +266,8 @@ vendor-install-deps "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
 parallel -j 75% --halt-on-error now,fail=1 -v \
     -a "${ROOTDIR}/build/images/index.txt" --colsep '\t' \
     "${ROOTDIR}/hack/snyk-scan.sh" "${BUILDDIR}/scans/docker" '{2}' '{1}'
-${ROOTDIR}/hack/snyk-aggregate-results.sh "${BUILDDIR}/scans/docker" --sheet-name "$RELEASE"
+cp "${ROOTDIR}/build/images/chartmap.csv" "${BUILDDIR}/scans/docker/"
+${ROOTDIR}/hack/snyk-aggregate-results.sh "${BUILDDIR}/scans/docker" --helm-chart-map "/data/chartmap.csv" --sheet-name "$RELEASE"
 ${ROOTDIR}/hack/snyk-to-html.sh "${BUILDDIR}/scans/docker"
 
 # Save scans to release distirbution

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022 Hewlett Packard Enterprise Development LP
 
 set -euo pipefail
 set -o xtrace

--- a/security/snyk-aggregate-results/snyk-aggregate-results.py
+++ b/security/snyk-aggregate-results/snyk-aggregate-results.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 from collections import defaultdict
 import csv

--- a/security/snyk-aggregate-results/snyk-aggregate-results.py
+++ b/security/snyk-aggregate-results/snyk-aggregate-results.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022 Hewlett Packard Enterprise Development LP
 
 from collections import defaultdict
 import csv

--- a/security/snyk-aggregate-results/snyk-aggregate-results.py
+++ b/security/snyk-aggregate-results/snyk-aggregate-results.py
@@ -1,5 +1,26 @@
-# Copyright 2022 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 from collections import defaultdict
 import csv
 import fileinput

--- a/security/snyk.md
+++ b/security/snyk.md
@@ -324,6 +324,17 @@ configuration and cached data are under build/.helm then calls sub-make against
 [build/images/Makefile].
 
 
+#### build/images/chartmap.csv
+
+
+The process of extracting and resolving references for all images required by Helm Charts
+is scripted using GNU Make to generate build/images/chartmap.csv,
+which maps Loftsman Manifests to a Helm Chart, to a _logical_ image reference. 
+As discussed above, the recommended way of building build/images/chartmap.csv is to run `make images`
+from the top-level directory. It sets up environment variables so that Helm
+configuration and cached data are under build/.helm then calls sub-make against
+[build/images/Makefile].
+
 ### Scan Helm Charts
 
 Snyk can find security issues in Infrastructure-As-Code files such as


### PR DESCRIPTION
Update Snyk aggregation report to breakdown fixable by severity

## Summary and Scope

- Update image chart extraction to output manifest->chart->image mapping
- Add fixable by severity count to snyk aggregation spreadsheet
- Split 'isPatchable' out to autopatchable column in synk aggregation spreadsheet
- Include impacted Helm charts in snyk aggregation spreadsheet

## Issues and Related PRs

* Resolves [CASM-2832](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2832)

## Testing

Tested by completing `make images` and verifying Snyk aggregation report execution manually. Notably, I did not execute the overall `release.sh` process. 

### Tested on:

 * Local development environment

### Test description:

See above.

## Risks and Mitigations

None known.

## Pull Request Checklist

- [X] Copyrights updated
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

