### PR TITLE
Sync up 1.2.5 with latest 1.2 assets

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220322200015-ga02c80b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220322200015-ga02c80b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220322200015-ga02c80b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220401194521-ga02c80b.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220401194521-ga02c80b.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20220401194521-ga02c80b.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.67/kubernetes-0.2.67.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.67/5.3.18-150300.59.43-default-0.2.67.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.67/initrd.img-0.2.67.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.71/kubernetes-0.2.71.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.71/5.3.18-150300.59.43-default-0.2.71.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.71/initrd.img-0.2.71.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.67/storage-ceph-0.2.67.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.67/5.3.18-150300.59.43-default-0.2.67.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.67/initrd.img-0.2.67.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.71/storage-ceph-0.2.71.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.71/5.3.18-150300.59.43-default-0.2.71.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.71/initrd.img-0.2.71.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

Bring 1.2.5 assets in line with 1.2 assets.  They should be the same up until we decide there will be new images in 1.2.5.