### PR TITLE
Dynamically specify overlay in skopeo opts depending on podman config

### DIFF
--- a/hack/load-container-image.sh
+++ b/hack/load-container-image.sh
@@ -57,7 +57,13 @@ if command -v podman >/dev/null 2>&1; then
 	mounts="-v ${graphroot}:/var/lib/containers/storage"
 	transport="containers-storage"
 	run_opts="--rm --network none --privileged --ulimit=host"
-	skopeo_dest="${transport}:${image}"
+
+        fuse_exe=$(podman info -f json | jq -r ".store.graphOptions[].Executable")
+        if [ "$fuse_exe" == "/usr/bin/fuse-overlayfs" ]; then
+          skopeo_dest="${transport}:${image}"
+        else
+          skopeo_dest="${transport}:[${graphdrivername}@${graphroot}+${runroot}]${image}"
+        fi
 
 elif command -v docker >/dev/null 2>&1; then
 


### PR DESCRIPTION
## Summary and Scope

Change load image script to be more flexible to handle running on systems with and without mount program specified for overlay.

## Issues and Related PRs

* Resolves [CASMINST-4280](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4280)

## Testing

Tested both environments (vshasta and drax).

### Tested on:

  * `drax`

### Test description:

Tested both with and without mount program configured for podman, the options were set correctly in both contexts.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

