### PR TITLE
CASMINST-4080: main High/Critical CVE Container use in platform->csm-algol60/cray-oauth2-proxies:0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080
 - Update cray-ceph-csi-rbd to support rolling upgrade strategy.  CASMINST-3857
 - Update cray-ceph-csi-cephfs to support rolling upgrade strategy.  CASMINST-3857
 - Released cray-sysmgmt-health v1.2.18 to fix license headers

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -262,5 +262,5 @@ spec:
     namespace: services
   - name: cray-oauth2-proxies
     source: csm-algol60
-    version: 0.1.1
+    version: 0.1.2
     namespace: services


### PR DESCRIPTION
## Summary and Scope

Updating image in oauth2-proxy to address High/Critical CVE in container

## Issues and Related PRs

* Resolves [CASMINST-4080](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4080)
* Change will also be needed in [release/1.2](https://github.com/Cray-HPE/csm/pull/519)

## Testing

vshasta

### Tested on:

  * Virtual Shasta

### Test description:

Deployed this new version and made sure I could get to grafana through oauth2-proxy.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
