### PR TITLE
Modify which docker container capmc uses for power off fixes.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -23,6 +23,9 @@ spec:
     source: csm-algol60
     version: 2.0.5
     namespace: services
+    values:
+        global:
+            appVersion: 1.33.1
   - name: cray-hms-firmware-action
     source: csm-algol60
     version: 2.1.1


### PR DESCRIPTION
### Summary and Scope

A previous mod implemented support for emulating restarts when the
hardware does not directly support it. It ended up causing every power
off to wait for the hardware to be off. This caused problems due to the
behavior change and a short timeout. Bumped the timeout from 1 minute to
15 minutes. This timeout is still site dependent.

### Issues and Related PRs

* Resolves CASMHMS-5480 for csm 1.2

### Testing

Tested on:

* `hela`

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Upgraded CAPMC to fixed version, verified CAPMC returns immediately after sending power Off to target node. There were no checks by CAPMC to see if the node was off. Issues a reinit to a node and verified CAPMC waited for the node to power off before issuing the power On and returning. It was discovered on hela that mountain nodes were taking ~11 minutes to power off.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y

No known issues.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

