### PR TITLE
Update hmcollector helm version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.3
+    version: 2.15.4
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update hmcollector helm version to 2.15.4 for CASMHMS-5479 - Slingshot data prefix has 'CrayFabricCriticalTelemetry' instead of 'CrayFabricCritTelemetry'

## Issues and Related PRs

* Resolves [CASMHMS-5479](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5479)

## Testing

For testing see https://github.com/Cray-HPE/hms-hmcollector/pull/36

## Risks and Mitigations

Low risk


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

