### PR TITLE
CASMPET-5485: update trustedcerts-operator to use latest alpine 3 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update trustedcerts-operator to 0.6.0 to use latest alpine 3 image (CASMPET-5485)
 - Istio is updated to 1.9.9, OPA envoy plugin to 0.26.0-envoy-6, kiali to 1.33.1 (CASMPET-5303, CASMPET-5359)
 - Released csm-testing v1.12.22 for recent test changes
 - Released csm-testing v1.13.0 for recent test changes

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -176,7 +176,7 @@ spec:
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
-    version: 0.5.0
+    version: 0.6.0
     namespace: pki-operator
   - name: cray-certmanager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Use latest alpine 3 base image from algol60 to reduce the need for engineering efforts to bump the alpine version string for CVE remediation.

## Issues and Related PRs

* Resolves [CASMPET-5485]
* Change will also be needed in `release/1.2.5`

## Testing

### Tested on:

  * `mug`

### Test description:

Upgraded trustedcerts-operator, and made sure no errors are seen from pod logs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

