### PR TITLE
Remove centos:7 from docker index

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -70,10 +70,6 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/istio/kubectl:
       - 1.5.4
 
-    # XXX Not sure where this is used, but should be deprecated
-    docker.io/library/centos:
-      - 7
-
     # Openjdk is used during install procedures to generate keystores
     docker.io/library/openjdk:
       - 11-jre-slim


### PR DESCRIPTION
## Summary and Scope

Remove vulnerable and unclaimed centos:7 image. 

Image is not present on main.

## Issues and Related PRs

* Resolves [CASMINST-4169](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4169)
