### PR TITLE
Add check during install.sh to ensure etcd clusters have three members

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,19 @@ deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
 
+# Ensure etcd clusters have three running members before proceeding
+for cluster in $(kubectl get etcd -n services | grep -v NAME | awk '{print $1}')
+do
+  size=$(kubectl get etcd -n services $cluster -o json | jq '.status.size')
+  if [ $size -ne 3 ]; then
+    echo >&2 "ERROR: etcd cluster: $cluster does not have three running members."
+    echo >&2 "       This must be addressed prior to continuing with the install."
+    exit 1
+  else
+    echo "validated etcd cluster: $cluster has three running members..."
+  fi
+done
+
 set +x
 cat >&2 <<EOF
 + CSM applications and services deployed


### PR DESCRIPTION
## Summary and Scope

Add step to ensure etcd cluster have three healthy members before proceeding with install

## Issues and Related PRs

* Resolves [CASMINST-4136](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4136)

## Testing

Tested script changes:

```
ncn-m002:~/bklein # ./foo.sh
validated etcd cluster: cray-bos-etcd has three running members...
validated etcd cluster: cray-bss-etcd has three running members...
validated etcd cluster: cray-crus-etcd has three running members...
validated etcd cluster: cray-externaldns-etcd has three running members...
validated etcd cluster: cray-fas-etcd has three running members...
validated etcd cluster: cray-hbtd-etcd has three running members...
validated etcd cluster: cray-hmnfd-etcd has three running members...
validated etcd cluster: cray-reds-etcd has three running members...
validated etcd cluster: cray-uas-mgr-etcd has three running members...
```

### Tested on:

  * `fanta`

### Test description:

Ran the new code in success/error case

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

