### PR TITLE
Include latest 1.3 images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.3.0/kubernetes-0.3.0.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.3.0/5.3.18-150300.59.43-default-0.3.0.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.3.0/initrd.img-0.3.0.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.3.1/kubernetes-0.3.1.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.3.1/5.3.18-150300.59.43-default-0.3.1.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.3.1/initrd.img-0.3.1.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.3.0/storage-ceph-0.3.0.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.3.0/5.3.18-150300.59.43-default-0.3.0.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.3.0/initrd.img-0.3.0.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.3.1/storage-ceph-0.3.1.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.3.1/5.3.18-150300.59.43-default-0.3.1.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.3.1/initrd.img-0.3.1.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
New 0.3.1 images including MTL-1660.

This also includes the following commits to the node-image-build repo:
- 65fde2499 (HEAD -> develop, tag: 0.3.1-4, origin/develop, origin/cleanup_workflow, origin/HEAD, cleanup_workflow) Handle all lts branches
- 17e32bbaf Quote Secret and Fix Missing Quote
- c6890a8df Remove duplicate file; rename main file
- 3a0a571e1 (tag: 0.3.1-3, origin/build-against-latest-main, build-against-latest-main) Update "csm-rpms" from "git@github.com:Cray-HPE/csm-rpms.git@main"
- a23107ffc Squashed 'vendor/github.com/Cray-HPE/csm-rpms/' changes from 2399afe4..4c172ed7
- 2db8d2c6f (tag: 0.3.1-2, origin/CASMTRIAGE-3193-develop) fixup labeler workflow
- 3d5692759 CASMTRIAGE-3193 fix kdump not working
- be00e5308 (origin/MTL-1591) MTL-1591: Remove kernel debug RPMs
- 1a2ff24a6 (tag: 0.3.1-1, origin/main, main) MTL-1667: Move base layer steps to common layer.
- 41da1550d (origin/MTL-1660-add-Ansible-NCN-common, MTL-1660-add-Ansible-NCN-common) Squashed 'vendor/github.com/Cray-HPE/csm-rpms/' changes from 6aaf2f06..2399afe4
- 3da1b9c54 MTL-1660 Add Ansible Virtualenv for CSM
- 38e019ddd (origin/CASMINST-4427-develop, CASMINST-4427-develop) CASMINST-4427: Move ldms sysctl config to ncn-common
- da5ccf23b (origin/Release, origin/CASMINST-4310-develop) CASMINST-4310: Add *.amslabs.hpecorp.net entries to containerd