### PR TITLE
CASMINST-4029 - Remove ceph csi 3.4.0 from pre-cached images

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -230,15 +230,6 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
-      # Remove old CSI provisioners in csm release 1.3
-      ## Start 1.0 CSI provisioners
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.4.0
-      - k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
-      - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
-      - k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-      - k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
-      - k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
-      ## End 1.0 CSI provisioners:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -11,8 +11,8 @@ spec:
   - name: cray-ceph-csi-rbd
     source: csm-algol60
     namespace: ceph-rbd
-    version: 3.5.1
+    version: 3.5.1-1
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs
-    version: 3.5.1
+    version: 3.5.1-1


### PR DESCRIPTION
## Summary and Scope

Remove ceph-csi 3.4.0 images from pre-cache since we will not be using them

## Issues and Related PRs

* Resolves CASMINST-4029

## Testing

### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

