### PR TITLE
CASMPET-5363 Update kafka charts

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -406,8 +406,9 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.15.0-noJndiLookupClass
 
     quay.io/strimzi/kafka: # Used by cray-shared-kafka-zookeeper pods
-    - 0.15.0-kafka-2.2.1-noJSM-chainsaw
-    - 0.15.0-kafka-2.3.1-noJSM-chainsaw
+    - 0.15.0-noJSM-chainsaw-kafka-2.2.1
+    - 0.15.0-noJSM-chainsaw-kafka-2.3.0
+    - 0.15.0-noJSM-chainsaw-kafka-2.3.1
 
     update-uas:
     - 1.0.14

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -168,7 +168,7 @@ spec:
           docker_image: 'dtr.dev.cray.com/acid/spilo-12:1.6-p3-csm1.0'
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 0.4.2
+    version: 0.5.0
     namespace: operators
   - name: spire-intermediate
     source: csm
@@ -196,7 +196,7 @@ spec:
     namespace: gatekeeper-system
   - name: cray-shared-kafka
     source: csm-algol60
-    version: 0.7.0
+    version: 0.5.0
     namespace: services
   - name: cray-sts
     source: csm


### PR DESCRIPTION
## Summary and Scope

This updates the operator to spin up kafka using the noJSM-chainsaw-kafka images that resolve a number of log4j CVEs. 

The cray-shared-kafka chart is being reverted so that it doesn't override the image set via the operator.

## Issues and Related PRs

* Resolves [CASMPET-5363](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5363) 

## Testing

### Tested on:
  * Virtual Shasta

### Test description:

Validated the operator came up properly and that all the kafka pods were recreated with the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

