### PR TITLE
CASMINST-4085: use updated image path for cray-externaldns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-externaldns to use updated image path (CASMINST-4085)
 - Update cray-ceph-csi-rbd to support rolling upgrade strategy.  CASMINST-3857
 - Update cray-ceph-csi-cephfs to support rolling upgrade strategy.  CASMINST-3857
 - Update cfs-api to 1.10.1 to add api validation and remove v1 api (CASMCMS-7806)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -177,7 +177,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.4.0
+    version: 1.4.1
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Use the updated image path for cray-externaldns to be consistent with other images.

## Issues and Related PRs

* Resolves [CASMINST-4085]
* Change will also be needed in `main`

## Testing

### Tested on:

  * `mug`

### Test description:

Upgraded the external-dns chart and restarted cray-dns-powerdns and cray-powerdns-manager deployments, and verified that no errors in pod logs and powerdns records are correct:

ncn-m001:~/bquan # kubectl -n services exec -it cray-dns-powerdns-84dd665566-qd8r8 -- sh -c 'pdnsutil list-zone nmn.mug.dev.cray.com' | head
Defaulting container name to cray-dns-powerdns.
Use 'kubectl describe pod/cray-dns-powerdns-84dd665566-qd8r8 -n services' to see all of the containers in this pod.
$ORIGIN .
kubeapi-vip.nmn.mug.dev.cray.com 3600 IN A 10.252.1.2
ncn-m001.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s1b0n0.nmn.mug.dev.cray.com.
ncn-m001-nmn.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s1b0n0.nmn.mug.dev.cray.com.
ncn-m002.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s3b0n0.nmn.mug.dev.cray.com.
ncn-m002-nmn.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s3b0n0.nmn.mug.dev.cray.com.
ncn-m003.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s5b0n0.nmn.mug.dev.cray.com.
ncn-m003-nmn.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s5b0n0.nmn.mug.dev.cray.com.
ncn-s001.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s13b0n0.nmn.mug.dev.cray.com.
ncn-s001-nmn.nmn.mug.dev.cray.com 3600 IN CNAME x3000c0s13b0n0.nmn.mug.dev.cray.com.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. The same image is used, the PR only changes the image path where we put the externaldns image.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

