### PR TITLE
CASMTRIAGE-3280 1.2

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.79/kubernetes-0.2.79.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.79/5.3.18-150300.59.43-default-0.2.79.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.79/initrd.img-0.2.79.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.80/kubernetes-0.2.80.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.80/5.3.18-150300.59.43-default-0.2.80.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.80/initrd.img-0.2.80.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.79/storage-ceph-0.2.79.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.79/5.3.18-150300.59.43-default-0.2.79.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.79/initrd.img-0.2.79.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.80/storage-ceph-0.2.80.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.80/5.3.18-150300.59.43-default-0.2.80.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.80/initrd.img-0.2.80.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
#### Summary and Scope

- Fixes # CASMTRIAGE-3280

##### Issue Type

- Bugfix Pull Request

We tracked down the root cause of weave split-brain on gamora.  The issue was caused by weave pods starting up before enough of the nodes have joined the cluster.   More details in https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3280.   To fix this, we are waiting for a quorum of nodes to join the cluster before applying the network manifests.   We tried this process manually on gamora and we were able to see the expected results in the weave logs showing that they had a enough peers in the peer list to avoid splitting the two masters into two separate seed groups.

#### Prerequisites

- [N/A] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
 
#### Risks and Mitigations
 
This code will be smoke tested on gamora to mitigate risk.
