### PR TITLE
CASMCMS-7965 - fix cray-cfs-api annoataion information to correct image packaging.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -82,7 +82,7 @@ spec:
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.10.3
+    version: 1.10.5
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Change the chart annotations to match the actual redis image used. This impacts the images that are packaged in a release and what is scanned for CVE vulnerabilities. It does not impact the actual use of the service.

## Issues and Related PRs
* Resolves [CASMCMS-7965](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7965)

## Testing
### Tested on:
  * `Wasp`

### Test description:
Installed the new version with loftsman, ran the ct tests (successfully), reverted back to the original install, then re-ran the ct tests to insure everything is still working correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is low risk as it is just modifying helm chart annotations.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

