### PR TITLE
casmpet-5560: specify first field returned to correct 13h not found e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-utils v1.2.9 for recent changes
 - Released csm-utils v1.2.8 for recent changes
 - Update update-uas to v1.6.0 - Adding cray-uai-gateway-test image
 - Update update-uas to 1.5.0 to fix missing 'awk' basic UAI

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -59,7 +59,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-sls-ct-test-1.11.0-1.x86_64
     - hms-smd-ct-test-1.48.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
-    - platform-utils-1.2.8-1.noarch
+    - platform-utils-1.2.9-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-1.5.7-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.2.9 released version of csm-utils
Update changelog: - Released csm-utils v1.2.9 for recent changes
This pulls in changes for:
    CASMPET-5560

### Summary and Scope
1.2 - CASMPET-5560: specify first field returned to correct 13h not found error.

Only keep/use the first field returned.

Validate updated utilities on drax, csm 1.2.0-rc.1 and wasp, 1.2.0-beta.102, with CASMINST-5560 fix applied.

### Issues and Related PRs
CASMPET-5560

### Testing
Validated on drax, csm 1.2.0-rc.1 and wasp, 1.2.0-beta.102.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A
