### PR TITLE
CASMINST-3992 - ncn-kubernetes-check failed for LoadBalancer Services Have External IP testcase

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,7 +42,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.2-1.noarch
+    - csm-testing-1.12.3-1.noarch
     - docs-csm-1.13.9-1.noarch
     - goss-servers-1.12.1-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

The introduction of the `cray-oauth2-proxies-customer-high-speed-ingress` causes the "LoadBalancer Services Have External IP" test to fail if CHN isn't configured as the LoadBalancer will always be in a `<pending>` state in this case.

Filtered this LoadBalancer out of the check similar to how `istio-ingressgateway-chn` is already excluded if CHN isn't configured.

Also fixed an issue where an update to the MetalLB chart meant that the test script was looking at the wrong ConfigMap.

## Issues and Related PRs

* Resolves [CASMINST-3992](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3992)

## Testing

### Tested on:

  * `starlord` - CHN is not configured, test was failing now passes.
  *  `hela` - CHN is configured, test should and does pass.

### Test description:

Installed new csm-testing rpm on all NCNs and ran the `ncn-kubernetes-checks` test suite.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

