### PR TITLE
CASMINST-4392: don't propagate known_hosts

### DIFF
--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -306,7 +306,8 @@ function setup_ssh() {
         # copy ssh key to the squashfs
         mkdir -pv "$squashfs_root"/root/.ssh
         chmod 700 "$squashfs_root"/root/.ssh
-        cp -av "$KEY_SOURCE"/* "$squashfs_root"/root/.ssh/
+        # host keys will change, don't propagate
+        rsync -av --exclude known_hosts "$KEY_SOURCE"/* "$squashfs_root"/root/.ssh/
 
         # set up passwordless ssh between NCNs
         if [ "$MODIFY_AUTHORIZED_KEYS" = "yes" ]; then


### PR DESCRIPTION
## Summary and Scope

Host keys change during upgrade to a new image.  Don't propagate
the known_hosts file as this will cause key conflicts post-upgrade
and make ssh mad.
