### PR TITLE
CASMHMS-4974 Add support for HSM /v2/locks/status 'GET' operation for listing all locks

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.0.6
+    version: 2.0.7
     namespace: services
     values:
       cray-service:

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -4,4 +4,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.41.11-1.x86_64
+    - craycli-0.48.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -45,7 +45,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-cmstools-crayctldeploy-1.2.116-1.x86_64
     - cray-switchboard-1.2.3-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.41.11-1.x86_64
+    - craycli-0.48.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
### Summary and Scope

This change adds support for the 'GET' operation to the HSM /v2/locks/status API which will list the lock status of all components in HSM. Optional query parameters may be supplied to filter the results based on component Type, State, Role, SubRole, and Locked, Reserved, ReservationDisabled status. Several corrections to the HSM Swagger specification and a few minor CT test updates are also included.

### Issues and Related PRs

* Resolves CASMHMS-4974.

### Testing

This change was tested by:

- Implementing unit tests for the new /v2/locks/status 'GET' operation
- Spinning up a local instance of HSM in a docker-compose environment, manually populating it with components and setting locks, and executing calls with various query parameters specified
- Upgrading the running HSM service on Mug using Helm to deploy the new version and testing the new functionality using the HSM data from a production environment
- Verifying that the HSM CT smoke and functional tests continued to pass

Was a fresh Install tested? Partially, via a fresh local instance of HSM
Was an Upgrade tested? Y, using Helm
Was a Downgrade tested? Y, using Helm

### Risks and Mitigations

Fairly low risk since this change adds new functionality. Changes that could impact existing HSM /locks/status APIs due to the use of shared functions are minimal and were verified by confirming that their unit tests continued to pass.