### PR TITLE
fixes for CASMTRIAGE-3111-csm-1.2 - Duplicate DNS entries for NCN xnames and …

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,7 +41,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.2 # update platform.yaml cray-precache-images with this
+    version: 0.10.3 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -41,7 +41,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- CASMTRIAGE-3111 - Duplicate DNS entries for NCN xnames
- CASMNET-1128 - dhcp-helper:/srv/kea/dhcp-helper.py:61: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

yes 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

- CASMTRIAGE-3111
- CASMNET-1128(one line change that cleans up logs)
## Testing

_List the environments in which these changes were tested._

### Tested on:
hela

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- tested bad ip getting into SMD
- tested ncn interface getting and dhcp ip and blocking the update to smd
- tested both scenarios above happening at the sametime

```bash
ncn-m001:~ # kubectl exec -it -n services cray-dhcp-kea-76f89448f-d6ffp /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulting container name to cray-dhcp-kea.
Use 'kubectl describe pod/cray-dhcp-kea-76f89448f-d6ffp -n services' to see all of the containers in this pod.
bash-5.1$ cd /tmp
bash-5.1$ vi dhcp-helper.py 
bash-5.1$ ./dhcp-helper.py 
bash-5.1$ curl -X PATCH 'http://cray-smd/hsm/v1/Inventory/EthernetInterfaces/9440c95f9e86' -H 'Content-Type: application/json' --data-raw '{"MACAddress": "94:40:c9:5f:9e:86","ComponentID": "x3000c0s10b0n0","IPAddress": "10.1.1.15"}'
{"ID":"9440c95f9e86","Description":"Bond0 - vlan002","MACAddress":"94:40:c9:5f:9e:86","IPAddress":"10.1.1.15","LastUpdate":"2022-03-17T16:07:01.087369Z","ComponentID":"x3000c0s10b0n0","Type":"Node"}
bash-5.1$ 
bash-5.1$ 
bash-5.1$ ./dhcp-helper.py 
2022-03-17 16:07:04,420 - __main__ - WARNING - Found an IP in SMD EthernetInterfaces that should not be there.MAC:94:40:c9:5f:9e:86, IP: 10.1.1.15
2022-03-17 16:07:04,421 - __main__ - WARNING - Removing {'ID': '9440c95f9e86', 'Description': 'Bond0 - vlan002', 'MACAddress': '94:40:c9:5f:9e:86', 'LastUpdate': '2022-03-17T16:07:01.087369Z', 'ComponentID': 'x3000c0s10b0n0', 'Type': 'Node', 'IPAddresses': [{'IPAddress': '10.1.1.15'}]} from in memory copy of SMD Ethernet Interfaces
bash-5.1$ ./dhcp-helper.py 
bash-5.1$ curl -X POST -H "Content-Type: application/json" -d '{"command": "lease4-add", "service": [ "dhcp4" ], "arguments": {"hw-address": "94:40:c9:5f:9e:86", "ip-address": "10.1.1.15", "force-create": true }}' cray-dhcp-kea-api:8000
[ { "result": 0, "text": "Lease for address 10.1.1.15, subnet-id 1 added." } ]bash-5.1$ 
bash-5.1$ 
bash-5.1$ ./dhcp-helper.py 
2022-03-17 16:07:25,689 - __main__ - WARNING - Interface 94:40:c9:5f:9e:86 10.1.1.15 via dynamic dhcp reservation and was on interface blacklist Will remove lease from kea
bash-5.1$ curl -X PATCH 'http://cray-smd/hsm/v1/Inventory/EthernetInterfaces/9440c95f9e86' -H 'Content-Type: application/json' --data-raw '{"MACAddress": "94:40:c9:5f:9e:86","ComponentID": "x3000c0s10b0n0","IPAddress": "10.1.1.15"}'
{"ID":"9440c95f9e86","Description":"Bond0 - vlan002","MACAddress":"94:40:c9:5f:9e:86","IPAddress":"10.1.1.15","LastUpdate":"2022-03-17T16:07:39.335778Z","ComponentID":"x3000c0s10b0n0","Type":"Node"}
bash-5.1$ curl -X POST -H "Content-Type: application/json" -d '{"command": "lease4-add", "service": [ "dhcp4" ], "arguments": {"hw-address": "94:40:c9:5f:9e:86", "ip-address": "10.1.1.15", "force-create": true }}' cray-dhcp-kea-api:8000
[ { "result": 0, "text": "Lease for address 10.1.1.15, subnet-id 1 added." } ]bash-5.1$ 
bash-5.1$ 
bash-5.1$ 
bash-5.1$ 
bash-5.1$ ./dhcp-helper.py 
2022-03-17 16:07:48,460 - __main__ - WARNING - Found an IP in SMD EthernetInterfaces that should not be there.MAC:94:40:c9:5f:9e:86, IP: 10.1.1.15
2022-03-17 16:07:48,461 - __main__ - WARNING - Removing {'ID': '9440c95f9e86', 'Description': 'Bond0 - vlan002', 'MACAddress': '94:40:c9:5f:9e:86', 'LastUpdate': '2022-03-17T16:07:39.335778Z', 'ComponentID': 'x3000c0s10b0n0', 'Type': 'Node', 'IPAddresses': [{'IPAddress': '10.1.1.15'}]} from in memory copy of SMD Ethernet Interfaces
bash-5.1$ ./dhcp-helper.py 
2022-03-17 16:07:53,580 - __main__ - WARNING - Interface 94:40:c9:5f:9e:86 10.1.1.15 via dynamic dhcp reservation and was on interface blacklist Will remove lease from kea
bash-5.1$ ./dhcp-helper.py 
bash-5.1$ 
bash-5.1$ 
bash-5.1$ 
bash-5.1$ curl http://cray-smd/hsm/v1/Inventory/EthernetInterfaces/9440c95f9e86|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   190  100   190    0     0  44012      0 --:--:-- --:--:-- --:--:-- 47500
{
  "ID": "9440c95f9e86",
  "Description": "Bond0 - vlan002",
  "MACAddress": "94:40:c9:5f:9e:86",
  "IPAddress": "",
  "LastUpdate": "2022-03-17T16:07:48.452194Z",
  "ComponentID": "x3000c0s10b0n0",
  "Type": "Node"
}
bash-5.1$ ncn-m001:~ #

```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?n
- Were continuous integration tests run? If not, why?n
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

- none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

