### PR TITLE
CASMTRIAGE-3036: Add zsh to NCNs & LiveCD

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/kubernetes-0.2.59.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/5.3.18-150300.59.43-default-0.2.59.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/initrd.img-0.2.59.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/kubernetes-0.2.60.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/5.3.18-150300.59.43-default-0.2.60.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/initrd.img-0.2.60.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/storage-ceph-0.2.59.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/5.3.18-150300.59.43-default-0.2.59.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/initrd.img-0.2.59.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/storage-ceph-0.2.60.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/5.3.18-150300.59.43-default-0.2.60.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/initrd.img-0.2.60.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

`zsh` is popular and people seem to like to switch to it.  `chsh`
lets you change your shell even if the desired shell is not
installed.

Install `zsh` to avoid getting locked out of nodes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-3036

## Testing

Tested on redbull