### PR TITLE
Change loadbalancer test to use sls bican toggle

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -49,9 +49,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.11-1.noarch
+    - csm-testing-1.12.13-1.noarch
     - docs-csm-1.13.2-1.noarch
-    - goss-servers-1.12.11-1.noarch
+    - goss-servers-1.12.13-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Use sls bican toggle, and exclude appropriate load balancers depending on default route

## Issues and Related PRs

* Resolves [CASMINST-4197](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4197)

## Testing

drax:

```
ncn-m002:~/bklein # cray sls networks describe BICAN --format json | jq '.ExtraProperties.SystemDefaultRoute'
"CAN"
ncn-m002:~/bklein # ./check_k8s_loadbalancers.sh -p
INFO: CHN is not configured, excluding istio-ingressgateway-chn and cray-oauth2-proxies-customer-high-speed-ingress LoadBalancers

NAMESPACE        LOADBALANCER                        IPADDRESS       STATUS
ceph-rgw         cray-s3                             10.102.3.65     PASS
istio-system     istio-ingressgateway                10.92.100.71    PASS
istio-system     istio-ingressgateway-can            10.102.3.160    PASS
istio-system     istio-ingressgateway-cmn            10.102.3.66     PASS
istio-system     istio-ingressgateway-hmn            10.94.100.71    PASS
istio-system     istio-ingressgateway-local          10.92.100.81    PASS
services         cray-dhcp-kea-tcp-hmn               10.94.100.222   PASS
services         cray-dhcp-kea-tcp-nmn               10.92.100.222   PASS
services         cray-dhcp-kea-udp-hmn               10.94.100.222   PASS
services         cray-dhcp-kea-udp-nmn               10.92.100.222   PASS
services         cray-dns-powerdns-cmn-tcp           10.102.3.61     PASS
services         cray-dns-powerdns-cmn-udp           10.102.3.61     PASS
services         cray-dns-powerdns-hmn-tcp           10.94.100.85    PASS
services         cray-dns-powerdns-hmn-udp           10.94.100.85    PASS
services         cray-dns-powerdns-nmn-tcp           10.92.100.85    PASS
services         cray-dns-powerdns-nmn-udp           10.92.100.85    PASS
services         cray-dns-unbound-tcp-hmn            10.94.100.225   PASS
services         cray-dns-unbound-tcp-nmn            10.92.100.225   PASS
services         cray-dns-unbound-udp-hmn            10.94.100.225   PASS
services         cray-dns-unbound-udp-nmn            10.92.100.225   PASS
services         cray-oauth2-proxies-customer-access-ingress 10.102.3.161    PASS
services         cray-oauth2-proxies-customer-management-ingress 10.102.3.64     PASS
services         cray-tftp                           10.92.100.60    PASS
services         cray-tftp-hmn                       10.94.100.60    PASS
spire            spire-lb                            10.92.100.82    PASS
```

hela:

```
ncn-m003:~/bklein # cray sls networks describe BICAN --format json | jq '.ExtraProperties.SystemDefaultRoute'
"CHN"
ncn-m003:~/bklein # ./check_k8s_loadbalancers.sh -p
INFO: CHN is configured, excluding stio-ingressgateway-can and cray-oauth2-proxies-customer-access-ingress LoadBalancers

NAMESPACE        LOADBALANCER                        IPADDRESS       STATUS
ceph-rgw         cray-s3                             10.101.8.130    PASS
istio-system     istio-ingressgateway                10.92.100.71    PASS
istio-system     istio-ingressgateway-chn            10.101.11.128   PASS
istio-system     istio-ingressgateway-cmn            10.101.8.129    PASS
istio-system     istio-ingressgateway-hmn            10.94.100.71    PASS
istio-system     istio-ingressgateway-local          10.92.100.81    PASS
services         cray-dhcp-kea-tcp-hmn               10.94.100.222   PASS
services         cray-dhcp-kea-tcp-nmn               10.92.100.222   PASS
services         cray-dhcp-kea-udp-hmn               10.94.100.222   PASS
services         cray-dhcp-kea-udp-nmn               10.92.100.222   PASS
services         cray-dns-powerdns-cmn-tcp           10.101.8.113    PASS
services         cray-dns-powerdns-cmn-udp           10.101.8.113    PASS
services         cray-dns-powerdns-hmn-tcp           10.94.100.85    PASS
services         cray-dns-powerdns-hmn-udp           10.94.100.85    PASS
services         cray-dns-powerdns-nmn-tcp           10.92.100.85    PASS
services         cray-dns-powerdns-nmn-udp           10.92.100.85    PASS
services         cray-dns-unbound-tcp-hmn            10.94.100.225   PASS
services         cray-dns-unbound-tcp-nmn            10.92.100.225   PASS
services         cray-dns-unbound-udp-hmn            10.94.100.225   PASS
services         cray-dns-unbound-udp-nmn            10.92.100.225   PASS
services         cray-oauth2-proxies-customer-high-speed-ingress 10.101.11.129   PASS
services         cray-oauth2-proxies-customer-management-ingress 10.101.8.128    PASS
services         cray-tftp                           10.92.100.60    PASS
services         cray-tftp-hmn                       10.94.100.60    PASS
spire            spire-lb                            10.92.100.82    PASS
```

### Tested on:

  * `drax`
  *  `hela`

### Test description:

Ran the updated script on CAN/CHN configured systems.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
