### PR TITLE
CASMPET-5362 Bump cray-kafka-operator to 1.1.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -201,7 +201,7 @@ spec:
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 1.0.0
+    version: 1.1.0
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update the strimzi operator to 0.27.1. This is the last version that supports Kafka 2.X

## Issues and Related PRs

* Resolves [CASMPET-5362](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5362)

## Testing

Validated the operator worked and that kafka clusters came up properly.

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why?  Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

