### PR TITLE
adding cray-canu image and bumping canu rpm version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -31,7 +31,7 @@ artifactory.algol60.net/csm-docker/stable:
   images:
     # adding cray-canu image till there is a chart
     cray-canu
-      - 1.5.6
+      - 1.5.7
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.59

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,6 +29,9 @@ quay.io:
 
 artifactory.algol60.net/csm-docker/stable:
   images:
+    # adding cray-canu image till there is a chart
+    cray-canu
+      - 1.5.6
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.59

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.8-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.3.2-1.x86_64
+    - canu-1.5.6-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.32-1.noarch
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.8-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.5.6-1.x86_64
+    - canu-1.5.7-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.32-1.noarch
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- added cray-canu container image
- bumped canu-1.5.6 rpm
- Feature: LAG preserve to help in adopting CANU
- Feature: Send arbitrary read-only commands to switches.
- Many switch configuration template fixes.
- Many docs updates and changes.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
- yes
## Issues and Related PRs
- CASMNET-1518

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._
Release notes https://github.com/Cray-HPE/canu/releases/1.5.6

## Testing

- local
- hela

### Tested on:

- local
- gamora
- jolt1
- wasp
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_yes

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?no
- Were continuous integration tests run? If not, why?no
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
- none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [ x Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

