### PR TITLE
Move loadbalancer test to suite after pit reboot

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.16-1.noarch
+    - csm-testing-1.12.17-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.16-1.noarch
+    - goss-servers-1.12.17-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Call load balancer test after pit is rebooted, and services are fully deployed.

## Issues and Related PRs

* Resolves [CASMINST-4250](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4250)

## Testing

N/A -- no change to test, just moving to different suite

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
