### PR TITLE
CASMINST-4324: update index to pull in v1.13.0 released version of cs…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.13.0 for recent test changes
 - Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080
 - Update cray-node-discovery for sec vulnerability

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.19-1.noarch
+    - csm-testing-1.13.0-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.19-1.noarch
+    - goss-servers-1.13.0-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.13.0 released version of csm-testing and goss-servers
Update changelog: - Released csm-testing v1.13.0 for recent test changes
This pulls in changes for:
* CASMINST-4324

### Summary and Scope
main - CASMINST-4324: Remove goss-basecamp-json-ncns.yaml test from ncn-upgrade-preflight-tests suite

Remove goss-basecamp-json-ncns.yaml test from ncn-upgrade-preflight-tests suite.
Update the goss-basecamp-json-ncns.yaml test with pipefail check to prevent false positive result.
Validate updated test on wasp, 1.2.5-alpha.1
