### PR TITLE
CASMINST-4081 Update Gatekeeper's curlimage.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -21,7 +21,7 @@ spec:
     namespace: loftsman
   - name: gatekeeper
     source: csm-algol60
-    version: 1.5.1
+    version: 1.5.2
     namespace: gatekeeper-system
     timeout: 20m
     values:


### PR DESCRIPTION
## Summary and Scope

Update to the latest OPA gatekeeper chart to resolve CVEs:
https://github.com/Cray-HPE/cray-opa-gatekeeper/pull/11