### PR TITLE
CASMINST-4069 Update HSM components test for new expected BMC management roles

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -41,7 +41,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-rts-ct-test-1.15.0-1.x86_64
     - hms-scsd-ct-test-1.8.0-1.x86_64
     - hms-sls-ct-test-1.11.0-1.x86_64
-    - hms-smd-ct-test-1.45.0-1.x86_64
+    - hms-smd-ct-test-1.48.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
     - platform-utils-1.2.7-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change updates the HSM /State/Components tests for the new expected Management roles of BMCs. A recent change was made for [CASMHMS-5346](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5346) to set the Management role in HSM for BMCs of NCNs for the purposes of locking. The test was not updated in accordance with that change, so adding the new expected roles to the test schema now.

### Issues and Related PRs

* Resolves CASMINST-4069.

### Testing

This change was tested on Surtur by deploying the updated version of the test, executing it with Management BMC roles set in HSM, and verifying that the previously failing test cases began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, fixes a problem that will cause HMS test failures.