### PR TITLE
CASMINST-4246:  Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image
 - Update cray-drydock 1.12.2 - adding kyverno namespace
 - Update trustedcerts-operator to 0.6.0 to use latest alpine 3 image (CASMPET-5485)
 - Istio is updated to 1.9.9, OPA envoy plugin to 0.26.0-envoy-6, kiali to 1.33.1 (CASMPET-5303, CASMPET-5359)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: manifests/v1beta1
 metadata:
   name: sysmgmt
@@ -147,7 +170,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.4.0
+    version: 1.6.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION

## Summary and Scope

This adds a new cray-uai-gateway-test image.   This image includes the API gateway tests and will be used for executing those tests at various times to ensure the gateways are isolated/accessible on the proper networks.

There was discussion of bringing the ADMIN_CLIENT_SECRET and other configuration items like the SYSTEM_DOMAIN and USER_NETWORK into the container using secrets and volumes so the test could be run automatically in the entrypoint.sh.   For now, I opted to instead inject those values into a vars.sh file via kubectl exec commands and then execute the test.  That is all driven by a bash script which makes it easy to run the tests from an NCN.  We may choose later to take the next step of running the tests in the entrypoint but this seems to work well for now and takes care of the lifecycle of this test pod.

## Issues and Related PRs

* Resolves CASMINST-4246

## Testing

### Tested on:

  * `hela`

### Test description:

There is a separate test script that will be added to the docs-csm repo for executing the UAI tests.  I used that script to create a UAI with this image and then execute the tests that are in the image with the proper inputs.   I tested both success and failure cases to ensure that clear output is given in both cases.