### PR TITLE
CASMINST-4538 & CASMINST-4548 Goss test improvements (main)

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -39,9 +39,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.14.13-1.noarch
+    - csm-testing-1.14.14-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.14.13-1.noarch
+    - goss-servers-1.14.14-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -39,9 +39,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.14.12-1.noarch
+    - csm-testing-1.14.13-1.noarch
     - docs-csm-1.13.9-1.noarch
-    - goss-servers-1.14.12-1.noarch
+    - goss-servers-1.14.13-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
Pull in two Goss test improvements:
* [CASMINST-4538](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4538) - artifacts-in-place preflight check also validate that squashfs is customized. (For details see [source PR](https://github.com/Cray-HPE/csm-testing/pull/297))
This allows us to remove a manual step from the install procedure.
* [CASMINST-4548](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4548) - Correct issues with Goss Weave test; fold Weave test from Deploy Management Nodes into it. (For details see [source PR](https://github.com/Cray-HPE/csm-testing/pull/299))
