### PR TITLE
CASMINST-4442: Extend timeout on goss-command-available test (1.0)

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,7 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - docs-csm-1.10.61-1.noarch
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-mdsquash-1.5.9-1.noarch
-    - csm-testing-1.6.53-1.noarch
+    - csm-testing-1.6.54-1.noarch
     - goss-servers-1.6.53-1.noarch
     - hms-ct-test-crayctldeploy-1.6.3-1.x86_64
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
See main code PR for details:
https://github.com/Cray-HPE/csm-testing/pull/269