### PR TITLE
CASMINST-4007 Add anti-affinity toggle to cray-opa

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -137,7 +137,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.8.0
+    version: 1.9.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This change allows us to choose whether to use required or preferred anti affinity. Preferred is needed on vshasta. On systems with 4 or more worker nodes, required should be used.

## Issues and Related PRs

* Resolves [CASMINST-4007](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4007) 

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated anti affinity rules worked with both toggles and that they functioned correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

