### PR TITLE
CASMPET-5534: Update cray-oauth2-proxy to use CSM built container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-oauth2-proxy to use CSM built container image (CASMPET-5534)
 - Released csm-utils v1.2.8 for recent changes
 - Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image
 - Update cray-drydock 1.12.2 - adding kyverno namespace

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -276,5 +276,5 @@ spec:
     namespace: services
   - name: cray-oauth2-proxies
     source: csm-algol60
-    version: 0.1.2
+    version: 0.2.0
     namespace: services


### PR DESCRIPTION
## Summary and Scope

This PR changes the cray-oauth2-proxies chart v0.2.0 to use CSM built container image. 

## Issues and Related PRs

* Resolves [CASMPET-5534]

## Testing

### Tested on:

  * `wasp`

### Test description:

Deployed the new helm chart, and verified the following test script still PASS:

tests/install/livecd/scripts/monitoring_check.sh

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

