### PR TITLE
Change velero backup test remediation to really delete PartiallyFailed backups

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.2-1.noarch
+    - csm-testing-1.12.4-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.1-1.noarch
+    - goss-servers-1.12.4-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Remediation steps for velero backup test don't permanently delete a backup, need to use velero command instead (not kubectl).

## Issues and Related PRs

* Resolves [CASMINST-4059](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4059)

## Testing

Ran the velero delete on surtur, the backup did not come back.

### Tested on:

  * `surtur`

### Test description:

Manually ran the new remediation step and it worked.

## Risks and Mitigations

None/Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable