### PR TITLE
CASMINST-4145 - update csm-config to resolve CVE vulnerabilities.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,7 +118,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.19
+    version: 1.9.21
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
We needed to update the version of alpine that cf-gitea-import was using to resolve CVE vulnerabilities. This rebuild pulls in the new base image.

Code PR's:
https://github.com/Cray-HPE/csm-config/pull/45
https://github.com/Cray-HPE/cf-gitea-import/pull/26

## Issues and Related PRs
* Resolves [CASMINST-4145](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4145)

## Testing
### Tested on:
  * `Drax`
  * Local development environment
  * Virtual Shasta

### Test description:

After the new image was built, I used snyk to insure the updated image was free of vulnerabilities. We installed the new image on Drax and insured that the gitea import worked correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as it just updates the alpine base image that our container is based on. There are no changes to our code or functionality.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

