### PR TITLE
CASMTRIAGE-3253: Bump CSI version to 1.17.1

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220502180335-g10e2532.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220502180335-g10e2532.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220502180335-g10e2532.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220502203317-g10e2532.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220502203317-g10e2532.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220502203317-g10e2532.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.15-1.x86_64
+    - cray-site-init-1.17.1-1.x86_64
     - metal-basecamp-1.1.12-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
     - pit-init-1.2.19-1.noarch


### PR DESCRIPTION
#### Summary and Scope

- Fixes #CASMTRIAGE-3253

##### Issue Type

- Bugfix Pull Request

Renames the uai_macvlan_bridge reservation in the uai_macvlan subnet to uai_nmn_blackhole.   uai_macvlan_bridge is no longer being used.  We are repurposing that reservation to be used as the gw for the NMNLB route in UAIs.  This will block access to the NMNLB from the UAI.

While in the same same section of code, I also made the allocation of IPs to the uai_macvlan reservations consistent.  This solves the issue with running CSI multiple times and ending up with different IPs for these reservations.


##### Testing

Built CSI locally and ran the `csi config init` with seed files from hela.   Checked the generated sls_input_file.json and customizations.yaml. 