### PR TITLE
CASMINST-4549 main

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-site-init-1.16.15-1.x86_64
+    - cray-site-init-1.16.17-1.x86_64
     - metal-basecamp-1.1.12-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
     - pit-init-1.2.21-1.noarch


### PR DESCRIPTION
## Summary and Scope

- In order to have interoperability between the HMN-SHCD parser and CANU we need to be able to have 0 as a destination port number on the HMN tab of the SHCD.
- This change allows SLS to accept 0 as a port number.  This is the same behavior as leaving it blank.


- Fixes # CASMINST-4549

## Testing

Tested locally.  All tests passed.
Generated SLS file has no differences with a "" or "0" as port destination.
