### PR TITLE
MTL-1530 signed ilorest

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220512221506-g10e2532.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220512221506-g10e2532.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220512221506-g10e2532.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220514052857-g10e2532.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220514052857-g10e2532.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220514052857-g10e2532.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,7 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - metal-net-scripts-0.0.2-1.noarch
     - pit-init-1.2.24-1.noarch
     - pit-nexus-1.1.3-1.x86_64
-    - ilorest-3.2.3-1.x86_64
+    - ilorest-3.5.0-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_


Includes a signed ilorest RPM and a version bump.
```bash
rpm -qi https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/metal-ilorest/x86_64/ilorest-3.5.0-1.x86_64.rpm
Name        : ilorest
Version     : 3.5.0
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : System/Configuration/Packaging
Size        : 15865347
License     : Copyright 2016-2021 Hewlett Packard Enterprise Development LP
Signature   : RSA/SHA256, Sat 14 May 2022 05:23:21 AM UTC, Key ID d4dae1e39da39f44
Source RPM  : ilorest-3.5.0-1.src.rpm
Build Date  : Sat 14 May 2022 05:21:49 AM UTC
Build Host  : a403a49170af
Relocations : (not relocatable)
Packager    : Hewlett Packard Enterprise
Vendor      : Hewlett Packard Enterprise
URL         : https://www.hpe.com/info/restfulapi
Summary     : RESTful Interface Tool
Description :
Command line interface for managing HPE ProLiant Servers

Authors:
--------
    Hewlett Packard Enterprise
Distribution: (none)
```

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1530](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1530)
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Ran `bios-baseline.sh`, ilorest successfully started and did the needful.

```bash
ncn-m001:~ # rpm -ivh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/metal-ilorest/x86_64/ilorest-3.5.0-1.x86_64.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/metal-ilorest/x86_64/ilorest-3.5.0-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:ilorest-3.5.0-1                  ################################# [100%]
ncn-m001:~ # rpm -q ilorest
ilorest-3.5.0-1.x86_64
ncn-m001:~ # rpm -iq ilorest
ilorest-3.5.0-1.x86_64
ncn-m001:~ # rpm -qi ilorest
Name        : ilorest
Version     : 3.5.0
Release     : 1
Architecture: x86_64
Install Date: Sat 14 May 2022 05:25:06 AM UTC
Group       : System/Configuration/Packaging
Size        : 15865347
License     : Copyright 2016-2021 Hewlett Packard Enterprise Development LP
Signature   : RSA/SHA256, Sat 14 May 2022 05:23:21 AM UTC, Key ID d4dae1e39da39f44
Source RPM  : ilorest-3.5.0-1.src.rpm
Build Date  : Sat 14 May 2022 05:21:49 AM UTC
Build Host  : a403a49170af
Relocations : (not relocatable)
Packager    : Hewlett Packard Enterprise
Vendor      : Hewlett Packard Enterprise
URL         : https://www.hpe.com/info/restfulapi
Summary     : RESTful Interface Tool
Description :
Command line interface for managing HPE ProLiant Servers

Authors:
--------
    Hewlett Packard Enterprise
Distribution: (none)
ncn-m001:~ # rpm -ivh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/pit-init/noarch/pit-init-1.2.24-1.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/pit-init/noarch/pit-init-1.2.24-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:pit-init-1.2.24-1                ################################# [100%]
ncn-m001:~ # bios-baseline.sh
The running host [ncn-m001-mgmt] will have settings applied last.
Verifying 9 iLO/BMCs (non-compute nodes) match BIOS baseline spec.
================================
Checking ncn-m002-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-m003-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-s001-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-s002-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-s003-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-w001-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-w002-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking ncn-w003-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
================================
Checking (self) ncn-m001-mgmt ... up-to-spec
ipmitool usage: enabled
BMC Shared NIC DHCP: disabled
All NCNs are up-to-spec
Re-run this script with --check as the first and only argument to validate spec.
See logs for reconfigured nodes in /var/log/metal/
ncn-m001:~ # rpm -e pit-init
ncn-m001:~ # rpm -e ilorest
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

