### PR TITLE
Adding cray-kyerno chart adn updating drydock chart to latest

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -132,7 +132,7 @@ spec:
           profile: dryrun
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.1.0
+    version: 1.2.0
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.12.1
+    version: 2.13.1
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60
@@ -130,6 +130,10 @@ spec:
           profile: dryrun
         volumes:
           profile: dryrun
+  - name: cray-kyverno
+    source: csm-algol60
+    version: 1.1.0
+    namespace: kyverno
   - name: cray-psp
     source: csm-algol60
     version: 0.3.0


### PR DESCRIPTION
## Summary and Scope

Adding new admission controller kyverno to CSM release/1.2 branch. This is for CSM 1.2.6 release

## Issues and Related PRs

CASMPET-5433:  https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5433

Chart PR https://github.com/Cray-HPE/cray-kyverno/pull/5

## Testing

Tested the chart on vshasta

## Risks and Mitigations

NA

## Dependency

No dependencies. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

