### PR TITLE
MTL-1744 Fix RPM Metadata

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220514052857-g10e2532.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220514052857-g10e2532.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220514052857-g10e2532.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220518152024-g10e2532.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220518152024-g10e2532.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.6.0/cray-pre-install-toolkit-sle15sp3.x86_64-1.6.0-20220518152024-g10e2532.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -7,4 +7,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - canu-1.3.2-1.x86_64
-    - metal-ipxe-2.2.6-1.noarch
+    - metal-ipxe-2.2.7-1.noarch


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Presently the distribution and git information is missing from the RPM metadata.

Additionally RPMs are being published to sle-15sp2 after the vendor change. Currently CSM picks up metal-ipxe from sle-15sp3 repos, this change will restore publishing RPMs to sle-15sp3.

Currently:
```bash
Name        : metal-ipxe
Version     : 2.2.7
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 737008
License     : GPLv2
Signature   : RSA/SHA256, Tue 17 May 2022 05:48:23 PM UTC, Key ID d4dae1e39da39f44
Source RPM  : metal-ipxe-2.2.7-1.src.rpm
Build Date  : Tue 17 May 2022 05:46:42 PM UTC
Build Host  : csm-jenkins-metal-builder-b0sfxy.us-central1-a.c.cloudbees-202004.internal
Relocations : (not relocatable)
Vendor      : Cray Inc.
Summary     : iPXE for booting bare metal in HPCaaS environments
Description :
An x86_64 iPXE binary with SecureBoot support and scripts for booting HPC metal. Contents are installed into /var/www/boot/ for serving via TFTP and HTTP.
Distribution: (none)
```

After applying this fix:
```bash
redbull-ncn-m001-pit:~ # rpm -qip https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/metal-ipxe/noarch/metal-ipxe-2.2.7-1~fix_rpm_metadata~20220517234320.009c102.noarch.rpm
Name        : metal-ipxe
Version     : 2.2.7
Release     : 1~fix_rpm_metadata~20220517234320.009c102
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 737008
License     : GPLv2
Signature   : (none)
Source RPM  : metal-ipxe-2.2.7-1~fix_rpm_metadata~20220517234320.009c102.src.rpm
Build Date  : Tue 17 May 2022 11:43:45 PM UTC
Build Host  : csm-jenkins-metal-builder-2nrp0k.us-central1-a.c.cloudbees-202004.internal
Relocations : (not relocatable)
Vendor      : Cray Inc.
URL         : https://github.com/Cray-HPE/metal-ipxe.git
Summary     : iPXE for booting bare metal in HPCaaS environments
Description :
Git Repository: metal-ipxe
Git Branch: fix-rpm-metadata
Git Commit Revision: 009c1020
Git Commit Timestamp: Tue May 17 18:41:40 2022 -0500

An x86_64 iPXE binary with SecureBoot support and scripts for booting HPC metal. Contents are installed into /var/www/boot/ for serving via TFTP and HTTP.
Distribution: SUSE Linux Enterprise Server 15 SP3
```

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1744](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1744)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `redbull`
  * Local development environment
  * Virtual Shasta

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No risks. This adds metadata to the RPM, and then allows more cards to be used for the HSN and MGMT network. No affect on present inventory for HSN or MGMT aside from the additional cards.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

