### PR TITLE
CASMTRIAGE-3263: Improve kube-api haproxy failover using http instead of tcp check

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.76/kubernetes-0.2.76.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.76/5.3.18-150300.59.43-default-0.2.76.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.76/initrd.img-0.2.76.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.78/kubernetes-0.2.78.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.78/5.3.18-150300.59.43-default-0.2.78.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.78/initrd.img-0.2.78.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.76/storage-ceph-0.2.76.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.76/5.3.18-150300.59.43-default-0.2.76.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.76/initrd.img-0.2.76.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.78/storage-ceph-0.2.78.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.78/5.3.18-150300.59.43-default-0.2.78.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.78/initrd.img-0.2.78.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

Code: https://github.com/Cray-HPE/node-image-build/pull/251