### PR TITLE
CASMCSM-7825/7824 - update gitea to use new keycloak version.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.3.4
+    version: 2.3.6
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

The gitea initialization job was using an old version of keycloak that contained CVE vulnerabilities. This updates to use the latest version of cray-keycloak-setup.

Code PR:
https://github.com/Cray-HPE/gitea/pull/14

## Issues and Related PRs
* Resolves [CASMCMS-7824](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7824)
* Resolves [CASMCMS-7825](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7825)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed the new version of gitea chart on Mug through a helm upgrade. We watched the initialization job run and verified it was able to connect to keycloak and check / update the required users in keycloak. As this image is only used during an initialization job, a downgrade test was not required.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - not required
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This should be a low risk change as we are upgrading to the current keycloak version and testing verified it worked correctly on an installed system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

