### PR TITLE
CASMREL-972

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220514052851-g18016f7.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220514052851-g18016f7.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220514052851-g18016f7.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220520211228-g18016f7.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220520211228-g18016f7.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220520211228-g18016f7.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.81/kubernetes-0.2.81.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.81/5.3.18-150300.59.43-default-0.2.81.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.81/initrd.img-0.2.81.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.82/kubernetes-0.2.82.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.82/5.3.18-150300.59.43-default-0.2.82.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.82/initrd.img-0.2.82.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.81/storage-ceph-0.2.81.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.81/5.3.18-150300.59.43-default-0.2.81.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.81/initrd.img-0.2.81.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.82/storage-ceph-0.2.82.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.82/5.3.18-150300.59.43-default-0.2.82.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.82/initrd.img-0.2.82.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -58,11 +58,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hms-scsd-ct-test-1.8.0-1.x86_64
     - hms-sls-ct-test-1.11.0-1.x86_64
     - hms-smd-ct-test-1.48.0-1.x86_64
-    - manifestgen-1.3.3-1~development~1955191.x86_64
+    - manifestgen-1.3.4-1~development~bbba190.x86_64
     - platform-utils-1.2.10-1.noarch
-    - cray-nexus-0.9.1-3.1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
-    - canu-1.5.7-1.x86_64
     - yapl-0.1.1-1.x86_64
     - hpe-csm-scripts-0.0.33-1.noarch
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -7,5 +7,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - metal-ipxe-2.2.6-1.noarch
-    - canu-1.3.2-1.x86_64
+    - canu-1.5.11-1.x86_64
 


### PR DESCRIPTION
LiveCD:
- [CASMNET-1541](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1541) (canu)
- [CASMNET-1548](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1548) (canu)
- [CASMNET-1549](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1549) (sshd)

NCN:
- [CASMNET-1541](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1541) (canu)
- [CASMNET-1548](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1548) (canu)
- [CASMNET-1549](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1549) (sshd)

Includes some ancillary updates

- cray-nexus is deprecated and replaced by pit-nexus
- manifestgen is currently at 1.3.4 not 1.3.3
