### PR TITLE
CASMINST-4246:  Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
-
+- Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image
 - Update update-uas to 1.5.0 to fix missing 'awk' basic UAI
 - Update update-uas to 1.4.0 to fix dbus errors in basic UAI logins
 - Update trustedcerts-operator to 0.6.0 to use latest alpine 3 image (CASMPET-5485)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -170,7 +170,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

This adds a new cray-uai-gateway-test image.   This image includes the API gateway tests and will be used for executing those tests at various times to ensure the gateways are isolated/accessible on the proper networks.

There was discussion of bringing the ADMIN_CLIENT_SECRET and other configuration items like the SYSTEM_DOMAIN and USER_NETWORK into the container using secrets and volumes so the test could be run automatically in the entrypoint.sh.   For now, I opted to instead inject those values into a vars.sh file via kubectl exec commands and then execute the test.  That is all driven by a bash script which makes it easy to run the tests from an NCN.  We may choose later to take the next step of running the tests in the entrypoint but this seems to work well for now and takes care of the lifecycle of this test pod.

## Issues and Related PRs

* Resolves CASMINST-4246

## Testing

### Tested on:

  * `hela`

### Test description:

There is a separate test script that will be added to the docs-csm repo for executing the UAI tests.  I used that script to create a UAI with this image and then execute the tests that are in the image with the proper inputs.   I tested both success and failure cases to ensure that clear output is given in both cases.