### PR TITLE
CASMINST-4007 Fix pre-cache upgrade issue

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -19,6 +19,43 @@ spec:
     source: csm-algol60
     version: 2.12.1
     namespace: loftsman
+  - name: cray-precache-images
+    source: csm-algol60
+    version: 0.5.0
+    namespace: nexus
+    values:
+      cacheRefreshSeconds: "120"
+      cacheImages:
+      # Kubernetes
+      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
+      # Istio
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
+      # OPA
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
+      # DNS
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
+      # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
+      # cray-nexus
+      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.0
   - name: gatekeeper
     source: csm-algol60
     version: 1.5.1
@@ -92,7 +129,7 @@ spec:
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.26.3   # Update cray-precache-images below on proxyv2 tag change.
+    version: 1.26.3   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -202,43 +239,6 @@ spec:
     source: csm-algol60
     version: 0.4.1
     namespace: operators
-  - name: cray-precache-images
-    source: csm-algol60
-    version: 0.4.0
-    namespace: nexus
-    values:
-      cacheRefreshSeconds: "120"
-      cacheImages:
-      # Kubernetes
-      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
-      # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
-      # OPA
-      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
-      # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.1
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.2
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
-      # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
-      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
-      # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.0
   - name: cray-metallb
     source: csm-algol60
     version: 1.1.0


### PR DESCRIPTION
## Summary and Scope

This adds a wait-for job that will pause loftsman until all the cray-precache-images are running.

## Issues and Related PRs

* Resolves [CASMINST-4007](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4007) 

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that images were cached and that the wait-for pod waited until all pods were up and caused the helm install pause until they were.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Due to how the pre-cache image pod is run, this doesn't wait for the images to be fully cached. It only waits until the cache pods are up.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

