### PR TITLE
Add cray-uas-mgr to etcd backup list

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -260,7 +260,7 @@ spec:
     namespace: operators
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.4.1
+    version: 0.4.2
     namespace: operators
   - name: cray-metallb
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Also remove externaldns backup -- no longer there, and fix benign but confusing shell error when creating manual backup.

## Issues and Related PRs

* Resolves [CASMPET-5638](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5638)

## Testing

```
ncn-m001-fec36008:/opt/cray/platform-utils/s3 # ./list-objects.py --bucket-name etcd-backup | grep uas
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:14:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:15:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:16:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:17:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:18:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:19:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:20:09
```

```
ncn-m001-fec36008:/home/bklein # kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- restore_from_backup cray-uas-mgr etcd.backup_v10_2022-05-17-16:19:09
etcdrestore.etcd.database.coreos.com/cray-uas-mgr-etcd created
```

```
cray-uas-mgr-5d859f48d6-pbmxg                                     2/2     Running            84         21d
cray-uas-mgr-5d859f48d6-zkf2p                                     2/2     Running            79         21d
cray-uas-mgr-etcd-9k4z9slrgl                                      1/1     Running            0          47s
cray-uas-mgr-etcd-rb9z6nsdr4                                      1/1     Running            0          2m7s
cray-uas-mgr-etcd-szc6mvg9cs                                      1/1     Running            0          2m45s
```

```
ncn-m001-fec36008:/home/bklein # kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- create_backup cray-uas-mgr bradley-was-here
etcdbackup.etcd.database.coreos.com/cray-uas-mgr-etcd-cluster-manual-backup-30496 created
```

```
ncn-m001-fec36008:/home/bklein # kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- restore_from_backup cray-uas-mgr bradley-was-here
etcdrestore.etcd.database.coreos.com/cray-uas-mgr-etcd created
```

### Tested on:

  * Virtual Shasta

### Test description:

Watched autobackups get taken, restored from one of those (good).  Took manual backup and restored from one of those (good).

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable