### PR TITLE
Pass curl image to etcd operator via values.yaml

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60
-    version: 0.17.2
+    version: 0.17.3
     namespace: operators
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Finally refactor the etcd operator code such that we can pass in the curl docker image from our chart, eliminating the hard-coding of the image in the operator.

## Issues and Related PRs

* Resolves [CASMINST-4465](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4465)

## Testing

Controller startup/restore logs:
```
time="2022-04-18T20:13:25Z" level=info msg="Go Version: go1.15.7"
time="2022-04-18T20:13:25Z" level=info msg="Go OS/Arch: linux/amd64"
time="2022-04-18T20:13:25Z" level=info msg="etcd-restore-operator Version: 0.12.6-cray"
time="2022-04-18T20:13:25Z" level=info msg="Git SHA: 0f4c7639"
time="2022-04-18T20:13:25Z" level=info msg="Curl image version: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.73.0"
.
.
time="2022-04-18T20:15:13Z" level=info msg="serving backup for restore CR cray-bss-etcd"
```

Successful restore pod using new image:
```
cray-bss-etcd-74nhj9cwfk                                          1/1     Running            0          52s
cray-bss-etcd-g7g7qlvp4s                                          1/1     Running            0          102s
cray-bss-etcd-z57n2rwz99                                          1/1     Running            0          84s
.
.
ncn-m001-990dc214:/home/bklein # kubectl get po -n services cray-bss-etcd-g7g7qlvp4s -o yaml | grep ' image.*curl:7'
    image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.73.0
```

### Tested on:

  * `vshasta`

### Test description:

Deploy chart with updated values.yaml and new operator image.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
