### PR TITLE
CASMTRIAGE-3126 Update the cray-nexus chart to 0.10.1 and cray-nexus-setup image precache to 0.6.1

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.10.0
+    version: 0.10.1
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -55,7 +55,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.0
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
   - name: gatekeeper
     source: csm-algol60
     version: 1.5.2


### PR DESCRIPTION
## Summary and Scope

This change will update the cray-nexus chart to 0.10.1 and cray-nexus-setup image precache to 0.6.1

## Issues and Related PRs

* Merge after https://github.com/Cray-HPE/cray-nexus/pull/11


