### PR TITLE
Casmmon 117 target down alert in prometheus for the DNS unbound exporter

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.3 # update platform.yaml cray-precache-images with this
+    version: 0.7.4 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.3
+        appVersion: 0.7.4
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -42,7 +42,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.1
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.3
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope
target down alert in prometheus for the DNS unbound exporter

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves 
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-117

https://github.com/Cray-HPE/cray-dns-unbound/pull/46

## Testing

Tested on Mug

![image](https://user-images.githubusercontent.com/22464568/157481249-92f55130-0601-447d-989b-545293f14ae6.png)

