### PR TITLE
CASMPET-5303: upgrade istio to 1.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Istio is updated to 1.9.9, OPA envoy plugin to 0.26.0-envoy-6, kiali to 1.33.1 (CASMPET-5303, CASMPET-5359)
 - Released csm-testing v1.13.2 for recent test changes
 - Released csm-testing v1.13.0 for recent test changes
 - Shared Broker UAI credentials: cray-uas-mgr v1.19.1, update-uas v1.4.0, switchboard v2.1.0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,9 +37,9 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
       # OPA
-      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.4
@@ -125,11 +125,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.23.2
+    version: 1.24.0
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.26.3   # Update cray-precache-images above on proxyv2 tag change.
+    version: 1.27.0   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -137,7 +137,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.10.0
+    version: 1.12.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60
@@ -169,11 +169,11 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.5.0
+    version: 2.6.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.2.2
+    version: 0.3.0
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -407,8 +407,6 @@ spec:
               external_services:
                 grafana:
                   url: https://{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].grafana.externalAuthority }}/
-                tracing:
-                  url: https://{{ kubernetes.services['cray-istio'].istio.tracing.externalAuthority }}/
       cray-metallb:
         metallb:
           configInline: '{{ network.metallb | toYaml }}'


### PR DESCRIPTION
## Summary and Scope

Upgrade istio to 1.9.9, OPA envoy plugin to 0.26.0-envoy-6, kiali to 1.33.1.

## Issues and Related PRs

* Resolves [CASMPET-5303]
* Change will also be needed in `main`

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

After upgrading to istio 1.9.9, OPA envoy plugin, as well as kiali, I validated that the keycloak token still works, as well as kiali, grafana, keycloak, and prometheus UIs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Medium. The upgrade was tested in both vshasta and bare metal systems, with success. Since we get into 1.2.5 early, any unexpected failures can be resolved or we can revert the upgrade as contingency plan.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

