### PR TITLE
Metallb chart change to wait for deployment/daemonsets to rollout before applying pod priority

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -264,7 +264,7 @@ spec:
     namespace: operators
   - name: cray-metallb
     source: csm-algol60
-    version: 1.1.0
+    version: 1.1.1
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This change will wait to apply pod priorities to the metallb controller/speaker pods until the initial chart deployment has completed spinning up the pods.

## Issues and Related PRs

* Resolves [CASMINST-4510](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4510)

## Testing

```
ncn-m001-fec36008:/home/bklein # kubectl -n metallb-system logs cray-metallb-patch-pod-priority-1-mgkb9 -f
Waiting for deployment "metallb-controller" rollout to finish: 0 of 1 updated replicas are available...
deployment "metallb-controller" successfully rolled out
Waiting for daemon set "metallb-speaker" rollout to finish: 6 of 9 updated pods are available...
Waiting for daemon set "metallb-speaker" rollout to finish: 7 of 9 updated pods are available...
Waiting for daemon set "metallb-speaker" rollout to finish: 8 of 9 updated pods are available...
Waiting for daemon set spec update to be observed...
Waiting for daemon set "metallb-speaker" rollout to finish: 0 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 1 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 1 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 2 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 2 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 3 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 3 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 4 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 4 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 5 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 5 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 5 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 6 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 6 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 7 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 7 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 8 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 8 out of 9 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 8 of 9 updated pods are available...
daemon set "metallb-speaker" successfully rolled out
Reconfiguring metallb controller deployment to include pod-priority class name
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
deployment.apps/metallb-controller configured
Reconfiguring metallb speaker daemonset to include pod-priority class name
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
daemonset.apps/metallb-speaker configured
```

### Tested on:

  * Virtual Shasta

### Test description:

Deployed the chart and watched the job wait for the daemonset and deployment to finish before applying pod priority.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


