### PR TITLE
CASMPET-5349: Updating shared-kafka chart version and kafka tag version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-shared-kafka 0.7.0 to mitigate CVE-2022-2330[257] and CVE-2021-4104
 - Update cray-kafka-operator 0.4.2 to mitigate CVE-2021-44228
 - Enable PSP admission controller
 - Updated resource limits for spire postgresql and spire-wait-for-postgres

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -31,6 +31,10 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.3.8
     cray-hmnfd:
     - 1.8.7
+    strimzi/kafka: # Used by cray-shared-kafka-zookeeper pods
+    - 0.15.0-kafka-2.2.1-noJSM-chainsaw
+    - 0.15.0-kafka-2.3.1-noJSM-chainsaw
+
 
 # XXX dtr.dev.cray.com/baseos
 arti.dev.cray.com/baseos-docker-master-local:
@@ -139,9 +143,6 @@ arti.dev.cray.com/third-party-docker-stable-local:
     - 3.25.0 # update platform.yaml cray-precache-images with this
     squareup/ghostunnel:
     - v1.5.2
-    strimzi/kafka: # Used by cray-shared-kafka-zookeeper pods
-    - 0.15.0-kafka-2.2.1
-    - 0.15.0-kafka-2.3.1
     strimzi/operator:
     - 0.15.0
     tutum/curl:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -128,7 +128,7 @@ spec:
     values:
       imagesHost: dtr.dev.cray.com
   - name: cray-shared-kafka
-    version: 0.4.1
+    version: 0.7.0
     namespace: services
   - name: cray-sts
     version: 0.4.2


### PR DESCRIPTION
## Summary and Scope

CASMPET-5349: Updating shared-kafka chart version and kafka tag version

Updated shared-kafka chart version to 0.7.0 under manifests/platform.yaml
Updated new docker tag under docker/index.yaml

## Issues and Related PRs

* Resolves [CASMPET-5349](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5349)

## Test description:

Full testing needs to be done from appropriate stakeholder(in this case SMA). Based on testing done with the 1.0.11 bits, having same changes, this is good to go.

## Risks and Mitigations

NA

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

