### PR TITLE
CASMINST-4372 CSI fix for CHN reservations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+
+- Updated cray-site-init v1.16.9 fixing CHN reservations generation. CASMINST-4372
 - Released csm-testing v1.12.20 for recent test changes
 - Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.8-1.x86_64
+    - cray-site-init-1.16.9-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

Cray Site Init generated CHN reservations with xname rather than common name. This created two xname records in DNS and played havoc with SAT and DVS.  Additionally UANs were missing from the CHN.  This change remediates these two issues for new/fresh installs of CSM 1.2 where the system has a CHN.

## Issues and Related PRs

* Resolves CASMINST-4372

## Testing

### Tested on:

  * Hela data (has a CHN)
  * Surtur data (does not have a CHN)

### Test description:

Ensured common names were generated in CHN SLS reservations and that UAN entries were generated in the CHN SLS structured.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
