### PR TITLE
CASMINST-4148: Change UAS to rolling update base images

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -169,11 +169,11 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.19.1
+    version: 1.21.0
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.6.1
+    version: 1.7.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
### Summary and Scope

Update uas-mgr and UAI images to use a different base layer. The new layer is kept more up to date to get timely security fixes.

### Issues and Related PRs

* Updates [CASMINST-4148](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4148)

### Testing

  * vshasta

### Tests

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, fresh install with vshasta
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N, covered by existing tests

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

