### PR TITLE
CASMPET-5591: Bump cray-nexus to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-nexus 0.10.2 to allow image auto rebuild (CASMPET-5591)
 - Released cray-postgres-operator 0.14.0 to trigger image auto rebuild (CASMPET-5567)
 - Released csm-utils v1.2.9 for recent changes
 - Released cray-node-discovery 1.2.4 for sec vulnerability (CASMPET-5566)

--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.10.1
+    version: 0.10.2
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -77,7 +77,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2
+      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
   - name: gatekeeper
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -77,7 +77,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0
+      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
   - name: gatekeeper
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This changes the location of the nexus3 image. It is in a process to move the location of the image build from the nexus3 repository to the container-images repository. The image being pulled adds no new or changing function only rebuild location as the nexus3 repository no longer can rebuild the image properly.

## Issues and Related PRs

* Resolves [CASMPET-5591](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5591)
* Future work required by [CASMPET-5592](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5592)

## Testing

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

Tested by running on vshasta by logging into nexus via the keycloak integration.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

No known risk to this change

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

