### PR TITLE
CASMINST-4618: Bump csm-testing and goss-servers to 1.12.33

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -42,9 +42,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.12.32-1.noarch
+    - csm-testing-1.12.33-1.noarch
     - docs-csm-1.13.15-1.noarch
-    - goss-servers-1.12.32-1.noarch
+    - goss-servers-1.12.33-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

The check_network_interface.sh fails when it is run during livecd preflight checks because the k8s cluster has not been created yet.   Therefore, it could not run kubectl to get the admin client secret.

It also fails on all of the storage nodes except for s001.   Only s001 has the k8s admin credentials to be able to run kubectl.

The fix here is to check if kubectl can be run.   If it cannot, then we will skip checking the can0 interface on the node.  Without being able to get the admin client secret, we cannot get to SLS to determine which user network is configured.

Also added a check for the argument to the script in case it is run independently of the goss test.

## Issues and Related PRs

* Resolves CASMINST-4618


## Testing

### Tested on:

  * `fanta`, `wasp`, and `redbull`

### Test description:

Ran check_network_interface.sh on EVERY NODE on fanta (master, worker, and storage).
Also ran /opt/cray/tests/install/ncn/automated/ncn-healthcheck which is the script that failed
Ran check_network_interface.sh on the PIT node on redbull to test that it will run successfully in the livecd preflight check.
Ran check_network_interface.sh on m001, w001, s001, and s002 of wasp.   This checks the CHN case.
Ran negative tests to check the error checking:
   * Ran check_network_interface.sh with no arguments
   * Ran check_network_interface.sh with empty string argument
   * Ran on a node with no kubectl installed
   * Ran with a bogus interface name


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable