### PR TITLE
CASMPET-5660: add a read-only monitoring role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak 3.5.0 to add a read-only monitoring role (CASMPET-5660)
 - Released cray-node-problem-detector 1.9.0 to use a newer image (CASMPET-5555)
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)
 - Released sealed-secrets 0.3.0 to use new image location (CASMPET-5602)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -232,7 +232,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.4.0
+    version: 3.5.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,7 +105,7 @@ spec:
     namespace: services
     values:
       keycloakImage:
-        tag: 3.4.0
+        tag: 3.5.0
   - name: cray-console-operator
     source: csm-algol60
     version: 1.3.5


### PR DESCRIPTION
## Summary and Scope

Add a read-only monitoring role in keycloak in shasta public client, per request from some customers.

## Issues and Related PRs

* Resolves [CASMPET-5660](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5660)
* Change will also be needed in `1.2.6`

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

After deploying it in vshasta, validated that a read-only monitoring role "monitor-ro" had been added to the shasta public client (in addition to existing "admin" and "user" roles.)

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

