### PR TITLE
bug/CASMINST-4706 - cray-dhcp-kea version bump to fix type-o in chart

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,7 +41,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.8 # update platform.yaml cray-precache-images with this
+    version: 0.10.9 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -64,7 +64,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.8
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.9
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.6
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- cray-dhcp-kea version bump to fix type-o in chart

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

CASMINST-4706 
## Testing

_List the environments in which these changes were tested._

### Tested on:
surtur
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?n
- Were continuous integration tests run? If not, why?n
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

no
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

