### PR TITLE
Canu release 1.3.2   casmnet 1348 1 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed CFS-Batcher bug that was causing extra sessions to be launched
 - Updated MEDS will now only make POST and PATCH a EthernetInterface in HSM when there is actually something to change.
 - Fixed RTS to have the correct pod security policies for the RTS Loader Job.
+- Updated power capping control for Olympus nodes
 
 
 ## [0.9.0] - 2021-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-sysmgmt-health v0.21.7 to adjust istio alert rules (CASMPET-5374)
 - Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890
 - Released csm-testing v1.12.9 for recent test changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update csm-config v1.9.24 for CASMCMS-7890
 - Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080
 - Update cray-node-discovery for sec vulnerability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890
 - Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Shared Broker UAI credentials: cray-uas-mgr v1.19.1, update-uas v1.4.0, switchboard v2.1.0
 - Released cray-sysmgmt-health v0.21.7 to adjust istio alert rules (CASMPET-5374)
 - Update gitea to fix tls chart upgrade problems
 - Update csm-config v1.9.24 for CASMCMS-7890

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080
 - Update cray-node-discovery for sec vulnerability
 - Update cray-externaldns to use updated image path (CASMINST-4085)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.13.0 for recent test changes
 - Shared Broker UAI credentials: cray-uas-mgr v1.19.1, update-uas v1.4.0, switchboard v2.1.0
 - Released cray-sysmgmt-health v0.21.7 to adjust istio alert rules (CASMPET-5374)
 - Update gitea to fix tls chart upgrade problems

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,30 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 @Library('csm-shared-library') _
-
+def credentialsId = 'artifactory-algol60'
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -83,12 +108,14 @@ pipeline {
                     steps {
                         script {
                             slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
-                            sh """
-                                . build/.env/bin/activate
-                                make clean
-                                rm -fr dist
-                                ./release.sh
-                            """
+                            withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                                sh """
+                                    . build/.env/bin/activate
+                                    make clean
+                                    rm -fr dist
+                                    ./release.sh
+                                """
+                            }
                         }
                     }
                     post {
@@ -96,6 +123,7 @@ pipeline {
                             script {
                                 slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Built release distribution")
                             }
+                            
                         }
                         unsuccessful {
                             script {

--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.62/kubernetes-0.2.62.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.62/5.3.18-150300.59.43-default-0.2.62.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.62/initrd.img-0.2.62.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.63/kubernetes-0.2.63.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.63/5.3.18-150300.59.43-default-0.2.63.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.63/initrd.img-0.2.63.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.62/storage-ceph-0.2.62.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.62/5.3.18-150300.59.43-default-0.2.62.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.62/initrd.img-0.2.62.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.63/storage-ceph-0.2.63.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.63/5.3.18-150300.59.43-default-0.2.63.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.63/initrd.img-0.2.63.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220302191903-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220302191903-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220302191903-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/kubernetes-0.2.60.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/5.3.18-150300.59.43-default-0.2.60.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/initrd.img-0.2.60.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.61/kubernetes-0.2.61.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.61/5.3.18-150300.59.43-default-0.2.61.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.61/initrd.img-0.2.61.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/storage-ceph-0.2.60.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/5.3.18-150300.59.43-default-0.2.60.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/initrd.img-0.2.60.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.61/storage-ceph-0.2.61.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.61/5.3.18-150300.59.43-default-0.2.61.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.61/initrd.img-0.2.61.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220301193325-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/kubernetes-0.2.59.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/5.3.18-150300.59.43-default-0.2.59.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/initrd.img-0.2.59.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/kubernetes-0.2.60.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/5.3.18-150300.59.43-default-0.2.60.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.60/initrd.img-0.2.60.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/storage-ceph-0.2.59.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/5.3.18-150300.59.43-default-0.2.59.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/initrd.img-0.2.59.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/storage-ceph-0.2.60.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/5.3.18-150300.59.43-default-0.2.60.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.60/initrd.img-0.2.60.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.61/kubernetes-0.2.61.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.61/5.3.18-150300.59.43-default-0.2.61.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.61/initrd.img-0.2.61.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.62/kubernetes-0.2.62.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.62/5.3.18-150300.59.43-default-0.2.62.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.62/initrd.img-0.2.62.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.61/storage-ceph-0.2.61.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.61/5.3.18-150300.59.43-default-0.2.61.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.61/initrd.img-0.2.61.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.62/storage-ceph-0.2.62.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.62/5.3.18-150300.59.43-default-0.2.62.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.62/initrd.img-0.2.62.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220317193332-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220317193332-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220317193332-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220322200015-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220322200015-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220322200015-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220302191903-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220302191903-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220302191903-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220303201622-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220303201622-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220303201622-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220307204428-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220307204428-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220307204428-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220309184614-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220309184614-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220309184614-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.63/kubernetes-0.2.63.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.63/5.3.18-150300.59.43-default-0.2.63.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.63/initrd.img-0.2.63.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.64/kubernetes-0.2.64.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.64/5.3.18-150300.59.43-default-0.2.64.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.64/initrd.img-0.2.64.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.63/storage-ceph-0.2.63.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.63/5.3.18-150300.59.43-default-0.2.63.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.63/initrd.img-0.2.63.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.64/storage-ceph-0.2.64.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.64/5.3.18-150300.59.43-default-0.2.64.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.64/initrd.img-0.2.64.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220224201707-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220224201707-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220224201707-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220228203953-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.58/kubernetes-0.2.58.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.58/5.3.18-150300.59.43-default-0.2.58.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.58/initrd.img-0.2.58.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/kubernetes-0.2.59.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/5.3.18-150300.59.43-default-0.2.59.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.59/initrd.img-0.2.59.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.58/storage-ceph-0.2.58.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.58/5.3.18-150300.59.43-default-0.2.58.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.58/initrd.img-0.2.58.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/storage-ceph-0.2.59.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/5.3.18-150300.59.43-default-0.2.59.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.59/initrd.img-0.2.59.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.66/kubernetes-0.2.66.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.66/5.3.18-150300.59.43-default-0.2.66.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.66/initrd.img-0.2.66.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.67/kubernetes-0.2.67.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.67/5.3.18-150300.59.43-default-0.2.67.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.67/initrd.img-0.2.67.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.66/storage-ceph-0.2.66.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.66/5.3.18-150300.59.43-default-0.2.66.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.66/initrd.img-0.2.66.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.67/storage-ceph-0.2.67.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.67/5.3.18-150300.59.43-default-0.2.67.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.67/initrd.img-0.2.67.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220314205018-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220314205018-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220314205018-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220315201615-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220315201615-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220315201615-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220315201615-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220315201615-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220315201615-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220317193332-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220317193332-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220317193332-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.64/kubernetes-0.2.64.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.64/5.3.18-150300.59.43-default-0.2.64.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.64/initrd.img-0.2.64.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.66/kubernetes-0.2.66.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.66/5.3.18-150300.59.43-default-0.2.66.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.66/initrd.img-0.2.66.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.64/storage-ceph-0.2.64.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.64/5.3.18-150300.59.43-default-0.2.64.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.64/initrd.img-0.2.64.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.66/storage-ceph-0.2.66.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.66/5.3.18-150300.59.43-default-0.2.66.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.66/initrd.img-0.2.66.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220309184614-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220309184614-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220309184614-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220314205018-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220314205018-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220314205018-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220303201622-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220303201622-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220303201622-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220307204428-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220307204428-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220307204428-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -70,10 +70,6 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/istio/kubectl:
       - 1.5.4
 
-    # XXX Not sure where this is used, but should be deprecated
-    docker.io/library/centos:
-      - 7
-
     # Openjdk is used during install procedures to generate keystores
     docker.io/library/openjdk:
       - 11-jre-slim

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -39,7 +39,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-ims-load-artifacts:
       - 1.3.59
     cray-grafterm:
-      - 1.0.1
+      - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to
     # XXX facilitate install/upgrade?
     hms-pytest:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -37,7 +37,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 1.3.56
+      - 1.3.59
     cray-grafterm:
       - 1.0.1
     # XXX Are these HMS images missing from a chart or are they used to

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -83,10 +83,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v3.1
       - v3.7
 
-    # XXX Not sure where this is used?
-    docker.io/openapitools/openapi-generator-cli:
-      - v5.1.0
-
     # XXX Is this missing from cray-sysmgmt-health?
     docker.io/prom/pushgateway:
       - v0.8.0

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,11 +29,11 @@ quay.io:
 
 artifactory.algol60.net/csm-docker/stable:
   images:
-    # XXX update-uas v1.3.2 should include these
-    cray-uai-sles15sp2:
-      - 1.3.1
+    # XXX update-uas v1.4.0 should include these
+    cray-uai-sles15sp3:
+      - 1.4.0
     cray-uai-broker:
-      - 1.3.1
+      - 1.4.0
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2021 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -ex
 
 # The repo options to rpm-index are generated from the CSM/csm-rpms repo as
@@ -12,7 +32,17 @@ set -ex
 # Note that the kubernetes/el7/x86_64 repo is included as it is implicitly
 # added by the ncn-k8s image.
 
-docker run --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0 rpm-index -v \
+#pass the repo credentials environment variables to the container that runs rpm-index
+REPO_FILENAME=${REPOCREDSFILENAME:-}
+REPO_FILENAME_PATH=${REPOCREDSPATH:-}
+REPO_CREDS_DOCKER_OPTIONS=""
+REPO_CREDS_RPMINDEX_OPTIONS=""
+if [ ! -z "$REPO_FILENAME" ] && [ ! -z "$REPO_FILENAME_PATH" ]; then
+    REPO_CREDS_DOCKER_OPTIONS="--mount type=bind,source=${REPO_FILENAME_PATH},destination=/repo_creds_data"
+    REPO_CREDS_RPMINDEX_OPTIONS="-c /repo_creds_data/${REPO_FILENAME}"
+fi
+
+docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.12.0 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
 -d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -174,4 +174,6 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.dev.cray.com/internal-docke
     -d  https://artifactory.algol60.net/artifactory/hpe-mirror-hexane/15/x86_64/current/                          hpe/hexane/ \
     -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update  cray/csm/sle-15sp2 \
     -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update_debug  cray/csm/sle-15sp2 \
+    -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Server-Applications/15-SP3/x86_64/update/  cray/csm/sle-15sp2 \
+    -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/  cray/csm/sle-15sp2 \
     -

--- a/hack/load-container-image.sh
+++ b/hack/load-container-image.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 [[ $# -eq 1 ]] || {
 	echo >&2 "usage: ${0##*/} IMAGE"
@@ -36,7 +57,7 @@ if command -v podman >/dev/null 2>&1; then
 	mounts="-v ${graphroot}:/var/lib/containers/storage"
 	transport="containers-storage"
 	run_opts="--rm --network none --privileged --ulimit=host"
-	skopeo_dest="${transport}:[${graphdrivername}@${graphroot}+${runroot}]${image}"
+	skopeo_dest="${transport}:${image}"
 
 elif command -v docker >/dev/null 2>&1; then
 

--- a/hack/load-container-image.sh
+++ b/hack/load-container-image.sh
@@ -57,7 +57,13 @@ if command -v podman >/dev/null 2>&1; then
 	mounts="-v ${graphroot}:/var/lib/containers/storage"
 	transport="containers-storage"
 	run_opts="--rm --network none --privileged --ulimit=host"
-	skopeo_dest="${transport}:${image}"
+
+        fuse_exe=$(podman info -f json | jq -r ".store.graphOptions[].Executable")
+        if [ "$fuse_exe" == "/usr/bin/fuse-overlayfs" ]; then
+          skopeo_dest="${transport}:${image}"
+        else
+          skopeo_dest="${transport}:[${graphdrivername}@${graphroot}+${runroot}]${image}"
+        fi
 
 elif command -v docker >/dev/null 2>&1; then
 

--- a/hack/verify-helm-index.sh
+++ b/hack/verify-helm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0"
+PACKAGING_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.12.0"
 
 set -o errexit
 set -o pipefail

--- a/install.sh
+++ b/install.sh
@@ -81,19 +81,6 @@ deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
 
-# Ensure etcd clusters have three running members before proceeding
-for cluster in $(kubectl get etcd -n services | grep -v NAME | awk '{print $1}')
-do
-  size=$(kubectl get etcd -n services $cluster -o json | jq '.status.size')
-  if [ $size -ne 3 ]; then
-    echo >&2 "ERROR: etcd cluster: $cluster does not have three running members."
-    echo >&2 "       This must be addressed prior to continuing with the install."
-    exit 1
-  else
-    echo "validated etcd cluster: $cluster has three running members..."
-  fi
-done
-
 set +x
 cat >&2 <<EOF
 + CSM applications and services deployed

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,19 @@ deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
 
+# Ensure etcd clusters have three running members before proceeding
+for cluster in $(kubectl get etcd -n services | grep -v NAME | awk '{print $1}')
+do
+  size=$(kubectl get etcd -n services $cluster -o json | jq '.status.size')
+  if [ $size -ne 3 ]; then
+    echo >&2 "ERROR: etcd cluster: $cluster does not have three running members."
+    echo >&2 "       This must be addressed prior to continuing with the install."
+    exit 1
+  else
+    echo "validated etcd cluster: $cluster has three running members..."
+  fi
+done
+
 set +x
 cat >&2 <<EOF
 + CSM applications and services deployed

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -64,5 +64,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.5.3
+    version: 0.5.4
     namespace: services

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.3 # update platform.yaml cray-precache-images with this
+    version: 0.7.4 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.3
+        appVersion: 0.7.4
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,7 +41,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.1 # update platform.yaml cray-precache-images with this
+    version: 0.10.2 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.2 # update platform.yaml cray-precache-images with this
+    version: 0.7.3 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.2
+        appVersion: 0.7.3
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,7 +41,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.2 # update platform.yaml cray-precache-images with this
+    version: 0.10.3 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.10.0
+    version: 0.10.1
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
-    version: 0.4.0
+    version: 0.5.0
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -42,7 +42,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.1
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -201,7 +201,7 @@ spec:
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 1.0.0
+    version: 1.1.0
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.3
+    version: 0.21.4
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -55,7 +55,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.0
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
   - name: gatekeeper
     source: csm-algol60
     version: 1.5.2

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.7
+    version: 0.21.10
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -42,7 +42,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.1
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.3
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
-    version: 0.5.0
+    version: 0.1.1
     namespace: pki-operator
   - name: cray-certmanager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -41,7 +41,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.4
+    version: 0.21.5
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -41,7 +41,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -44,7 +44,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.3
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.5
+    version: 0.21.7
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
-    version: 0.1.1
+    version: 0.5.0
     namespace: pki-operator
   - name: cray-certmanager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -137,7 +137,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.9.0
+    version: 1.10.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -51,7 +51,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.4.9
+    version: 3.4.11
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -21,7 +21,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 2.0.4
+    version: 2.0.5
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -41,7 +41,7 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.0.1
+    version: 2.0.2
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -90,7 +90,7 @@ spec:
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.3.1
+    version: 1.3.3
     namespace: services
   - name: cray-crus
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,7 +118,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.19
+    version: 1.9.21
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.3.6
+    version: 2.3.9
     namespace: services
     values:
       keycloakImage:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.9
+    version: 1.9.11
     namespace: services
   - name: cray-tftp
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.3.9
+    version: 2.3.11
     namespace: services
     values:
       keycloakImage:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,5 +153,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.3.1
+    version: 2.4.0
     namespace: spire

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,11 +143,11 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.18.0
+    version: 1.19.1
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.3.3
+    version: 1.4.0
     namespace: services
 
   # Spire service

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,7 +118,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.21
+    version: 1.9.24
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -25,7 +25,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.0.4
+    version: 2.1.1
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60

--- a/release.sh
+++ b/release.sh
@@ -57,6 +57,15 @@ RELEASE_VERSION_BUILDMETADATA="$(echo "$RELEASE_VERSION" | perl -pe "s/${semver_
 # Setup
 #
 
+#serialize an object containing repo credentials to disk, and put the path to it in an environment variable
+if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
+    export REPOCREDSPATH="/tmp/"
+    export REPOCREDSFILENAME="repo_creds.json"
+    export REPOCREDSFULL=$REPOCREDSPATH$REPOCREDSFILENAME
+    jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/sles-mirror/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
+    trap "rm -f '${REPOCREDSFULL}'" EXIT
+fi
+
 # Load and verify assets
 source "${ROOTDIR}/assets.sh"
 

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -1,7 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
-    - cray-switchboard-1.2.3-1.x86_64
+    - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.46.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.7-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.2.1-1.x86_64
+    - canu-1.3.2-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.32-1.noarch
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.4-1.x86_64
+    - cray-site-init-1.16.5-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.17-1.noarch
+    - csm-testing-1.12.18-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.17-1.noarch
+    - goss-servers-1.12.18-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.7-1.noarch
+    - csm-testing-1.12.9-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.7-1.noarch
+    - goss-servers-1.12.9-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
     - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
-    - cray-switchboard-1.2.3-1.x86_64
+    - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.46.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.2-1.x86_64
+    - cray-site-init-1.16.3-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.10-1.noarch
+    - csm-testing-1.12.11-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.10-1.noarch
+    - goss-servers-1.12.11-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.9-1.noarch
+    - csm-testing-1.12.10-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.9-1.noarch
+    - goss-servers-1.12.10-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.11-1.noarch
+    - csm-testing-1.12.14-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.11-1.noarch
+    - goss-servers-1.12.14-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.7-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.1.11-1.x86_64
+    - canu-1.2.1-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.32-1.noarch
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.19-1.noarch
+    - csm-testing-1.13.0-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.19-1.noarch
+    - goss-servers-1.13.0-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.14-1.noarch
+    - csm-testing-1.12.15-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.14-1.noarch
+    - goss-servers-1.12.15-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.6-1.x86_64
+    - cray-site-init-1.16.7-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.15-1.noarch
+    - csm-testing-1.12.16-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.15-1.noarch
+    - goss-servers-1.12.16-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.3-1.x86_64
+    - cray-site-init-1.16.4-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.16-1.noarch
+    - csm-testing-1.12.17-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.16-1.noarch
+    - goss-servers-1.12.17-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.5-1.x86_64
+    - cray-site-init-1.16.6-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.1-1.x86_64
+    - cray-site-init-1.16.2-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.7-1.x86_64
+    - cray-site-init-1.16.8-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch
     - dracut-metal-mdsquash-1.9.3-1.noarch
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.18-1.noarch
+    - csm-testing-1.12.19-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.12.18-1.noarch
+    - goss-servers-1.12.19-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,7 +42,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.13.0-1.noarch
+    - csm-testing-1.13.1-1.noarch
     - docs-csm-1.13.9-1.noarch
     - goss-servers-1.13.0-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -7,4 +7,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - metal-ipxe-2.2.3-1.noarch
+    - canu-1.3.2-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -6,5 +6,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cfs-trust-1.3.94-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - metal-ipxe-2.2.2-1.noarch
+    - metal-ipxe-2.2.3-1.noarch
 

--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/README.md
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/README.md
@@ -72,7 +72,7 @@ dependencies. Installation via Homebrew is simply `breq install git-vendor`.
 Once installed, vendor this library into a product release repository via:
 
 ```bash
-$ git vendor add release https://stash.us.cray.com/scm/shastarelm/release.git master
+$ git vendor add release https://github.hpe.com/hpe/hpc-shastarelm-release.git master
 ```
 
 

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -279,13 +279,7 @@ spec:
       cray-externaldns:
         external-dns:
           domainFilters:
-            - 'cmn.{{ network.dns.external }}'
-            - 'can.{{ network.dns.external }}'
-            - 'chn.{{ network.dns.external }}'
-            - 'nmn.{{ network.dns.external }}'
-            - 'hmn.{{ network.dns.external }}'
-            - 'nmnlb.{{ network.dns.external }}'
-            - 'hmnlb.{{ network.dns.external }}'
+            - '.{{ network.dns.external }}'
       cray-dns-unbound:
         domain_name: '{{ network.dns.external }}'
         forwardZones:

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -494,12 +494,14 @@ spec:
         macvlan:
           subnet: '{{ wlm.macvlansetup.nmn_supernet }}'
           routes: '{{ wlm.macvlansetup.routes }}'
+          master: '{{ wlm.macvlansetup.nmn_vlan }}'
       cray-slurmctld:
         clusterName: '{{ wlm.cluster_name }}'
         macvlan:
           ip: '{{ wlm.wlmstaticips.slurmctld }}'
           subnet: '{{ wlm.macvlansetup.nmn_supernet }}'
           routes: '{{ wlm.macvlansetup.routes }}'
+          master: '{{ wlm.macvlansetup.nmn_vlan }}'
       slurm-config:
         cluster_name: '{{ wlm.cluster_name }}'
         slurmctld_ip: '{{ wlm.wlmstaticips.slurmctld }}'
@@ -702,6 +704,7 @@ spec:
         macvlan:
           subnet: '{{ wlm.macvlansetup.nmn_supernet }}'
           routes: '{{ wlm.macvlansetup.routes }}'
+          master: '{{ wlm.macvlansetup.nmn_vlan }}'
         #
         # Node label(s) take the form:
         #


### PR DESCRIPTION
## Summary and Scope

Canu: Release 1.3.2 

**Quick summary:**

New feature: Customer custom config injection.

Both code and switch configuration bug fixes and updates.

**Detailed change log since last official release.**

```
    Fix aruba banner output during canu validate
    shutdown unused ports by default on aruba 6300+dell+mellanox
    Removed the override feature
    Add feature to inject custom configs into generated switch configs
    Change Aruba banner from motd to exec
    Reordered the configuration output so that vlans are defined before being applied to ports.
    Fix Leaf-bmc naming corner case: leaf-bmc-bmc to leaf-bmc
    Fix OSPF CAN vlan for 1.2 in full/tds
    Fixed bug to allow canu to exit gracefully with sys.exit(1)
    Add network test cases
    Add network test cases for DNS and site connectivity
    Fixed missing DNS from Aruba switches
    Add NMN network for 1.0 to ssh allowed into switches because of BGP DOCS in 1.0 allowing it.
    Remove router ospfv3 from 1.0/1.2
    Fixed ACL, OSPF, BGP config files
    Fixed test templates for ACL, OSPF, BGP
    Change Aruba banner to match running config.
    Fix Canu test --network
    Add OSPF to vlan 1.
    Add 'ip ospf passive' to vlan 1,4.
    Fix test cases: test_generate_switch_config_aruba_csm_1_2.py | test_generate_switch_config_dellanox_csm_1_2.py.
    Fix missing OSPF configuration from VLAN 7 in /network_modeling/configs/templates/dellmellanox/1.2/*.
    Fix descriptions for MTL
    Config backup create /running.
    Add SHCD filename to paddle/ccj JSON to obtain originating SHCD version.
```


## Issues and Related PRs

* Resolves [CASMNET-1348](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1348)


## Testing

NOX

### Tested on:

NOX

### Test description:

NOX/Jenkins

## Risks and Mitigations

No.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

