### PR TITLE
CASMPET-5555: use a newer node-problem-detector image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-node-problem-detector 1.9.0 to use a newer image (CASMPET-5555)
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)
 - Released sealed-secrets 0.3.0 to use new image location (CASMPET-5602)
 - Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60
-    version: 1.8.0
+    version: 1.9.0
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Release cray-node-problem-detector 1.9.0 to use a newer image. 

## Issues and Related PRs

* Resolves [CASMPET-5555](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5555)

## Testing

### Tested on:

  * `mug`

### Test description:

Upgraded the cray-node-problem-detector chart, and verified that events were correctly received by following the smoke test procedures in https://connect.us.cray.com/confluence/pages/viewpage.action?spaceKey=CASMPET&title=Platform+Component+Smoketests

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

