### PR TITLE
CASMUSER-2994 update update-uas to 1.5.0 fix missing awk in UAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update update-uas to 1.5.0 to fix missing 'awk' basic UAI
 - Update update-uas to 1.4.0 to fix dbus errors in basic UAI logins
 - Update trustedcerts-operator to 0.6.0 to use latest alpine 3 image (CASMPET-5485)
 - Released csm-testing v1.12.22 for recent test changes

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -170,7 +170,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.4.0
+    version: 1.5.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

Update update-uas chart version to 1.5.0 to fix missing `awk` in the Basic UAI image which was causing
the Basic UAI entry-point script to fail to set up the user correctly before first login.

Backwards compatible bugfix.

## Issues and Related PRs

* Resolves [CASMUSER-2994](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2994)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Reproduced problem and verified fix on vshasta.  Upgraded to this version of update-uas and verified that the correct configuration was installed.  Verified that the Basic UAI worked correctly with the new UAI image installed by update-uas.  Downgraded back to update-uas 1.4.0 and verified that the correct config was installed for that version and that the problem returned with the unfixed Basic UAI image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? N/A
- Was upgrade tested? yes
- Was downgrade tested? yes
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

There are no known risks with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

