### PR TITLE
CASMINST-4363: skopeo-sync updates images from docker/dtr.dev.cray.com directory

### DIFF
--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -56,7 +56,7 @@ nexus-setup blobstores   "${ROOTDIR}/nexus-blobstores.yaml" "$unbound_ip"
 nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml" "$unbound_ip"
 
 # Upload assets to existing repositories
-skopeo-sync "${ROOTDIR}/docker" "$unbound_ip"
+skopeo-sync "${ROOTDIR}/docker/dtr.dev.cray.com" "$unbound_ip"
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}" "$unbound_ip"
 
 # Upload repository contents


### PR DESCRIPTION
Supports upgrade to latest hpc-shastarelm-release vendor update.

Resolves [CASMINST-4353](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4363)