### PR TITLE
CASMCMS-7823 - update bos and cfs-api to remediate redis CVE vulnerability.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -59,7 +59,7 @@ spec:
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.10.1
+    version: 1.10.3
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60
@@ -110,7 +110,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 1.10.21
+    version: 1.10.23
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update the database image from redis:5.0-alpine3.12 to redis:5.0-alpine. This less specific tag allows use of more recent alpine base images that are still being patched for security vulnerabilities. The current version uses alpine:3.15 and has the security issues resolved.

Code PRs:
https://github.com/Cray-HPE/bos/pull/30
https://github.com/Cray-HPE/config-framework-service/pull/36

## Issues and Related PRs
* Resolves [CASMCMS-7823](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7823)

## Testing
### Tested on:
  * `Mug`

### Test description:

I verified the new image is clean using the SNYK scanner. After building a new version of cray-cfs-api and cray-bos using the new database image, I updated the deployment on Mug, verified the db was working correctly, then rolled back to the original version

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a fairly low risk change as there is nothing in the code that has changed, just the image version that is running the db. The testing verified the db is functioning as expected.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

