### PR TITLE
Remove container image (openapi-generator-cli:v5.1.0)

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -79,10 +79,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v3.1
       - v3.7
 
-    # XXX Not sure where this is used?
-    docker.io/openapitools/openapi-generator-cli:
-      - v5.1.0
-
     # XXX Is this missing from cray-sysmgmt-health?
     docker.io/prom/pushgateway:
       - v0.8.0


### PR DESCRIPTION
## Summary and Scope

Removed vulnerable container image not used in distribution.

## Issues and Related PRs
* Resolves [CASMINST-4084](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4084)
* Change will also be needed in `release/1.2` (https://github.com/Cray-HPE/csm/pull/533)

## Testing

Not tested. Teams were polled via Slack and no one claimed a need to ship this image. CSM Docs was additionally searched with no reference indicated. Git blame also suggested the image may not be needed. 

## Risks and Mitigations

Risk if image is actually used, but not documented. 

## Pull Request Checklist

- [X] Target branch correct


