### PR TITLE
CASMINST-4394: update index to pull in v1.12.22 released version of c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-testing v1.12.22 for recent test changes
 - Released csm-testing v1.13.0 for recent test changes
 - Released csm-testing v1.12.9 for recent test changes
 - Update cray-oauth2-proxy for sec vulnerability. CASMINST-4080

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.13.0-1.noarch
+    - csm-testing-1.12.22-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.13.0-1.noarch
+    - goss-servers-1.12.22-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.12.22 released version of csm-testing and goss-servers
Update changelog: - Released csm-testing v1.12.22 for recent test changes
This pulls in changes for:
* CASMINST-4394

### Summary and Scope
main - CASMINST-4394: TESTS: After CSM Services Upgrade, stage 3, should validate at this point.

New ncn-post-csm-service-upgrade-tests.yaml test suite to validate CSM services after upgrade stage3.
Update the goss-k8s-istio-endpoint.yaml, goss-k8s-istio-pod-containers-running.yaml and
goss-k8s-istio-pods-running.yaml tests with pipefail check to prevent false test results.
Validate new suite and updated tests on wasp, 1.2.5-alpha.1

### Issues and Related PRs
CASMINST-4394

### Testing
Tested on wasp with 1.2.5-alpha.1
