### PR TITLE
Update csm-testing/goss-servers to pull in CASMINST-4060, CASMINST-41…

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.7-1.noarch
+    - csm-testing-1.12.8-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.7-1.noarch
+    - goss-servers-1.12.8-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
Update csm-testing and/or goss-servers RPMs to pull in fixes for CASMINST-4060, CASMINST-4108, and CASMINST-4113.