### PR TITLE
Update csm-testing/goss-servers to pull in CASMINST-4060, CASMINST-41…

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,7 +28,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - docs-csm-1.10.61-1.noarch
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
-    - csm-testing-1.6.47-1.noarch
+    - csm-testing-1.6.50-1.noarch
+    - goss-servers-1.6.50-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
     - loftsman-1.2.0-1.x86_64
     - ilorest-3.2.3-1.x86_64


### PR DESCRIPTION
Update csm-testing and/or goss-servers RPMs to pull in fixes for CASMINST-4060, CASMINST-4108, and CASMINST-4113.