### PR TITLE
CASMCMS-7814 - resolve CVE vulnerabilities in cray-crus.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.5
+    version: 1.9.7
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This rebuilds the cray-crus service to resolve vulnerabilities in the base image at to use a fixed version of munge-munge in wlm-slurm.

The fixed version of munge-munge is not an official release version, but that will not be available until early March according to David Gloe.  In this fix I have changed the version of munge-munge used to point to a patched (but pre-release) version.  See the code PR for details on the munge-munge version:
https://github.com/Cray-HPE/cray-crus/pull/14

See details on munge-munge patch in:
https://jira-pro.its.hpecorp.net:8443/browse/PE-39542

## Issues and Related PRs
* Resolves [CASMCMS-7814](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7814)
* Resolves [CASMCMS-7818](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7818)

## Testing
### Tested on:
  * Local development environment

### Test description:

Rebuilt the images and verified via SNYK that the vulnerabilities were resolved by the rebuilds with base versions and inclusion of the new munge-munge image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk for the updated base image rebuilds as there were no code changes, just patched base images.  I am not sure what the risk is on including the pre-release munge-munge image in the build.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

