### PR TITLE
Bump the cray-grafterm image as part of CASMINST-4144

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -39,7 +39,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-ims-load-artifacts:
       - 1.3.59
     cray-grafterm:
-      - 1.0.1
+      - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to
     # XXX facilitate install/upgrade?
     hms-pytest:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.3
+    version: 0.21.4
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope
Upgrade the golang base os version in the cray-grafterm image to fix the vulnerability issue.
To resolve this we are using the golang:1.17.3-alpine3.15 version for the grafterm.

## Issues and Related PRs
https://github.com/Cray-HPE/container-images/pull/406 (merged)
https://github.com/Cray-HPE/cray-grafterm/pull/3 (merged)
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/56 (merged)

* Resolves 
 [CASMINST-4144](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4144)

* Future work required:
None

* Documentation changes required
None

* Merge with/before/after
None

## Testing
Done

### Tested on:
gamora

### Test description:
Able to get the Grafterm graphs

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
