### PR TITLE
bug/CASMNET-1385 - csm-1.2cray-dhcp-kea version bump for CASMNET-1385

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,7 +41,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.4 # update platform.yaml cray-precache-images with this
+    version: 0.10.5 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -64,7 +64,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.4
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.5
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.6
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- Background
  - a place holder dhcp lease is a dhcp reservation added via the kea api that the hardware is not renewed their lease yet or has stopped renewing their lease(like the rosetta management port, see https://jira-pro.its.hpecorp.net:8443/browse/SSHOTPLAT-1151?focusedCommentId=3404829&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-3404829)
  - place holder dhcp leases helps speed up DNS record generation for unbound-manager 3 way check.
- Problem 
  - a race condition can occur when you want to remove an IP in SMD EthernetInterfaces that is set for a dhcp reservation.  the placeholder lease can put back the IP into SMD EthernetInterfeces  
- Solution
  - when creating place holder lease, uniquely identify them with a different lease expire time and when loading active leases from kea, filter out the placeholder lease by identifying them with their lease expire time that is not the same as standard lease.
  - The reason the PR looks like a large amount of code change was wrapping a section of logic around the filtering of leases by the lease expire time
- Impact
  - When troubleshooting live systems it is sometimes necessary to remove bad entries from SMD.  This bug can cause that troubleshooting to fail because bad entries removed from SMD can be automatically regenerated, causing a very frustrating experience for admins.  This fix prevents these failure cases and will improve future troubleshooting efforts.


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

CASMNET-1385

## Testing

_List the environments in which these changes were tested._

### Tested on:

- hela
- fanta

### Test description:

- test #1
  - injected a place holder lease via kea api
  - verified dhcp-helper.py did not add the record into SMD EthernetInterfaces table
- test #2 
  - manually added an dhcp reservation entry into SMD EthernetInterfaces 
    - verified place holder lease created
  - removed the IP on test SMD EthernetInterface entry
    - verified IP was not put back into SMD EthernetInterfaces test entry  

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?na
- Were continuous integration tests run? If not, why?na
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

- no
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

