### PR TITLE
CASMUSER-2720 Shared Broker UAI Credential Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Shared Broker UAI credentials: cray-uas-mgr v1.19.1, update-uas v1.4.0, switchboard v2.1.0
 - Released cray-sysmgmt-health v0.21.7 to adjust istio alert rules (CASMPET-5374)
 - Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -30,7 +30,7 @@ quay.io:
 artifactory.algol60.net/csm-docker/stable:
   images:
     # XXX update-uas v1.4.0 should include these
-    cray-uai-sles15sp2:
+    cray-uai-sles15sp3:
       - 1.4.0
     cray-uai-broker:
       - 1.4.0

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,11 +29,11 @@ quay.io:
 
 artifactory.algol60.net/csm-docker/stable:
   images:
-    # XXX update-uas v1.3.2 should include these
+    # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp2:
-      - 1.3.1
+      - 1.4.0
     cray-uai-broker:
-      - 1.3.1
+      - 1.4.0
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,11 +143,11 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.18.0
+    version: 1.19.1
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.3.3
+    version: 1.4.0
     namespace: services
 
   # Spire service

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -2,6 +2,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
-    - cray-switchboard-1.2.3-1.x86_64
+    - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.46.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
     - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
-    - cray-switchboard-1.2.3-1.x86_64
+    - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.46.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

This change releases the Shared Broker UAI Credential Storage feature implemented in:
- cray-uas-mgr v1.19.1
- update-uas v1.4.0 (and its related UAI images)
- switchboard v2.1.0
This change is a backwards compatible feature.

## Issues and Related PRs

* Resolves [CASMUSER-2720](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2720)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Broker UAIs were deployed on Virtual Shasta using all combinations of old and new Broker UAI image versions, cray-uas-mgr versions, and update-uas versions.  Backward compatibility (i.e. preserver old Broker UAI behavior) and new functionality were tested manually.  Unit tests were written to cover new UAS functionality and are run during builds.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? unit tests

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

