### PR TITLE
CASMINST-4030 1.2 : TESTS - Kubernetes Postgresql Check that Automated Backup are Working

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.11.0-1.noarch
+    - csm-testing-1.11.1-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.11.0-1.noarch
+    - goss-servers-1.11.1-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope
During the csm 1.2 upgrade, cronjobs may get re-created because of too many failed attempts to start.
Postgresql cronjob based backup are expected to exist 24hr after the cluster is created. This window needs to be based on when the cronjobs were created (or re-created in the case of the upgrade) and not when the cluster was created.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? Yes

## Issues and Related PRs

* Resolves [CASMINST-4030](issue link)
* Change will also be needed in `master`
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta
drax 

### Tested on:

### Test description:

Verified on drax that the script passes as expected.  Some of the postgresql cronjobs had been re-created as part of the upgrade (but not all)

```
ncn-m001:~ # /tmp/kimj/postgresql_backups_check.sh -p
keycloak-postgres -- recent backup found: keycloak-postgres-2022-02-15T15:41:06.manifest
cray-sls-postgres is less than 24 hours old. Did not check if recent backups exist.
cray-smd-postgres is less than 24 hours old. Did not check if recent backups exist.
gitea-vcs-postgres is less than 24 hours old. Did not check if recent backups exist.
spire-postgres is less than 24 hours old. Did not check if recent backups exist.
PASS

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? NA
- Was upgrade tested? NA
- Was downgrade tested? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable