### PR TITLE
CASMINST-4261 - update cray-crus base image for security patches.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.9
+    version: 1.9.11
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
There is a CVE vulnerability in the base image. A rebuild of the image is required to pick up a patched base image.

Code PR:
https://github.com/Cray-HPE/cray-crus/pull/19

## Issues and Related PRs
* Resolves [CASMINST-4261](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4261)

## Testing
### Tested on:
  * Local development environment

### Test description:

Rebuilt the docker image and locally ran snyk to verify the vulnerability is resolved.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc) N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N - needs system with slurm installed - none present for testing
- Was downgrade tested? If not, why? N - needs system with slurm installed - none present for testing
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a very low risk change as it only forces a rebuild to pick up a patched base image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

