### PR TITLE
FAS to chart 2.1.1 FAS version 1.19.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -25,7 +25,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.0.4
+    version: 2.1.1
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60


### PR DESCRIPTION
Update FAS to chart version 2.1.1 (FAS version 1.19.0) for CASMHMS-5368