### PR TITLE
CASMINST-4734 bump spire to 2.6.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,5 +179,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.6.0
+    version: 2.6.1
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Change preferred pod anti-affinity to required pod anti-affinity. This should prevent spire from bringing down the entire API gateway if the pods end up on the same worker node and that node gets rebooted.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4734](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4734)
* Related PR https://github.com/Cray-HPE/cray-spire/pull/41
