### PR TITLE
CASMINST-1673:  Update goss-servers and csm-testing RPMs to 1.12.11

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.10-1.noarch
+    - csm-testing-1.12.11-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.10-1.noarch
+    - goss-servers-1.12.11-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION

## Summary and Scope

Running livecd-preflight-check always ended with the terminal session messed up requiring a reset.
I isolated the problem down to the goss-dhcp-router-ip-distinct test.   This test runs an `nmap` command for all of each of 5 interfaces specified in the variables file.  The problem happens when these tests run in parallel.

To fix this, I changed the test so it passes ALL interface name as a list into the test script and then the script does the work of running through each interface serially.   This avoids goss running each individual interface test in parallel.

## Issues and Related PRs

* Resolves CASMINST-1673

## Testing

### Tested on:

  * `wasp`

### Test description:

I ran the goss-dhcp-router-ip-distinct individually and ran the livecd-preflight-check suite.   I ran both cases such that the test succeeds and I also caused a failure condition to see the results when the test fails.
In all cases I verified that the terminal was not corrupted and did not need to be reset.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

