### PR TITLE
CASMINST-4082: use cray-spire version 2.3.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -131,10 +131,10 @@ artifactory.algol60.net/csm-docker/stable:
       - 3.2
 
     # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
-    # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21
+    # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L43
     # XXX but it is not extracted from any charts?
     registry.opensource.zalan.do/acid/pgbouncer:
-      - master-19
+      - master-21
 
     # XXX Spilo-12 is not properly extracted from cray-postgres-operator, see
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,5 +153,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.3.0
+    version: 2.3.1
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Use cray-spire chart 2.3.1 to pull in the latest pgbouncer image master-21 for CVE remediation.

## Issues and Related PRs

* Resolves [CASMINST-4082]
* Change will also be needed in `main`

## Testing

### Tested on:

  * `mug`

### Test description:

Deployed the new spire chart on mug, and verified that the latest pgbouncer image was pulled. The pod log shows no error after running for 15 minutes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. It's a minor patch version upgrade.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

