### PR TITLE
CASMUSER-2949 Update Broker UAI Image to 1.2.4 (CAST-28881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update Broker UAI Docker image version to 1.2.4 CAST-28881
 - Update craycli to 0.40.20 in RPM manifests
 - Update cray-kafka-operator to 0.4.2 to include CVE-2021-44228 fix
 - Updated cray-keycloak and cray-keycloak-users-localize to pick up security fixes (CVE-2021-3711)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -366,7 +366,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-tftpd:
     - 1.4.23
     cray-uai-broker:
-    - 1.2.3
+    - 1.2.4
     cray-uai-sles15sp2:
     - 1.0.14
     cray-uas-mgr:

--- a/docker/transform.sh
+++ b/docker/transform.sh
@@ -68,7 +68,7 @@ DISTDIR=$1
     cp -v -r baseos/alpine:3.13.5 baseos/alpine:3.13
     cp -v -r cray/cray-nexus-setup:0.5.2 cray/cray-nexus-setup:0.3.2
     cp -v -r cray/cray-nexus-setup:0.5.2 cray/cray-nexus-setup:0.4.0
-    cp -v -r cray/cray-uai-broker:1.2.3 cray/cray-uai-broker:latest
+    cp -v -r cray/cray-uai-broker:1.2.4 cray/cray-uai-broker:latest
     cp -v -r loftsman/docker-kubectl:0.2.0 loftsman/docker-kubectl:latest
     cp -v -r loftsman/loftsman:0.5.1 loftsman/loftsman:latest
     cp -v -r openpolicyagent/opa:0.24.0-envoy-1 openpolicyagent/opa:latest


### PR DESCRIPTION
## Summary and Scope

Update the Broker UAI to a version that works. The security fix (removing cpio from the image) that produced v1.2.3 of the Broker UAI image caused openssh to be uninstalled because of a dependency in the build.  The result was a Broker UAI with no SSH server in it.  Version 1.2.4 restored the SSH server.

This change is a backward compatible bugfix.

## Issues and Related PRs

* Resolves [CASMUSER-2949](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2949)
* Resolves [CAST-28881](https://jira-pro.its.hpecorp.net:8443/browse/CAST-28881)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Deployed and used the Version 1.2.4 Broker UAI image on vshasta and verified that it functioned as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

There are no known risks or issues with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

