### PR TITLE
CASMNET-1157: Add edge switches to MetalLB config for CHN

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.15.0-1.x86_64
+    - cray-site-init-1.16.0-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

This adds the capability to specify edge routers in switch_metadata.csv to get them added to SLS with xnames and get them added as CHN peers to the metallb config map.

See https://github.com/Cray-HPE/cray-site-init/pull/121

## Issues and Related PRs

* Resolves CASMNET-1157

## Testing

#### Testing

I have tested this by running `csi config init` with hela seed files using various combinations of inputs.

* With two edge switches specified and bgp-peer-types set to [spine, edge]
* Without edge switches specified in switch_metadata.csv
* With two edge switches specified but bgp-peer-types set to [spine]
* With no edge switches specified but bgp-peer-types set to [spine, edge]
* With only one edge switch specified
* With and without CHN defined in CSI inputs



## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable