### PR TITLE
Bump cray-opa to 1.10.5

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.10.1
+    version: 1.10.5
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Switch anti-affinity from required to preferred so that opa pods don't get stuck redeploying on 3 worker node clusters.

## Issues and Related PRs

* Resolves [CASMINST-4757](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4757)
* https://github.com/Cray-HPE/cray-opa/pull/42