### PR TITLE
CASMINST-4370: minor cleanup and cease creating new initrd/kernel files

### DIFF
--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -98,7 +98,10 @@ function usage() {
     echo    "                                to set it. When setting this variable, be sure to use"
     echo    "                                single quotes (') to ensure any '$' characters are not"
     echo -e "                                interpreted.\n"
-    echo    "       DEBUG                    If set, the script will be run with 'set -x'"
+    echo -e "       DEBUG                    If set, the script will be run with 'set -x'\n"
+    echo    "NOTES"
+    echo    "       If it is desired to not have any ssh in the image, specifiy -d with an empty"
+    echo    "       directory along with -a"
 
 }
 

--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -158,10 +158,13 @@ function process_args() {
                     usage
                     exit 1
                 fi
-                # ensure the comment is quoted in case it contains spaces
                 SSH_KEY_DIR=$2
+                if ! test -d "$SSH_KEY_DIR"; then
+                    echo "ERROR: directory $SSH_KEY_DIR not found"
+                    exit 1
+                fi
                 # no longer using TMPDIR
-                KEY_SOURCE=$2
+                KEY_SOURCE=$SSH_KEY_DIR
                 shift # past argument
                 shift # past value
                 ;;

--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -251,7 +251,7 @@ function verify_and_unsquash() {
             exit 1
         fi
         echo -e "\nvalidated squashfs path, unsquashing: $squash"
-        unsquashfs -d "$(dirname "$squash")"/squashfs-root "$squash"
+        unsquashfs -n -no -ig -d "$(dirname "$squash")"/squashfs-root "$squash" 2>/dev/null || true
     done
 }
 

--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -272,7 +272,7 @@ function set_timezone() {
         for squash in ${SQUASH_PATHS[*]}; do
             squashfs_root="$(dirname "$squash")"/squashfs-root
             echo "TZ=$TIMEZONE" > "$squashfs_root"/etc/environment
-            sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" "$squashfs_root"//srv/cray/scripts/metal/ntp-upgrade-config.sh
+            sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" "$squashfs_root"/srv/cray/scripts/metal/ntp-upgrade-config.sh
         done
     fi
 }


### PR DESCRIPTION
## Summary and Scope

We do not need to create a new initrd or kernel when changing the squashfs for the purposes of adding a new root password, keys, or timezone.  Cease doing so.  The dracut code to create a new initrd has problems running on an overly filesystem.  By not creating an initrd we are avoiding this problem.

## Issues and Related PRs

* Resolves CASMINST-4370


## Testing

### Tested on:

  * `redbull`, `surtur`

### Test description:

I was able to create a new squashfs on both redbull and surtur while being on an overlayfs.


