### PR TITLE
CASMINST-4265: Bump csm-testing and goss-servers to 1.12.19

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.17-1.noarch
+    - csm-testing-1.12.19-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.17-1.noarch
+    - goss-servers-1.12.19-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This adds the goss-switch-bgp-neighbor-aruba-or-mellanox.yaml test to ncn-upgrade-preflight-tests.yaml suite.  This allows us to check the BGP peering sessions before we attempt to boot nodes.

## Issues and Related PRs

* Resolves CASMINST-4265

## Testing

### Tested on:

  * `drax`

### Test description:

I manually added this test to the ncn-upgrade-preflight-tests.yaml suite and ran the suite as it is done in prerequisites.sh.   I verified that the test ran and checked the logs for the test in /opt/cray/tests/install/logs/bgp_neighbors_established.

```
GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable