### PR TITLE
CASMINST-4533 Add pit-init 1.2.19

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220422210645-g18016f7.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220422210645-g18016f7.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220422210645-g18016f7.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220428153442-g18016f7.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220428153442-g18016f7.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220428153442-g18016f7.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - dracut-metal-mdsquash-1.9.3-1.noarch
     - metal-basecamp-1.1.9-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - pit-init-1.2.18-1.noarch
+    - pit-init-1.2.19-1.noarch
     - pit-nexus-1.1.0-1.1.x86_64
     - ilorest-3.2.3-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This includes the `yq` package, and a small tweak from pit-init 1.2.19. If `/usr/bin/yq` exists, it'll be a symlink not a file. The current -f test fails to find it if it exists. This change tests for its existence with command.

This also sets up the need for `CSM_PATH` only when `/usr/bin/yq` is not present.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

No.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4533](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4533)
* **This change is already in `main`**

