### PR TITLE
Change etcd backup support scripts to not rely on k8s

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -59,7 +59,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-sls-ct-test-1.11.0-1.x86_64
     - hms-smd-ct-test-1.48.0-1.x86_64
     - manifestgen-1.3.3-1~development~1955191.x86_64
-    - platform-utils-1.2.9-1.noarch
+    - platform-utils-1.2.10-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - canu-1.5.7-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Change scripts that support getting files from S3 when restoring bare-metal backup to not depend on kubernetes to get creds (use radosgw-admin instead).

## Issues and Related PRs

* Resolves [CASMPET-5626](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5626)

## Testing

```
ncn-m001-fec36008:/opt/cray/platform-utils/s3 # ./list-objects.py --bucket-name boot-images
foo.txt
foo2.txt
```

```
ncn-m001-fec36008:/opt/cray/platform-utils/s3 # ./download-file.py --bucket-name boot-images --key-name foo2.txt --file-name /var/tmp/foo2.txt
```

```
ncn-m001-fec36008:/opt/cray/platform-utils/s3 # ls -lh /var/tmp/foo2.txt
-rw-r--r-- 1 root root 8 May 16 22:08 /var/tmp/foo2.txt
```

### Tested on:

  * Virtual Shasta

### Test description:

Ran several lists/downloads

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
