### PR TITLE
CASMINST-4565/CASMINST-4576: Goss test improvements

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.29-1.noarch
+    - csm-testing-1.12.30-1.noarch
     - docs-csm-1.13.14-1.noarch
-    - goss-servers-1.12.29-1.noarch
+    - goss-servers-1.12.30-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
[CASMINST-4565](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4565) Enhance kube-system Goss test to remove need for manual test during Deploy Management Nodes install procedure.
[CASMINST-4576](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4576) Validate that ceph -s works where and when it ought to. This would have caught a problem on the gamora install much earlier and saved hours of time.

See source PRs for full details:
https://github.com/Cray-HPE/csm-testing/pull/301
https://github.com/Cray-HPE/csm-testing/pull/304
