### PR TITLE
CASMINST-4075 main : High/Critical CVE Container use in platform->csm-algol60/cray-node-discovery:1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-node-discovery for sec vulnerability
 - Update cray-ceph-csi-rbd to support rolling upgrade strategy.  CASMINST-3857
 - Update cray-ceph-csi-cephfs to support rolling upgrade strategy.  CASMINST-3857
 - Released cray-sysmgmt-health v1.2.18 to fix license headers

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -180,7 +180,7 @@ spec:
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
-    version: 1.2.0
+    version: 1.2.1
     namespace: services
   - name: gatekeeper-policy-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Rebuilding the cray-node-discovery image to take advantage of container-image for alpine 3.14

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_Yes

## Issues and Related PRs

* Resolves [CASMINST-4075](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4075)
* Change will also be needed in release/1.2
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

  * Virtual Shasta

### Test description:
* Daemonset pods restarted (one per worker node)
```
$ kubectl get pods -A -o wide | grep node-disc
services            cray-node-discovery-8xslf                                         1/1     Running     0          8m22s   10.1.0.7     ncn-w002-afbdd1f9   <none>           <none>
services            cray-node-discovery-gslgw                                         1/1     Running     0          8m38s   10.1.0.2     ncn-w003-eca627f6   <none>           <none>
services            cray-node-discovery-xfwl8                                         1/1     Running     0          8m12s   10.1.0.5     ncn-w001-ac529188   <none>           <none>
```
* Using newly built (unstable) image
```
$ kubectl get pod cray-node-discovery-8xslf -n services -o yaml | grep image | grep node-dis
    image: gcr.io/vsha-kjensen-35682334251632301/unstable/cray-node-discovery:1.2.1-20220223174300_4cb1ed7
    image: gcr.io/vsha-kjensen-35682334251632301/unstable/cray-node-discovery:1.2.1-20220223174300_4cb1ed7
    imageID: gcr.io/vsha-kjensen-35682334251632301/unstable/cray-node-discovery@sha256:b82022ab7a3225583ad384f24c3c1939578b8944a00277f9c812c415208eeae7
```
* No errors in logs
```
$ kubectl logs -l app.kubernetes.io/instance=cray-node-discovery --prefix=true -n services
[pod/cray-node-discovery-8xslf/node-discovery] Managing label namespace 'node-discovery.cray.com' for node 'ncn-w002-afbdd1f9'
[pod/cray-node-discovery-gslgw/node-discovery] Managing label namespace 'node-discovery.cray.com' for node 'ncn-w003-eca627f6'
[pod/cray-node-discovery-xfwl8/node-discovery] Managing label namespace 'node-discovery.cray.com' for node 'ncn-w001-ac529188'
```
* Check the node-discovery label for running nodes is true
```
$ kubectl get nodes -l node-discovery.cray.com/running=true
NAME                STATUS   ROLES    AGE     VERSION
ncn-w001-ac529188   Ready    <none>   3h21m   v1.19.9
ncn-w002-afbdd1f9   Ready    <none>   3h20m   v1.19.9
ncn-w003-eca627f6   Ready    <none>   3h20m   v1.19.9
```
* Snyk report looks good
```$  snyk test --docker artifactory.algol60.net/csm-docker/unstable/cray-node-discovery:1.2.1-20220223174300_4cb1ed7

Testing artifactory.algol60.net/csm-docker/unstable/cray-node-discovery:1.2.1-20220223174300_4cb1ed7...

Organization:      kim.jensenhpe.com
Package manager:   apk
Project name:      docker-image|artifactory.algol60.net/csm-docker/unstable/cray-node-discovery
Docker image:      artifactory.algol60.net/csm-docker/unstable/cray-node-discovery:1.2.1-20220223174300_4cb1ed7
Platform:          linux/amd64
Base image:        alpine:3.14.3
Licenses:          enabled

✓ Tested 27 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
