### PR TITLE
CASMINST-3828: Update cray-site-init RPM to 1.14.10

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.14.9-1.x86_64
+    - cray-site-init-1.14.10-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

Adds the MTL route (e.g. 10.1.0.0/16) via NMN gateway to write_files in BSS.

See https://github.com/Cray-HPE/cray-site-init/pull/121

## Issues and Related PRs

* Resolves CASMINST-3828

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `fanta`

### Test description:

See https://github.com/Cray-HPE/cray-site-init/pull/121

## Risks and Mitigations

See https://github.com/Cray-HPE/cray-site-init/pull/121


## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
