### PR TITLE
CASMINST-4505: use spire 2.5.0 for CVE remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)
 - Released cray-nexus 0.10.2 to allow image auto rebuild (CASMPET-5591)
 - Released cray-postgres-operator 0.14.0 to trigger image auto rebuild (CASMPET-5567)
 - Released csm-utils v1.2.9 for recent changes

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,5 +179,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.4.0
+    version: 2.5.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Release spire 2.5.0 to use newly rebuilt images (spire-tokens & wait-for-it) for CVE remediation.

## Issues and Related PRs

* Resolves [CASMINST-4505](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4505)
* Change will also be needed in `main`

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Upgraded spire chart; validated that it uses the new images, and ncn-join-tokens are generated correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

