### PR TITLE
CASMPET-5566: add image annotations to node-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-node-discovery 1.2.4 for sec vulnerability (CASMPET-5566)
 - Released csm-utils v1.2.9 for recent changes
 - Update cray-oauth2-proxy to use CSM built container image (CASMPET-5534)
 - Released csm-utils v1.2.8 for recent changes

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,7 +240,7 @@ spec:
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
-    version: 1.2.1
+    version: 1.2.4
     namespace: services
   - name: gatekeeper-policy-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Use node-discovery 1.2.4 for CVE remediation. The older 1.2.1 version has not been rebuilt for a few months.

## Issues and Related PRs

* Resolves [CASMPET-5566]
* Change will also be needed in `release/1.2`

## Testing

### Tested on:

  * `wasp`
  
### Test description:

Deployed the new node-discovery chart, deleted a label from one of the worker nodes and verified that it gets added back shortly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

