### PR TITLE
CASMPET-5182: cray-drydock release v1.2.4

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -17,7 +17,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.12.0
+    version: 2.12.1
     namespace: loftsman
   - name: gatekeeper
     source: csm-algol60


### PR DESCRIPTION
This release[0] contains the following fix:

* CASMPET-5182: sonar-jobs-watcher restarts when containerd restarted

[0] https://github.com/Cray-HPE/cray-drydock/releases/tag/v1.2.4

(cherry picked from commit aff4f33639ea169fdd2264d917cafae785c287ac)
