### PR TITLE
CASMINST-4142: Update csm-testing/goss-servers to v1.6.52

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,8 +28,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - docs-csm-1.10.61-1.noarch
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
-    - csm-testing-1.6.51-1.noarch
-    - goss-servers-1.6.51-1.noarch
+    - csm-testing-1.6.52-1.noarch
+    - goss-servers-1.6.52-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
     - loftsman-1.2.0-1.x86_64
     - ilorest-3.2.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

A change was put in to add `set -e` to the top of the livecd-preflight-check script.  When `/usr/bin/goss validate -f json` is run in that script to execute all of the goss tests in that suite, it will return non-zero if any of the tests fail.  The `set -e` causes the script to then stop execution immediately without giving any output indicating which tests failed.   We need to run `/usr/bin/goss validate -f json` without the `set -e`.

## Issues and Related PRs

* Resolves CASMINST-4142

## Testing

### Tested on:

  * `drax`

### Test description:

I ran `/opt/cray/tests/install/livecd/automated/livecd-preflight-checks` on drax with this fix and injected a test failure I was able to see the test results include the one test that was failing.



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
