### PR TITLE
CASMTRIAGE-3123 - Update externaldns domain filters to only permit subdomain updates

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -279,13 +279,7 @@ spec:
       cray-externaldns:
         external-dns:
           domainFilters:
-            - 'cmn.{{ network.dns.external }}'
-            - 'can.{{ network.dns.external }}'
-            - 'chn.{{ network.dns.external }}'
-            - 'nmn.{{ network.dns.external }}'
-            - 'hmn.{{ network.dns.external }}'
-            - 'nmnlb.{{ network.dns.external }}'
-            - 'hmnlb.{{ network.dns.external }}'
+            - '.{{ network.dns.external }}'
       cray-dns-unbound:
         domain_name: '{{ network.dns.external }}'
         forwardZones:


### PR DESCRIPTION
## Summary and Scope

It was found that the way externaldns domain filters were configured could result in records being created in the wrong zone (e.g. `cmn.hela.dev.cray.com` records could be created in the `hela.dev.cray.com` zone) if externaldns performed an update before powerdns-manager had completed its first pass and created all the zones.

Reconfigured externaldns to prohibit updates to the TLD.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3123](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3123)

## Testing

### Tested on:

  * `surtur`
  * `hela`

### Test description:

Redeployed cray-externaldns, cray-dns-powerdns, and cray-powerdns-manager on `surtur` and `hela` a number of times verifying the goss test passes as expected.
```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn /opt/cray/tests/install/ncn/scripts/monitoring_check.sh
PASS
```
## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable