### PR TITLE
CASMINST-4720: Add logging to additional Goss tests

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,9 +27,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.52.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - csm-testing-1.14.22-1.noarch
+    - csm-testing-1.14.23-1.noarch
     - docs-csm-1.13.16-1.noarch
-    - goss-servers-1.14.22-1.noarch
+    - goss-servers-1.14.23-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Update goss-servers to pull in CASMINST-4720, which adds test logging to a handful of Goss tests. See source PR for details:
https://github.com/Cray-HPE/csm-testing/pull/328

## Issues and Related PRs

This is only going into 1.3.
