### PR TITLE
Update csm-testing/goss-servers to v1.6.51

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,8 +28,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - docs-csm-1.10.61-1.noarch
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
-    - csm-testing-1.6.50-1.noarch
-    - goss-servers-1.6.50-1.noarch
+    - csm-testing-1.6.51-1.noarch
+    - goss-servers-1.6.51-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
     - loftsman-1.2.0-1.x86_64
     - ilorest-3.2.3-1.x86_64


### PR DESCRIPTION
Pull in:
* Move interface MAC check into script file
* CASMINST-4157: Increase some test timeouts to avoid false failures
* Appease the license checker
* Remove needless comment from livecd preflight script
* Replace hard-coded paths with GOSS_BASE variable; protect string variables with quotes
* Make script hash-bang lines consistent
* Correct grep command regular expressions
* CASMINST-4157: Remove unnecessary -it arguments to kubectl exec commands in scripts