### PR TITLE
Update craycli version to 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli version to 0.47.0
 - Shared Broker UAI credentials: cray-uas-mgr v1.19.1, update-uas v1.4.0, switchboard v2.1.0
 - Released cray-sysmgmt-health v0.21.7 to adjust istio alert rules (CASMPET-5374)
 - Update gitea to fix tls chart upgrade problems

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -27,4 +27,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.46.0-1.x86_64
+    - craycli-0.47.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.46.0-1.x86_64
+    - craycli-0.47.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update craycli RPM to version 0.47.0.  This brings in CSM-1.2.5 content in CLI.

This change is backward compatible

## Issues and Related PRs

* Resolves [CASMCLOUD-1203](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1203)
* Merge with [csm-rpms PR](https://github.com/Cray-HPE/csm-rpms/pull/318)

## Testing

The CLI changes were tested by the developer at the time of the CLI change. These changes were tested by verifying that the Jenkins build for the branch worked.

### Test description:
Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
Were continuous integration tests run? If not, why? N/A
Was upgrade tested? If not, why? N/A
Was downgrade tested? If not, why? N/A
Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks from this change


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

