### PR TITLE
Casminst 3955

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,5 @@
 @Library('csm-shared-library') _
-
+def credentialsId = 'artifactory-algol60'
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -81,14 +81,16 @@ pipeline {
                         SNYK_TOKEN = credentials('SNYK_TOKEN')
                     }
                     steps {
-                        script {
-                            slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
-                            sh """
-                                . build/.env/bin/activate
-                                make clean
-                                rm -fr dist
-                                ./release.sh
-                            """
+                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                            script {
+                                slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
+                                sh """
+                                    . build/.env/bin/activate
+                                    make clean
+                                    rm -fr dist
+                                    ./release.sh
+                                """
+                            }
                         }
                     }
                     post {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -81,9 +81,9 @@ pipeline {
                         SNYK_TOKEN = credentials('SNYK_TOKEN')
                     }
                     steps {
-                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-                            script {
-                                slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
+                        script {
+                            slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
+                            withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
                                 sh """
                                     . build/.env/bin/activate
                                     make clean
@@ -97,11 +97,22 @@ pipeline {
                         success {
                             script {
                                 slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Built release distribution")
+                                sh """
+                                if [[ -f "/tmp/repo_creds.json" ]]; then
+                                    rm /tmp/repo_creds.json
+                                fi
+                                """
                             }
+                            
                         }
                         unsuccessful {
                             script {
                                 slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: release.sh did not exit successfully")
+                                sh """
+                                if [[ -f "/tmp/repo_creds.json" ]]; then
+                                    rm /tmp/repo_creds.json
+                                fi
+                                """
                             }
                         }
                     }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -122,22 +122,12 @@ pipeline {
                         success {
                             script {
                                 slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Built release distribution")
-                                sh """
-                                if [[ -f "/tmp/repo_creds.json" ]]; then
-                                    rm /tmp/repo_creds.json
-                                fi
-                                """
                             }
                             
                         }
                         unsuccessful {
                             script {
                                 slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: release.sh did not exit successfully")
-                                sh """
-                                if [[ -f "/tmp/repo_creds.json" ]]; then
-                                    rm /tmp/repo_creds.json
-                                fi
-                                """
                             }
                         }
                     }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,3 +1,28 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 @Library('csm-shared-library') _
 def credentialsId = 'artifactory-algol60'
 pipeline {

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -12,15 +12,17 @@ set -ex
 # Note that the kubernetes/el7/x86_64 repo is included as it is implicitly
 # added by the ncn-k8s image.
 
-#changes to pass the repo credentials environment variables to the container that runs rpm-index
+#pass the repo credentials environment variables to the container that runs rpm-index
 REPO_FILENAME=${REPOCREDSFILENAME:-}
 REPO_FILENAME_PATH=${REPOCREDSPATH:-}
-REPO_CREDS_OPTIONS=""
+REPO_CREDS_DOCKER_OPTIONS=""
+REPO_CREDS_RPMINDEX_OPTIONS=""
 if [ ! -z "$REPO_FILENAME" ] && [ ! -z "$REPO_FILENAME_PATH" ]; then
-    REPO_CREDS_OPTIONS="--env REPOCREDSFILENAME=${REPO_FILENAME} --mount type=bind,source=${REPO_FILENAME_PATH},destination=/repo_creds_data"
+    REPO_CREDS_DOCKER_OPTIONS="--mount type=bind,source=${REPO_FILENAME_PATH},destination=/repo_creds_data"
+    REPO_CREDS_RPMINDEX_OPTIONS="-c /repo_creds_data/${REPO_FILENAME}"
 fi
 
-docker run ${REPO_CREDS_OPTIONS} --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.12.0 rpm-index -v \
+docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.12.0 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2021 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -ex
 
 # The repo options to rpm-index are generated from the CSM/csm-rpms repo as

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -20,7 +20,7 @@ if [ ! -z "$REPO_FILENAME" ] && [ ! -z "$REPO_FILENAME_PATH" ]; then
     REPO_CREDS_OPTIONS="--env REPOCREDSFILENAME=${REPO_FILENAME} --mount type=bind,source=${REPO_FILENAME_PATH},destination=/repo_creds_data"
 fi
 
-docker run ${REPO_CREDS_OPTIONS} --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0 rpm-index -v \
+docker run ${REPO_CREDS_OPTIONS} --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.12.0 rpm-index -v \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -12,7 +12,15 @@ set -ex
 # Note that the kubernetes/el7/x86_64 repo is included as it is implicitly
 # added by the ncn-k8s image.
 
-docker run --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0 rpm-index -v \
+#changes to pass the repo credentials environment variables to the container that runs rpm-index
+REPO_FILENAME=${REPOCREDSFILENAME:-}
+REPO_FILENAME_PATH=${REPOCREDSPATH:-}
+REPO_CREDS_OPTIONS=""
+if [ ! -z "$REPO_FILENAME" ] && [ ! -z "$REPO_FILENAME_PATH" ]; then
+    REPO_CREDS_OPTIONS="--env REPOCREDSFILENAME=${REPO_FILENAME} --mount type=bind,source=${REPO_FILENAME_PATH},destination=/repo_creds_data"
+fi
+
+docker run ${REPO_CREDS_OPTIONS} --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0 rpm-index -v \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \

--- a/hack/verify-helm-index.sh
+++ b/hack/verify-helm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0"
+PACKAGING_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.12.0"
 
 set -o errexit
 set -o pipefail

--- a/release.sh
+++ b/release.sh
@@ -62,7 +62,7 @@ if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
     export REPOCREDSPATH="/tmp/"
     export REPOCREDSFILENAME="repo_creds.json"
     export REPOCREDSFULL=$REPOCREDSPATH$REPOCREDSFILENAME
-    jq --null-input   --arg url "sles-mirror" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
+    jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/sles-mirror/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
 fi
 
 # Load and verify assets

--- a/release.sh
+++ b/release.sh
@@ -63,6 +63,7 @@ if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
     export REPOCREDSFILENAME="repo_creds.json"
     export REPOCREDSFULL=$REPOCREDSPATH$REPOCREDSFILENAME
     jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/sles-mirror/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
+    trap "rm -f '${REPOCREDSFULL}'" EXIT
 fi
 
 # Load and verify assets

--- a/release.sh
+++ b/release.sh
@@ -57,6 +57,14 @@ RELEASE_VERSION_BUILDMETADATA="$(echo "$RELEASE_VERSION" | perl -pe "s/${semver_
 # Setup
 #
 
+#serialize an object containing repo credentials to disk, and put the path to it in an environment variable
+if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
+    export REPOCREDSPATH="/tmp/"
+    export REPOCREDSFILENAME="repo_creds.json"
+    export REPOCREDSFULL=$REPOCREDSPATH$REPOCREDSFILENAME
+    jq --null-input   --arg url "sles-mirror" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
+fi
+
 # Load and verify assets
 source "${ROOTDIR}/assets.sh"
 


### PR DESCRIPTION
These changes look for private repository credentials present in the Jenkins pipeline environment, and make them available for use in the rpm-index and rpm-sync processes when needing to access private repository resources during CSM packaging.

RELATED PRs: 
https://github.hpe.com/hpe/hpc-shastarelm-packaging-tools/pull/2

https://github.hpe.com/hpe/hpc-shastarelm-release/pull/9/files 