### PR TITLE
CASMINST-4369: copy ncn modification script into the release dir

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -102,6 +102,7 @@ gen-version-sh "$RELEASE_NAME" "$RELEASE_VERSION" >"${BUILDDIR}/lib/version.sh"
 chmod +x "${BUILDDIR}/lib/version.sh"
 rsync -aq "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh" "${BUILDDIR}/lib/install.sh"
 rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
+rsync -aq "${ROOTDIR}/ncn-image-modification.sh" "$BUILDDIR}/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
 


### PR DESCRIPTION
## Summary and Scope

The script was among those included in the release directory that gets tarred and shipped.