### PR TITLE
CASMCMS-7901: Update gitea chart for tls upgrade issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890
 - Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.3.9
+    version: 2.3.11
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

Enables tls in the gitea chart for postgres to fix an upgrade issue from 1.0 to 1.2

## Issues and Related PRs

* Resolves CASMCMS-7901

## Testing

### Tested on:

  * Hela

### Test description:

Deployed the chart and validated the postgres cluster was up and running

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

