### PR TITLE
CASMINST-4381: use the full path for the passwd command

### DIFF
--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -284,7 +284,7 @@ function setup_ssh() {
 
     # set the password and set up passwordless ssh if appropriate
     for squash in ${SQUASH_PATHS[*]}; do
-        squashfs_root="$(dirname "$squash")"/squashfs-root
+        squashfs_root=$(realpath "$(dirname "$squash")/squashfs-root")
         name=$(basename "$squash")
 
         echo -e "\nSetting the password for $name"


### PR DESCRIPTION
## Summary and Scope

The `passwd --root` command does not recognize an alternate root
path unless it starts with a `/` - use `realpath` to provide the
full path to `passwd`.

Tested on redbull by providing relative paths to  the squashfs files.