### PR TITLE
CASMINST-4442: Extend timeout on goss-command-available test (1.2)

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,7 +42,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.22-1.noarch
+    - csm-testing-1.12.23-1.noarch
     - docs-csm-1.13.11-1.noarch
     - goss-servers-1.12.22-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64


### PR DESCRIPTION
See main code PR for details:
https://github.com/Cray-HPE/csm-testing/pull/269