### PR TITLE
CASMINST-4142:  Update goss-servers and csm-testing RPMs to 1.12.10

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.9-1.noarch
+    - csm-testing-1.12.10-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.9-1.noarch
+    - goss-servers-1.12.10-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION

## Summary and Scope

A change was put in about a week ago to add `set -e` to the top of the livecd-preflight-check script.  When `/usr/bin/goss validate -f json` is run in that script to execute all of the goss tests in that suite, it will return non-zero if any of the tests fail.  The `set -e` causes the script to then stop execution immediately without giving any output indicating which tests failed.   We need to run `/usr/bin/goss validate -f json` without the `set -e`.

## Issues and Related PRs

* Resolves CASMINST-4142

## Testing

### Tested on:

  * `wasp`

### Test description:

I ran `/opt/cray/tests/install/livecd/automated/livecd-preflight-checks` on wasp with this fix and I was able to see the test results include the one test that was failing.



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

