### PR TITLE
CASMPET-5082 Bump spire-intermediate to 0.5.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
-    version: 0.4.0
+    version: 0.5.0
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This adds support for checking to see if the existing spire intermediate CA certificate has less than a month left before expiration, and if it does it'll replace the secret with a new intermediate CA.
## Issues and Related PRs

* Resolves [CASMPET-5082](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5082) 

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Validated that the certificate was updated properly when the conditions were met. Also validated that the cert was created correctly when it didn't already exist and that it wasn't touched when it wasn't ready to be updated.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

