### PR TITLE
Update csm-config to 1.9.24 for CASMCMS-7890

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update csm-config v1.9.24 for CASMCMS-7890
 - Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080
 - Update cray-node-discovery for sec vulnerability

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,7 +118,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.21
+    version: 1.9.24
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Update csm-config to bring in new cf-gitea-import (v1.6.0) image which fixes an issue where a new csm-config chart is installed, but with no material changes still updates git commit IDs in Gitea.

## Issues and Related PRs

* Resolves CASMCMS-7890

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

See https://github.com/Cray-HPE/cf-gitea-import/pull/34 and https://github.com/Cray-HPE/csm-config/pull/48 for testing.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

