### PR TITLE
Canu: Release 1.3.2 - CASMNET-1348_1_2

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.7-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.2.1-1.x86_64
+    - canu-1.3.2-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.32-1.noarch
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -7,4 +7,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - metal-ipxe-2.2.3-1.noarch
+    - canu-1.3.2-1.x86_64
 


### PR DESCRIPTION
## Summary and Scope

Canu: Release 1.3.2 

**Quick summary:**

New feature: Customer custom config injection.

Both code and switch configuration bug fixes and updates.

**Detailed change log since last official release.**

```
    Fix aruba banner output during canu validate
    shutdown unused ports by default on aruba 6300+dell+mellanox
    Removed the override feature
    Add feature to inject custom configs into generated switch configs
    Change Aruba banner from motd to exec
    Reordered the configuration output so that vlans are defined before being applied to ports.
    Fix Leaf-bmc naming corner case: leaf-bmc-bmc to leaf-bmc
    Fix OSPF CAN vlan for 1.2 in full/tds
    Fixed bug to allow canu to exit gracefully with sys.exit(1)
    Add network test cases
    Add network test cases for DNS and site connectivity
    Fixed missing DNS from Aruba switches
    Add NMN network for 1.0 to ssh allowed into switches because of BGP DOCS in 1.0 allowing it.
    Remove router ospfv3 from 1.0/1.2
    Fixed ACL, OSPF, BGP config files
    Fixed test templates for ACL, OSPF, BGP
    Change Aruba banner to match running config.
    Fix Canu test --network
    Add OSPF to vlan 1.
    Add 'ip ospf passive' to vlan 1,4.
    Fix test cases: test_generate_switch_config_aruba_csm_1_2.py | test_generate_switch_config_dellanox_csm_1_2.py.
    Fix missing OSPF configuration from VLAN 7 in /network_modeling/configs/templates/dellmellanox/1.2/*.
    Fix descriptions for MTL
    Config backup create /running.
    Add SHCD filename to paddle/ccj JSON to obtain originating SHCD version.

```

## Issues and Related PRs

* Resolves [CASMNET-1348](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1348)


## Testing

NOX

### Tested on:

NOX

### Test description:

NOX/Jenkins

## Risks and Mitigations

No.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

