### PR TITLE
CASMNET-1240:  Update update-uas to v1.6.1 - Updated test cray-uai-gateway-test image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update update-uas to v1.6.1 - Updated test in cray-uai-gateway-test image
 - Released cray-nexus 0.10.2 to fix auto rebuild of nexus image (CASMPET-5591)
 - Released cray-postgres-operator 0.14.0 to trigger image auto rebuild (CASMPET-5567)
 - Released cray-node-discovery 1.2.4 for sec vulnerability (CASMPET-5566)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -173,7 +173,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

Made some enhancements to the gateway-test.py script to better handle failure conditions when getting tokens.   We don't want to fail immediately that case.   We want to move on to the other networks to test those before failing.  
This also adds support for additional node types.   Trying to keep this copy in the gateway-test image in sync with the one in docs-csm for other nodes.

## Issues and Related PRs

* Relates to CASMNET-1240

## Testing

### Tested on:

  * `drax`, `surtur`, and `hela`

### Test description:

Launched a UAI with the gateway-test image, copied the updated gateway-test.py into the image and ran `run-test.sh`.   Verified that the test runs across all networks on systems with and without the fix to block the NMN network.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
