### PR TITLE
CASMPET-5301: Updating shared-kafka chart version and kafka tag version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
-- Update cray-shared-kafka to 0.6.0 and image tags under index.yaml
+- Update cray-shared-kafka to 0.7.0 and image tags under index.yaml
 - Update Broker UAI Docker image version to 1.2.4 CAST-28881
 - Update craycli to 0.40.20 in RPM manifests
 - Update cray-kafka-operator to 0.4.2 to include CVE-2021-44228 fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-shared-kafka to 0.6.0 and image tags under index.yaml
 - Update Broker UAI Docker image version to 1.2.4 CAST-28881
 - Update craycli to 0.40.20 in RPM manifests
 - Update cray-kafka-operator to 0.4.2 to include CVE-2021-44228 fix

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -102,9 +102,6 @@ arti.dev.cray.com/third-party-docker-stable-local:
     - 3.25.0 # update platform.yaml cray-precache-images with this
     squareup/ghostunnel:
     - v1.5.2
-    strimzi/kafka: # Used by cray-shared-kafka-zookeeper pods
-    - 0.15.0-kafka-2.2.1
-    - 0.15.0-kafka-2.3.1
     strimzi/operator:
     - 0.15.0
     tutum/curl:
@@ -407,6 +404,10 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.4.1
     quay.io/strimzi/operator:
     - 0.15.0-noJndiLookupClass
+
+    quay.io/strimzi/kafka: # Used by cray-shared-kafka-zookeeper pods
+    - 0.15.0-kafka-2.2.1-noJSM-chainsaw
+    - 0.15.0-kafka-2.3.1-noJSM-chainsaw
 
     update-uas:
     - 1.0.14

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: gatekeeper-system
   - name: cray-shared-kafka
     source: csm
-    version: 0.6.0
+    version: 0.7.0
     namespace: services
   - name: cray-sts
     source: csm

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: gatekeeper-system
   - name: cray-shared-kafka
     source: csm
-    version: 0.5.0
+    version: 0.6.0
     namespace: services
   - name: cray-sts
     source: csm


### PR DESCRIPTION
## Summary and Scope

CASMPET-5301: Updating shared-kafka chart version and kafka tag version

Updated shared-kafka chart version to 0.7.0 under manifests/platform.yaml
Updated new docker tag under docker/index.yaml

## Issues and Related PRs

Related PR would be from cray-shared-kafka. Soon it will be up.
CASMPET-5301: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5301

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

Once CSM 1.0.11 build is out, full testing needs to be done by the appropriate stake holders

## Risks and Mitigations

NA

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

