### PR TITLE
Export system domain name to Fabric Manager container 

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -587,7 +587,6 @@ spec:
             authJwksUrl: http://cray-keycloak-http.services.svc.cluster.local/keycloak/realms/shasta/protocol/openid-connect/certs
       slingshot-fabric-manager:
         base_domain: {{ network.dns.external }}
-        telemetry_collector_url: https://api.nmnlb.{{ network.dns.external }}/apis/fabric-manager/telemetry-collector
       sma-zk-kafka:
         kafkaPVCSize: 65Gi
         zkPVCSize: 1Gi

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -585,6 +585,9 @@ spec:
         config:
           server:
             authJwksUrl: http://cray-keycloak-http.services.svc.cluster.local/keycloak/realms/shasta/protocol/openid-connect/certs
+      slingshot-fabric-manager:
+        base_domain: {{ network.dns.external }}
+        telemetry_collector_url: https://api.nmnlb.{{ network.dns.external }}/apis/fabric-manager/telemetry-collector
       sma-zk-kafka:
         kafkaPVCSize: 65Gi
         zkPVCSize: 1Gi


### PR DESCRIPTION
SSHOTMGP-5040 Export system domain name to Fabric Manager container

## Summary and Scope

Slingshot need to get Base-domain to config slingshot switches with telemetry url . i am adding base-domain. Earlier versions we used to use static basename "api-gw-service-nmn.local" 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ 
its not backward compatible but not a breaking change for us . 

## Issues and Related PRs

-  SSHOTMGP-5040 Export system domain name to Fabric Manager container
* Change will also be needed in shasta CSM 1.2 


## Testing 
will test asap 

## Risks and Mitigations

No real risk as its a env variable. 


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable 
Not sure its applicable for my change
- [ ] Copyrights updated 
NA
- [ ] License file intact
Yes
- [ ] Target branch correct
Yes
- [ ] CHANGELOG.md updated 
Not sure its applicable for my change
- [ ] Testing is appropriate and complete, if applicable
Not sure its applicable for my change
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
Not sure its applicable for my change

