### PR TITLE
Point to locally built alpine image, fix upgrade issue for configmap for cray-precache-images

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -44,7 +44,7 @@ spec:
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60
-    version: 0.5.0
+    version: 0.5.1
     namespace: nexus
     values:
       cacheRefreshSeconds: "120"


### PR DESCRIPTION
## Summary and Scope

Fix alpine image for cray-precache-images chart, force pod restarts on upgrade, and fix wait-for job.

## Issues and Related PRs

* Resolves [CASMINST-4568](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4568)

## Testing

```
ncn-m001-fec36008:/home/bklein # kubectl logs -n nexus pod/wait-for-cray-precache-images-pods-m898g -f
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "cray-precache-images" rollout to finish: 5 of 6 updated pods are available...
daemon set "cray-precache-images" successfully rolled out
```

### Tested on:

  * Virtual Shasta

### Test description:

Tested multiple upgrades in vshasta, watched the wait job wait for pods to recycle, saw configmap updated with new values.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable