### PR TITLE
CASMPET-5567: release cray-postgres-operator 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-postgres-operator 0.14.0 to trigger image auto rebuild (CASMPET-5567)
 - Released cray-node-discovery 1.2.4 for sec vulnerability (CASMPET-5566)
 - Released csm-utils v1.2.9 for recent changes
 - Update cray-oauth2-proxy to use CSM built container image (CASMPET-5534)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,7 +220,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 0.13.0
+    version: 0.14.0
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Release cray-postgres-operator 0.14.0 to trigger image auto rebuild of underlying images (e.g., postgres-operator) for CVE remediation.

## Issues and Related PRs

* Resolves [CASMPET-5567]
* Change will also be needed in `release/1.2`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `wasp`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

