### PR TITLE
CASMINST-4446: Bump csm-testing and goss-servers to 1.12.32

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.29-1.noarch
+    - csm-testing-1.12.32-1.noarch
     - docs-csm-1.13.14-1.noarch
-    - goss-servers-1.12.29-1.noarch
+    - goss-servers-1.12.32-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This test will always check to see if the bond0.can0 interface exists on the worker and master nodes.   However, this interface not exist if the system was configured with CHN instead of CAN.   This changes the test into a script that checks the BICAN network configuration in SLS to determine if it is CAN or CHN.   It will only check for the bond0.can0 interface if it is configured for CAN.

## Issues and Related PRs

* Resolves CASMINST-4446

## Testing

### Tested on:

  * `surtur` and `wasp`

### Test description:

I ran this goss test on wasp where it is configured for CHN and previous failed.  It now passes there.
I also ran this goss test on surtur where it was configured for CAN to make sure it still passes there.

Wasp:
```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-network-interfaces.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
....

Total Duration: 0.283s
Count: 4, Failed: 0, Skipped: 0
```

I also ran through several injected negative test cases (not able to get secret, not able to pull token, etc.) to test the error checking.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

