### PR TITLE
CASMPET-5374: adjust istio alert rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-sysmgmt-health v0.21.7 to adjust istio alert rules (CASMPET-5374)
 - Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890
 - Released csm-testing v1.12.9 for recent test changes

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.5
+    version: 0.21.7
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

The default istio alert rules have some unit errors (e.g., milliseconds vs seconds) and need adjustments in other cases. This PR will address false alarms caused by the default istio alert rules.

## Issues and Related PRs

* Resolves [CASMPET-5374]

## Testing

### Tested on:

  * `mug`

### Test description:

The istio alert rules were changed and verified on mug.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

