### PR TITLE
CASMINST-3979 Disable external spire-jwks access

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -137,7 +137,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.9.0
+    version: 1.10.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,5 +153,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.3.1
+    version: 2.4.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Disabled exposing spire-jwks externally and switched the jwks endpoint opa uses to the internal URL.

## Issues and Related PRs

* Resolves [CASMINST-3979](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3979) 

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that spire tokens kept working after the upgrade and failed if the spire-jwks service was scaled down to 0.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

If cray-opa gets downgraded to 1.9.0, spire also needs to be downgraded to 2.3.1 in order to create the spire-jwks VirtualService.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

