### PR TITLE
Add oidc client and mappers for multi-tenancy

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -232,7 +232,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.3.1
+    version: 3.4.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,7 +105,7 @@ spec:
     namespace: services
     values:
       keycloakImage:
-        tag: 3.1.1
+        tag: 3.4.0
   - name: cray-console-operator
     source: csm-algol60
     version: 1.3.5


### PR DESCRIPTION
## Summary and Scope

Create new keycloak client for k8s api OIDC integration for multi-tenancy

## Issues and Related PRs

* Resolves [CASMINST-4294](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4294)

## Testing

```
ncn-m001-fec36008:/home/bklein # kubectl logs -n services $pod keycloak-setup | grep oidc
2022-05-19 22:26:59,151 - INFO    - keycloak_setup - Create Keycloak client kubernetes-api-oidc-client
2022-05-19 22:26:59,267 - INFO    - keycloak_setup - Created client kubernetes-api-oidc-client
2022-05-19 22:26:59,267 - INFO    - keycloak_setup - Fetching 'kubernetes-api-oidc-client' client URL from keycloak...
2022-05-19 22:26:59,304 - INFO    - keycloak_setup - Client 'kubernetes-api-oidc-client' has URL 'http://keycloak.services:8080/keycloak/admin/realms/shasta/clients/21711e54-96d4-4acf-9ff0-127cb4f8db2c'.
2022-05-19 22:26:59,304 - INFO    - keycloak_setup - Requested service account roles for client kubernetes-api-oidc-client: {}
```

### Tested on:

  * Virtual Shasta

### Test description:

Installed chart and was able to view/use the client for OIDC mapping

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
