### PR TITLE
CASMINST-4668 adjust rsync path to create chrony dir

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -103,7 +103,7 @@ chmod +x "${BUILDDIR}/lib/version.sh"
 rsync -aq "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh" "${BUILDDIR}/lib/install.sh"
 rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/ncn-image-modification.sh" "${BUILDDIR}/"
-rsync -aq "${ROOTDIR}/chrony" "${BUILDDIR}/chrony/"
+rsync -aq "${ROOTDIR}/chrony/" "${BUILDDIR}/chrony/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
 

--- a/release.sh
+++ b/release.sh
@@ -103,7 +103,7 @@ chmod +x "${BUILDDIR}/lib/version.sh"
 rsync -aq "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh" "${BUILDDIR}/lib/install.sh"
 rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/ncn-image-modification.sh" "${BUILDDIR}/"
-rsync -aq "${ROOTDIR}/chrony/" "${BUILDDIR}/chrony/"
+rsync -aq "${ROOTDIR}/chrony" "${BUILDDIR}/chrony/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
 

--- a/release.sh
+++ b/release.sh
@@ -103,7 +103,7 @@ chmod +x "${BUILDDIR}/lib/version.sh"
 rsync -aq "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh" "${BUILDDIR}/lib/install.sh"
 rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/ncn-image-modification.sh" "${BUILDDIR}/"
-rsync -aq "${ROOTDIR}/chrony/" "${BUILDDIR}/"
+rsync -aq "${ROOTDIR}/chrony/" "${BUILDDIR}/chrony/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adjusted the `rysync` command to make the chrony dir instead of putting the files in the root of the tarball.

## Issues and Related PRs

* Resolves CASMINST-4668
* Merge with main https://github.com/Cray-HPE/csm/pull/852

## Testing

### Tested on:

  * `#drax`

### Test description:

Tested an `rsync` command from a source to the tarball directory.

```
ncn-m001:~ # ls -l /root/chrony
ls: cannot access '/root/chrony': No such file or directory
ncn-m001:~ # rsync -aq /etc/cray/upgrade/csm/csm-1.2.0-beta.127/tarball/csm-1.2.0-beta.127/chrony/ /root/chrony/
ncn-m001:~ # ls -l /root/chrony/
total 8
-rwxr-xr-x 1 root root 7256 May 23 09:45 csm_ntp.py
drwxr-xr-x 2 root root   26 May 23 09:50 templates
ncn-m001:~ #
```

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

