### PR TITLE
casmpet-5479: remove references to no longer existing etcd selfLink m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-utils v1.2.8 for recent changes
 - Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image
 - Update update-uas to 1.5.0 to fix missing 'awk' basic UAI
 - Update update-uas to 1.4.0 to fix dbus errors in basic UAI logins

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -59,7 +59,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-sls-ct-test-1.11.0-1.x86_64
     - hms-smd-ct-test-1.48.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
-    - platform-utils-1.2.7-1.noarch
+    - platform-utils-1.2.8-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-1.3.2-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.2.8 released version of csm-utils
Update changelog: - Released csm-utils v1.2.8 for recent changes
This pulls in changes for:
* CASMPET-5479

### Summary and Scope
Master - CASMPET-5479: Remove references to no longer existing etcd selfLink metadata attribute.

With new versions of etcd and kubernetes in 1.2, the etcd selfLink metadata atribute is no longer in use. As a result all etcd restore/rebuild operations fail. Remove references to selfLink metadata atribute in edit_yaml_for_rebuild.py.

At same time:
Add missing exit in move_pods.sh help function.
Enable ncnHealthchecks.sh tool to report csm version on system.
Use dynamic PROGNAME in grafterm.sh rather than hardcoded "grafterm".

Validate updated utilities on mug, csm 1.2.0-beta.52 and drax, csm 1.2.0-beta.104, and on wasp, 1.2.0-beta.102, with CASMINST-4465 fixes applied.

### Issues and Related PRs
CASMPET-5479

### Testing
Validated on mug, csm 1.2.0-beta.52 and drax, csm 1.2.0-beta.104, and on wasp, 1.2.0-beta.102, with CASMINST-4465 fixes applied.
