### PR TITLE
MTL-1660 Include Ansible in all NCN Images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.72/kubernetes-0.2.72.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.72/5.3.18-150300.59.43-default-0.2.72.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.72/initrd.img-0.2.72.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.73/kubernetes-0.2.73.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.73/5.3.18-150300.59.43-default-0.2.73.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.73/initrd.img-0.2.73.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.72/storage-ceph-0.2.72.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.72/5.3.18-150300.59.43-default-0.2.72.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.72/initrd.img-0.2.72.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.73/storage-ceph-0.2.73.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.73/5.3.18-150300.59.43-default-0.2.73.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.73/initrd.img-0.2.73.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1660
- Relates to MTL-1513

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This moves some of the Ansible init out of storage-ceph and into NCN common, making Ansible available on every NCN.

A CSM Ansible virtualenv will exist at `/etc/ansible/csm_ansible`.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1660](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1660)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `redbull`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Ansible is available after sourcing the env.

```bash
ncn-m002:~ # source /etc/ansible/csm_ansible/bin/activate
(csm_ansible) ncn-m002:~ # ansible --version
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the
controller starting with Ansible 2.12. Current version: 3.6.15 (default, Sep 23
 2021, 15:41:43) [GCC]. This feature will be removed from ansible-core in
version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
ansible [core 2.11.10]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /etc/ansible/csm_ansible/lib/python3.6/site-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /etc/ansible/csm_ansible/bin/ansible
  python version = 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]
  jinja version = 3.0.3
  libyaml = True
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

