### PR TITLE
New csm-testing for goss console pods test timeout fix

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,9 +26,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.10.1-1.noarch
+    - csm-testing-1.12.1-1.noarch
     - docs-csm-1.13.2-1.noarch
-    - goss-servers-1.9.0-1.noarch
+    - goss-servers-1.12.1-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Need more than ten seconds for this test -- bumped to 60 seconds to give plenty of headroom.

## Issues and Related PRs

* Resolves [CASMINST-4055](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4055)

## Testing

```
ncn-w001:~ # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-console-services.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
.

Total Duration: 6.203s
Count: 1, Failed: 0, Skipped: 0
```

### Tested on:

  * `hela`

### Test description:

Changed the timeout, ran fine (but finished in 6 seconds on hela)

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable