### PR TITLE
version bumps for kea,unbound,pdns,pdsn-mgr for security fixes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,28 +41,28 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.3 # update platform.yaml cray-precache-images with this
+    version: 0.10.4 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.5 # update platform.yaml cray-precache-images with this
+    version: 0.7.6 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.5
+        appVersion: 0.7.6
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.2.3 # update platform.yaml cray-precache-images with this
+    version: 0.2.5 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.2.3
+        appVersion: 0.2.5
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.5.4
+    version: 0.5.5
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -41,10 +41,10 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.5
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.3
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.4
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.4
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.6
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- update container baseos to be rolling versions of alpine3
- resolve powerdns CVE-2022-27227 https://github.com/advisories/GHSA-67fj-vc46-4xmv by bumping powerdns version 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

Resolves:
CASMINST-4262
CASMINST-4400
CASMINST-4399
CASMNET-1390

## Testing

_List the environments in which these changes were tested._

### Tested on:

hela

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?n/a
- Were continuous integration tests run? If not, why?yes, running on hela for a few days
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

- none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

