### PR TITLE
CASMINST-4074 - update keycloak image tag to resolve CVE.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -79,7 +79,7 @@ spec:
     namespace: services
     values:
       keycloakImage:
-        tag: 0.14.4
+        tag: 3.1.1
   - name: cray-console-operator
     source: csm-algol60
     version: 1.3.5


### PR DESCRIPTION
## Summary and Scope

When CASMCMS-7825/7824 was checked in I missed updating this one image tag override value in the csm manifest file.  This completes getting gitea to point to the correct (updated) version of cray-keycloak-setup.

## Issues and Related PRs
* Resolves [CASMINST-4074](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4074)

## Testing

None - update missed version tag in csm manifest update.

## Risks and Mitigations

Very low risk - just fixing mistake in previous update.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
