### PR TITLE
CASMNET-1151 - powerdns-manager creating PTR records with missing zeroes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -64,5 +64,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.5.3
+    version: 0.5.4
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -44,7 +44,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

cray-powerdns-manager was computing the reverse zone by eliminating zeroes from the IP address.

The same `GetReverseZoneName` function was used to generate the zone contents which resulted in truncated PTR records.
```
x1000c5s0b0n1h2.hsn.hela.dev.cray.com	3600	IN	A	10.253.0.69
69.253.10.in-addr.arpa	3600	IN	PTR	x1000c5s0b0n1h2.hsn.hela.dev.cray.com
```
## Issues and Related PRs

* Resolves [CASMNET-1151](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1151)

## Testing

### Tested on:

  * `hela` and `mug`
  * Local development environment
  * Virtual Shasta

### Test description:

Deployed the new version of cray-powerdns-manager and validated the generated records are now correct
```
/ $ pdnsutil list-zone 253.10.in-addr.arpa
$ORIGIN .
100.0.253.10.in-addr.arpa	3600	IN	PTR	x1000c5s7b0n1h3.hsn.vshasta.io
1.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s7b0n0h0.hsn.vshasta.io
15.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s18b32n32h32.hsn.vshasta.io
16.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s19b32n32h32.hsn.vshasta.io
17.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s18b31n31h31.hsn.vshasta.io
18.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s19b31n31h31.hsn.vshasta.io
19.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s6b0n0h0.hsn.vshasta.io
20.0.253.10.in-addr.arpa	3600	IN	PTR	x3000c0s7b0n0h1.hsn.vshasta.io
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable