### PR TITLE
updated capmc chart to 3.0.1; which pulls in CAPMC 2.1.0 which is the…

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -21,7 +21,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 2.0.5
+    version: 3.0.1
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
… v1 partial deprecation

## Summary and Scope

pulls in the changes related to: https://github.com/Cray-HPE/hms-capmc/pull/64

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASM-2648
* Documentation changes  might be required but Ive read: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/CAPMC_deprecation.md and this still seems valid.

## Testing

the chart changes and service changes were tested on Mug

### Test description:


- Were continuous integration tests run? Y
- Was upgrade tested?Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations



## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

