### PR TITLE
CASMUSER-2992 update-uas to 1.4.0 to fix basic UAI dbus complaint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- update update-uas to 1.4.0 to fix dbus errors in basic UAI logins
 - Released csm-testing v1.12.22 for recent test changes
 - Updated cray-site-init v1.16.9 fixing CHN reservations generation. CASMINST-4372
 - Released csm-testing v1.12.20 for recent test changes

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,12 +29,6 @@ quay.io:
 
 artifactory.algol60.net/csm-docker/stable:
   images:
-    # XXX update-uas v1.3.2 should include these
-    cray-uai-sles15sp2:
-      - 1.3.1
-    cray-uai-broker:
-      - 1.3.1
-
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.59

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: manifests/v1beta1
 metadata:
   name: sysmgmt

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,7 +147,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.3.3
+    version: 1.4.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

Update `update-uas` in the sysmgmt manifest to 1.4.0 from 1.3.3 to fix the DBUS error displayed on login to the Basic UAI.  At the same time, remove the unnecessary and out-of-sync basic and broker UAI images from the list in `docker/index.yaml` after verifying that the correct image is being discovered in the `update-uas` chart and shipped.  This removes two obsolete docker images from the final released blob and eliminates a double (frequently out of sync) source of truth in building CSM.

This is a backward compatible bugfix

## Issues and Related PRs

* Resolves [CASMUSER-2992](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2992)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Reproduced the original problem with update-uas 1.3.3 on vshasta, then verified that the problem is fixed in update-uas 1.4.0.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

There are no known risks with this PR

## Pull Request Checklist

- [ N/A ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

