### PR TITLE
CASMUSER-2994 update update-uas to 1.5.0 fix missing awk in UAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update update-uas to 1.5.0 to fix missing 'awk' basic UAI
 - Update cray-drydock 1.12.2 - adding kyverno namespace
 - Update trustedcerts-operator to 0.6.0 to use latest alpine 3 image (CASMPET-5485)
 - Istio is updated to 1.9.9, OPA envoy plugin to 0.26.0-envoy-6, kiali to 1.33.1 (CASMPET-5303, CASMPET-5359)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,7 +147,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.4.0
+    version: 1.5.0
     namespace: services
 
   # Spire service

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: manifests/v1beta1
 metadata:
   name: sysmgmt


### PR DESCRIPTION
## Summary and Scope

Update update-uas chart version to 1.5.0 to fix missing `awk` in the Basic UAI image which was causing
the Basic UAI entry-point script to fail to set up the user correctly before first login.

Backwards compatible bugfix.

## Issues and Related PRs

* Resolves [CASMUSER-2994](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2994)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Reproduced problem and verified fix on vshasta.  Upgraded to this version of update-uas and verified that the correct configuration was installed.  Verified that the Basic UAI worked correctly with the new UAI image installed by update-uas.  Downgraded back to update-uas 1.4.0 and verified that the correct config was installed for that version and that the problem returned with the unfixed Basic UAI image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? N/A
- Was upgrade tested? yes
- Was downgrade tested? yes
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

There are no known risks with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable