### PR TITLE
CASMNET-1548 CANU version bump 1.2

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.10-1.noarch
     - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.5.7-1.x86_64
+    - canu-1.5.11-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.33-1.noarch
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

- Create unique VSX system macs for each VSX cluster.
- Fixed Mellanox Customer ACL.
- Add VLAN 7 to Dellanox UAN for 1.0
- Fix canu paddle-file.json schema
- Change Rosetta/Columbia switch naming to be sw-hsn-<rack>-<###> (as with PDU and CMM/CEC).
- Change switch port/interface descriptions to `dst:slot:port==>src` to avoid truncation.
- Change gateway nodes to 4 port 1G OCP card definitions.
- Add dvs and ssn nodes as 4 port 1G OCP card definitions.
- Change large memory node common name from `lm` to `lmem`.
- Beta release of `--reorder` for switch/network config generation where custom-config is not used.
- Added shellcheck GitHub action
- Bump ipython to 7.16.3 to remediate CVE
- Clean up Jenkins build



## Issues and Related PRs

CASMNET-1548
CASMNET-1555
CASMNET-1540

## Testing

Virtual
