### PR TITLE
CASMPET-5602: release sealed-secrets 0.3.0 to use new image location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released sealed-secrets 0.3.0 to use new image location (CASMPET-5602)
 - Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)
 - Update update-uas to v1.6.1 - Updated test in cray-uai-gateway-test image
 - Released cray-nexus 0.10.2 to fix auto rebuild of nexus image (CASMPET-5591)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -140,7 +140,7 @@ spec:
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60
-    version: 0.2.0
+    version: 0.3.0
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR use sealed-secrets 0.3.0 for updated image location, as it was moved from quay.io to docker.io.

## Issues and Related PRs

* Resolves[CASMPET-5602](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5602)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Upgraded the sealed-secrets chart, and made sure that the secrets were unsealed successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

