### PR TITLE
MTL-1740 Faster pit-init

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-site-init-1.17.4-1.x86_64
     - metal-basecamp-1.1.13-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - pit-init-1.2.22-1.noarch
+    - pit-init-1.2.23-1.noarch
     - pit-nexus-1.1.3-1.x86_64
     - ilorest-3.2.3-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64


### PR DESCRIPTION
new pit-init with fixes from shellcheck ([MTL-1497](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1497)).

`metalid.sh` now prints a lot faster.