### PR TITLE
MTL-1613 new metal ipxe

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220203204843-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220203204843-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220203204843-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220210203810-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220210203810-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220210203810-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -6,5 +6,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cfs-trust-1.3.94-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - metal-ipxe-2.1.1-1.noarch
+    - metal-ipxe-2.1.2-1.noarch
 


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-3789 MTL-1613
- Relates to CASMTRIAGE-2793

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

This reverts commit 5303a8bea5fb7160936043b17da2171e448eeada, ceasing DHCPing on every NIC. Instead the xname issue from CASMINST-3789 by removing an ambiguous variable in the iPXE script.

Prior to CASMTRIAGE-2793 the netX variable was reliably relaying the current, active DHCP interface. This behavior broke after CASMTRIAGE-2793, the netX variable actually refers to the current open interface which is _all_ of them. Thus we have to specifically select the interface that truly succeed DHCP, instead of relying on the short-cut variable.

This change removes the null setting, to prevent retries from erasing the xname as well.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)

> redbull 

- All NCNs reported xnames in their `/proc/cmdline` files.

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?

On PXE failures the xname will still be set, despite DHCP packet information being lost. This is because we set it the first time it exists, instead of every time we DHCP. See [line 16 of script.ipxe](https://github.com/Cray-HPE/metal-ipxe/blob/2c654c5a03ade887275a65bf3e2392871d915b6d/script.ipxe#L16) for this explanation in code.
