### PR TITLE
Fixes for Olympus power capping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed CFS-Batcher bug that was causing extra sessions to be launched
 - Updated MEDS will now only make POST and PATCH a EthernetInterface in HSM when there is actually something to change.
 - Fixed RTS to have the correct pod security policies for the RTS Loader Job.
+- Updated power capping control for Olympus nodes
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -21,7 +21,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 2.0.4
+    version: 2.0.5
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Olympus power capping is disabled by default. When power cap requests are sent to Olympus nodes include enabling the power capping. Also had to change how power capping is disabled for Olympus nodes.

### Issues and Related PRs

* Resolves [CASMHMS-5399](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5399)

### Testing

Tested on:

* `hela`

Were the install/upgrade based validation checks/tests run? no
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Power capped and verified settings with CAPMC. Disabled power capping and verified settings via curl.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? Y

No known issues.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

