### PR TITLE
canu release 1.6.1 (main)

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -30,7 +30,7 @@ quay.io:
 artifactory.algol60.net/csm-docker/stable:
   images:
     cray-canu:
-      - 1.5.12
+      - 1.6.1
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - canu-1.5.12-1.x86_64
+    - canu-1.6.1-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Upgrading Canu from 1.5.7 to 1.6.1.

    Disable load balacing configuration for Dell CDU/Leaf.
    Add canu report network version feature.
    Fix Errors in the output of canu test
    Add route-map and prefixes to allow connection to UAI's from CAN network.
    Fix Dell4148 template to include correct port count

## Issues and Related PRs

https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3322
https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1572

## Testing

Nox, surtur, drax

### Test description:

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

