### PR TITLE
CASMPET-5635 Bump spire to 2.6.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,5 +179,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.5.0
+    version: 2.6.0
     namespace: spire


### PR DESCRIPTION
This includes a fix where the bos-reporter-spire-agent was incorrectly named, preventing the bos reporter from getting a spire token.