### PR TITLE
CASMNET-1528 - BI-CAN: Create CFS play that will setup CHN IP on NCNs after HSN install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)
 - Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)
 - Update update-uas to v1.6.1 - Updated test in cray-uai-gateway-test image
 - Released cray-nexus 0.10.2 to fix auto rebuild of nexus image (CASMPET-5591)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.27
+    version: 1.9.31
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION


## Summary and Scope

Ansible role to determine whether the bifurcated CAN is configured to use CAN or CHN by reading the systemDefaultRoute property from the BICAN SLS network. In the case that CHN is defined configure the CHN IP addresses on the worker HSN interfaces.

## Issues and Related PRs

* Resolves [CASMNET-1528](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1528)
* Documentation will be addressed via [CASMINST-4135](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4135)

## Testing

### Tested on:

  * `hela` - systemDefaultRoute = CHN
  * `wasp` - systemDefaultRoute = CAN

### Test description:

wasp - Verified that this role does nothing beyond query SLS on a system configured to use CAN.

hela - Verified the following scenarios
  * CHN IP address is applied successfully if HSN interface is configured
     ```
    TASK [csm.ncn.enable_chn : Check that the hsn0 interface has the expected IP] ***
    changed: [x3000c0s7b0n0]
    ```
  * Role fails appropriately if the required HSN interface does not exist.
     ```
    TASK [csm.ncn.enable_chn : FAIL if hsn0 is not found] **************************
    fatal: [x3000c0s7b0n0]: FAILED! => {"changed": false, "msg": "Interface hsn0 not found."}
    ```
  * Role fails appropriately if the SLS CHN network lacks an IP reservation for the node.
    ```
    TASK [csm.ncn.enable_chn : FAIL if CHN IP is not defined] **********************
    fatal: [x3000c0s7b0n0]: FAILED! => {"changed": false, "msg": "CHN IP is not defined for ncn-w004"

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

