### PR TITLE
CASMCMS-7831 - update cray-crus for CVE remediations.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.7
+    version: 1.9.9
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
The munge-munge image used in cray-crus was provided by PE, however there were CVE vulnerabilities and they were not creating a new stable version until the next complete release of their software. Since munge is open source, we started with their Dockerfile and used it to build our own version of the image with the security patches supplied.

PR to build munge-munge image:
https://github.com/Cray-HPE/container-images/pull/393

Code PR's:
https://github.com/Cray-HPE/cray-crus/pull/15

## Issues and Related PRs
* Resolves [CASMCMS-7831](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7831)

## Testing
### Tested on:
  * Local development environment

### Test description:

After all needed images were built, I used snyk to locally verify that all security vulnerabilities are resolved.

Due to the need for a 1.2 system with a complete PE install and available compute nodes to boot, there is no system currently available that can be used to test cray-crus. No system testing was done.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - no system available.
- Was upgrade tested? If not, why? N - no system available.
- Was downgrade tested? If not, why? N - no system available.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change. The new munge-munge image was built using the existing PE Dockerfile as a base, but needed to be modified to get it to build from the container-images github actions workflows. To all appearances this should replicate the PE munge-munge image, but without a system to test on we can't 100% insure there isn't some unknown issue.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

