### PR TITLE
CASMINST-4683 main : worker node upgrade failed - cray-console-data-postgres

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -39,9 +39,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
-    - csm-testing-1.14.21-1.noarch
+    - csm-testing-1.14.22-1.noarch
     - docs-csm-1.13.15-1.noarch
-    - goss-servers-1.14.21-1.noarch
+    - goss-servers-1.14.22-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Adds more logic around checking if a leader exists.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4683](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4683)
* Change will also be needed in master and release/csm-1.2
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

drax and vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

o Verified in vshasta where a cluster had no leader (no patroni services were running on any members)
```
$ ./postgres_replication_lag.sh -p
PostgreSQL cluster checks may take several minutes, depending on the number of attempts per cluster.
Checking to see if any cluster members need a patroni service restart.
Cluster cray-sls-postgres:
  Unable to determine the leader from cray-sls-postgres-0, trying the next member.
  Unable to determine the leader from cray-sls-postgres-1, trying the next member.
  Unable to determine the leader from cray-sls-postgres-2, trying the next member.
  No Leader exists for cray-sls-postgres cluster - unable to restart patroni service.
Cluster cray-smd-postgres:
  Found leader cray-smd-postgres-0 from cray-smd-postgres-0.
  No lag was found for cray-smd-postgres cluster - patroni service restart not needed.
Cluster gitea-vcs-postgres:
  Found leader gitea-vcs-postgres-2 from gitea-vcs-postgres-0.
  No lag was found for gitea-vcs-postgres cluster - patroni service restart not needed.
Cluster keycloak-postgres:
  Found leader keycloak-postgres-0 from keycloak-postgres-0.
  No lag was found for keycloak-postgres cluster - patroni service restart not needed.
Cluster spire-postgres:
  Found leader spire-postgres-0 from spire-postgres-0.
  No lag was found for spire-postgres cluster - patroni service restart not needed.
Done checking for patroni service restarts, validating lag.
Cluster cray-sls-postgres:
  Unable to determine the leader from cray-sls-postgres-0, trying the next member.
  Unable to determine the leader from cray-sls-postgres-1, trying the next member.
  Unable to determine the leader from cray-sls-postgres-2, trying the next member.
No Leader exists for cray-sls-postgres cluster - unable to check for lag.
Cluster cray-smd-postgres:
  Found leader cray-smd-postgres-0 from cray-smd-postgres-0.
  cray-smd-postgres -  OK
Cluster gitea-vcs-postgres:
  Found leader gitea-vcs-postgres-2 from gitea-vcs-postgres-0.
  gitea-vcs-postgres -  OK
Cluster keycloak-postgres:
  Found leader keycloak-postgres-0 from keycloak-postgres-0.
  keycloak-postgres -  OK
Cluster spire-postgres:
  Found leader spire-postgres-0 from spire-postgres-0.
  spire-postgres -  OK
FAIL
```

o Verified in drax where the clusters were healthy but the leader was not always running on the -0 member
```
# ./postgres_replication_lag.sh -p
PostgreSQL cluster checks may take several minutes, depending on the number of attempts per cluster.
Checking to see if any cluster members need a patroni service restart.
Cluster cray-console-data-postgres:
  Found leader cray-console-data-postgres-1 from cray-console-data-postgres-0.
  No lag was found for cray-console-data-postgres cluster - patroni service restart not needed.
Cluster cray-sls-postgres:
  Found leader cray-sls-postgres-2 from cray-sls-postgres-0.
  No lag was found for cray-sls-postgres cluster - patroni service restart not needed.
Cluster cray-smd-postgres:
  Found leader cray-smd-postgres-0 from cray-smd-postgres-0.
  No lag was found for cray-smd-postgres cluster - patroni service restart not needed.
Cluster gitea-vcs-postgres:
  Found leader gitea-vcs-postgres-1 from gitea-vcs-postgres-0.
  No lag was found for gitea-vcs-postgres cluster - patroni service restart not needed.
Cluster keycloak-postgres:
  Found leader keycloak-postgres-2 from keycloak-postgres-0.
  No lag was found for keycloak-postgres cluster - patroni service restart not needed.
Cluster spire-postgres:
  Found leader spire-postgres-1 from spire-postgres-0.
  No lag was found for spire-postgres cluster - patroni service restart not needed.
Done checking for patroni service restarts, validating lag.
Cluster cray-console-data-postgres:
  Found leader cray-console-data-postgres-1 from cray-console-data-postgres-0.
  cray-console-data-postgres -  OK
Cluster cray-sls-postgres:
  Found leader cray-sls-postgres-2 from cray-sls-postgres-0.
  cray-sls-postgres -  OK
Cluster cray-smd-postgres:
  Found leader cray-smd-postgres-0 from cray-smd-postgres-0.
  cray-smd-postgres -  OK
Cluster gitea-vcs-postgres:
  Found leader gitea-vcs-postgres-1 from gitea-vcs-postgres-0.
  gitea-vcs-postgres -  OK
Cluster keycloak-postgres:
  Found leader keycloak-postgres-2 from keycloak-postgres-0.
  keycloak-postgres -  OK
Cluster spire-postgres:
  Found leader spire-postgres-1 from spire-postgres-0.
  spire-postgres -  OK
PASS
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
