### PR TITLE
CASMINST-3930 - Update WLM network attachment definitions to use new CSM 1.2 naming convention

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -494,12 +494,14 @@ spec:
         macvlan:
           subnet: '{{ wlm.macvlansetup.nmn_supernet }}'
           routes: '{{ wlm.macvlansetup.routes }}'
+          master: '{{ wlm.macvlansetup.nmn_vlan }}'
       cray-slurmctld:
         clusterName: '{{ wlm.cluster_name }}'
         macvlan:
           ip: '{{ wlm.wlmstaticips.slurmctld }}'
           subnet: '{{ wlm.macvlansetup.nmn_supernet }}'
           routes: '{{ wlm.macvlansetup.routes }}'
+          master: '{{ wlm.macvlansetup.nmn_vlan }}'
       slurm-config:
         cluster_name: '{{ wlm.cluster_name }}'
         slurmctld_ip: '{{ wlm.wlmstaticips.slurmctld }}'
@@ -702,6 +704,7 @@ spec:
         macvlan:
           subnet: '{{ wlm.macvlansetup.nmn_supernet }}'
           routes: '{{ wlm.macvlansetup.routes }}'
+          master: '{{ wlm.macvlansetup.nmn_vlan }}'
         #
         # Node label(s) take the form:
         #


### PR DESCRIPTION
## Summary and Scope

CSM 1.2 changed how network interfaces are named on the NCNs e.g. `vlan002` -> `bond0.nmn0`

## Issues and Related PRs

* Resolves [CASMINST-3930](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3930)
* Upgrade story will be addressed in [CASMINST-3927](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3927)

## Testing

### Tested on:

 * `hela`
  * Local development environment

### Test description:

<UPDATE ME> To be tested on the next install of hela.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable