### PR TITLE
bug/CASMINST-4441 -  handling to getting unbound-manager jobs if there are no unbound-…

### DIFF
--- a/lib/wait-for-unbound.sh
+++ b/lib/wait-for-unbound.sh
@@ -6,7 +6,7 @@ set -exo pipefail
 
 function clean_up_unbound_manager_jobs() {
 
-    unbound_manager_jobs=$(kubectl get jobs -n services |awk '{ print $1 }'|grep unbound-manager)
+    unbound_manager_jobs=$(kubectl get jobs -n services |awk '{ print $1 }'|grep unbound-manager || true)
 
     for job in $unbound_manager_jobs; do
         job_entry=$(kubectl get jobs -n services $job|sed 1d)


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- during install, wait-for-unbound.sh errors out when unbound-manager cronjob has not run yet

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
- yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

- CASMINST-4441

## Testing

_List the environments in which these changes were tested._

### Tested on:

- hela
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- test was done on hela by checking for an invalid string(unbound-manager1) to simulate cronjob had not been run.  verified that return of null/0 was able to continue with success.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?na
- Were continuous integration tests run? If not, why?na
- Was upgrade tested? If not, why?na
- Was downgrade tested? If not, why?na
- Were new tests (or test issues/Jiras) created for this change?na

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
- none

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

