### PR TITLE
CASMPET-5595 Bump cray-drydock to 2.13.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.12.2
+    version: 2.13.0
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
This removes the istio-injection: enabled label from the kyverno namespace. This is not needed per Jeremy Duckworth