### PR TITLE
CASMINST-4742 Bump cray-istio to 2.5.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.5.0
+    version: 2.5.1
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Enable requiredDuringSchedulingIgnoredDuringExecution to prevent multiple ingress gateway pods from starting on the same worker, causing downtime when that worker gets restarted.

## Issues and Related PRs

* Resolves [CASMINST-4742](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4742)
* Related PR https://github.com/Cray-HPE/cray-istio/pull/31

## Testing

### Tested on:

  * Virtual Shasta