### PR TITLE
Change nexus load script to not specify overlay now that podman config does

### DIFF
--- a/hack/load-container-image.sh
+++ b/hack/load-container-image.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 [[ $# -eq 1 ]] || {
 	echo >&2 "usage: ${0##*/} IMAGE"
@@ -36,7 +57,7 @@ if command -v podman >/dev/null 2>&1; then
 	mounts="-v ${graphroot}:/var/lib/containers/storage"
 	transport="containers-storage"
 	run_opts="--rm --network none --privileged --ulimit=host"
-	skopeo_dest="${transport}:[${graphdrivername}@${graphroot}+${runroot}]${image}"
+	skopeo_dest="${transport}:${image}"
 
 elif command -v docker >/dev/null 2>&1; then
 


### PR DESCRIPTION
## Summary and Scope

Now that podman config is configured for overlay out of the box in 1.2, the load-container-images.sh script needs to change to not specify the overlay driver.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3092](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3092)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`

### Test description:

Ran the prerequisites.sh script with this change, and it worked.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

