### PR TITLE
Update HSM chart version for CASMTRIAGE-3430

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.0.8
+    version: 2.0.9
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Updates the HSM image version for CASMTRIAGE-3430

ChassisBMC discovery is complete, it should check that all child components are correctly marked as Mountain components. The filtering for identifying the child components was incorrect. This mod fixes the issue.

This also changes HSM to get class from SLS for node components.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3430](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3430)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/76

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

