### PR TITLE
CASMPET-5268 Update trustedcerts-operator to 0.5.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
-    version: 0.1.1
+    version: 0.5.0
     namespace: pki-operator
   - name: cray-certmanager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the base image that trusted cert operator uses in order to resolve a number of CVEs.

## Issues and Related PRs

* Resolves [CASMPET-5268](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5268)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated snyk scans passed and that the updated image and helm chart worked correctly in vshasta.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y 
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

