### PR TITLE
CASMPET-5331 - add ceph container image v15.2.15

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -55,6 +55,9 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/ceph/ceph:
       - v15.2.8
 
+    quay.io/ceph/ceph:
+      - v15.2.15
+
     # XXX See also k8s.gcr.io/coredns:1.7.0 below
     docker.io/coredns/coredns:
       - 1.6.2


### PR DESCRIPTION
## Summary and Scope

This addresses multiple Ceph CVEs and also utilizes a supported
base image of centos:stream8.  The older image were centos:8 based which
is EOL.


## Issues and Related PRs

* Resolves CASMPET-5331

## Testing

### Tested on:

  * Hela
  * craystack

### Test description:

Ran a fresh install on craystack utilizing on the v15.2.15 container image from algol60.  
Upgraded hela utilizing the v15.2.15 container image from algol60

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

This is an in-family upgrade.  


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

