### PR TITLE
CASMTRIAGE-3326 images with csm_ntp template updates

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.80/kubernetes-0.2.80.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.80/5.3.18-150300.59.43-default-0.2.80.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.80/initrd.img-0.2.80.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.81/kubernetes-0.2.81.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.81/5.3.18-150300.59.43-default-0.2.81.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.81/initrd.img-0.2.81.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.80/storage-ceph-0.2.80.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.80/5.3.18-150300.59.43-default-0.2.80.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.80/initrd.img-0.2.80.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.81/storage-ceph-0.2.81.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.81/5.3.18-150300.59.43-default-0.2.81.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.81/initrd.img-0.2.81.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds images from https://github.com/Cray-HPE/node-image-build/pull/283

## Issues and Related PRs


* Resolves CASMTRIAGE-3326

## Testing

### Tested on:

  * `#redbull`

### Test description:

Fresh install smoke tests.  Ran `csm_ntp.py` and then `chronyc waitsync 6 0.5 0.5 10`

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

