### PR TITLE
CASMPET-5352: update index to pull in v1.12.9 released version of csm…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080
 - Update cray-node-discovery for sec vulnerability
 - Update cray-externaldns to use updated image path (CASMINST-4085)

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.7-1.noarch
+    - csm-testing-1.12.9-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.7-1.noarch
+    - goss-servers-1.12.9-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.12.9 released version of csm-testing and goss-servers
Update changelog: - Released csm-testing v1.12.9 for recent test changes
This pulls in changes for:
* CASMPET-5352

### Summary and Scope
1.2 - CASMPET-5352: Add two new upgrade istio-ingressgateway goss tests in 1.2

Update the goss-k8s-istio-pods-running test that validates that the istio-ingressgateway pods are all running.
Add new goss-k8s-istio-pod-containers-running.yaml test that validates istio-ingressgateway containers are up.

Update ncn-upgrade-tests-worker.yaml and ncn-upgrade-tests-1.2.yaml suites to include both tests.

### Issues and Related PRs
CASMPET-5352

### Testing
Tested on drax with 1.2.0-alpha.72
