### PR TITLE
CASMINT-3275 - manuf network interface vendor lookup doesn't always r…

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,7 +41,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.6 # update platform.yaml cray-precache-images with this
+    version: 0.10.7 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -64,7 +64,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.6
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.7
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.6
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5


### PR DESCRIPTION
…eturn a string, enforce string return

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
-  manuf network interface vendor lookup doesn't always return a string and crash dhcp-helper.py
  - one line change to dhcp-helper.py https://github.com/Cray-HPE/cray-dhcp-kea/pull/34/files

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

CASMTRIAGE-3275
## Testing

_List the environments in which these changes were tested._

### Tested on:

- found and solution verified on drax
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?na
- Were continuous integration tests run? If not, why?na
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

none


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

