### PR TITLE
CASMINST-4001: Update goss-server package to 1.11.0

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.10.5-1.noarch
+    - csm-testing-1.11.0-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.10.5-1.noarch
+    - goss-servers-1.11.0-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This adds tests that are run on workers and storage nodes after the nodes have been deployed in fresh install (csi pit validate --ceph and csi pit validate --k8s) and after they are upgraded.

## Issues and Related PRs

* Resolves CASMINST-4001
* Related to CASMINST-3828

## Testing


### Tested on:

  * `fanta`

### Test description:

Ran `csi pit validate --ceph` and `csi pit validate --k8s` to test fresh install
Ran `ncn-upgrade-tests-storage.yaml` and `ncn-upgrade-tests-storage.yaml` to test upgrades.

Verified that the new test shows up in the output and passes.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

