### PR TITLE
Add patroni service restarts for lagging PG members before checking lag

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.26-1.noarch
+    - csm-testing-1.12.27-1.noarch
     - docs-csm-1.13.14-1.noarch
-    - goss-servers-1.12.26-1.noarch
+    - goss-servers-1.12.27-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Add service restart for patroni service in lagging members before validating lag (required when bouncing masters due to backoff in postgres pods that's not tunable), as well as correct lag check to exec into the leader.

## Issues and Related PRs

* Resolves [CASMINST-4544](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4544)

## Testing

Ran many times on surter when rebuilding master node.

### Tested on:

  * `surtur`

### Test description:

Ran many times

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable