### PR TITLE
canu release 1.6.1 (release/1.2)

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220525192710-g18016f7.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220525192710-g18016f7.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220525192710-g18016f7.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220603160132-g18016f7.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220603160132-g18016f7.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220603160132-g18016f7.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.86/kubernetes-0.2.86.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.86/5.3.18-150300.59.43-default-0.2.86.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.86/initrd.img-0.2.86.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.87/kubernetes-0.2.87.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.87/5.3.18-150300.59.43-default-0.2.87.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.87/initrd.img-0.2.87.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.86/storage-ceph-0.2.86.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.86/5.3.18-150300.59.43-default-0.2.86.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.86/initrd.img-0.2.86.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.87/storage-ceph-0.2.87.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.87/5.3.18-150300.59.43-default-0.2.87.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.87/initrd.img-0.2.87.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -31,7 +31,7 @@ artifactory.algol60.net/csm-docker/stable:
   images:
     # adding cray-canu image till there is a chart
     cray-canu:
-      - 1.5.12
+      - 1.6.1
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.59

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,6 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
+    - canu-1.6.1-1.x86_64
     - cray-site-init-1.16.18-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -23,7 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - canu-1.6.1-1.x86_64
     - cray-site-init-1.16.18-1.x86_64
     - dracut-metal-dmk8s-1.5.2-1.noarch
     - dracut-metal-luksetcd-1.5.4-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -7,5 +7,3 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - metal-ipxe-2.2.6-1.noarch
-    - canu-1.5.12-1.x86_64
-

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -1,5 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
+    - canu-1.6.1-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cray-cmstools-crayctldeploy-1.3.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Upgrading Canu from 1.5.7 to 1.6.1.

    Disable load balancing configuration for Dell CDU/Leaf.
    Add canu report network version feature.
    Fix Errors in the output of canu test
    Add route-map and prefixes to allow connection to UAI's from CAN network.
    Fix Dell4148 template to include correct port count

## Issues and Related PRs

https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3322
https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1572

## Testing

Nox, surtur, drax

### Test description:

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

