### PR TITLE
CASMCMS-7900 - fix for postgres upgrade issue.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -90,7 +90,7 @@ spec:
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.3.1
+    version: 1.3.3
     namespace: services
   - name: cray-crus
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The certificate handling of the postgres pods was not working on an upgrade from csm-1.0.x -> csm-1.2. This fixes the chart setting to allow the upgraded pod to read the needed k8s secrets during the upgrade operation.

See https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5404 for details.

Code PR:
https://github.com/Cray-HPE/console-data/pull/18

## Issues and Related PRs
* Resolves [CASMCMS-7900](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7900)

## Testing
### Tested on:

  * `Drax`

### Test description:

Drax has csm-1.0.10 installed. I used helm to upgrade to the new version without issues. I then used helm rollback to revert to the original version.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk change as it is following the suggestion of the PET team after they investigated the upgrade issue. There is no code change for this, just the helm chart update.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

