### PR TITLE
CASMTRIAGE-3386-1.3 : TESTS: CSM etcd cluster backups silently failing

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,9 +27,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.52.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - csm-testing-1.14.23-1.noarch
+    - csm-testing-1.14.24-1.noarch
     - docs-csm-1.13.16-1.noarch
-    - goss-servers-1.14.23-1.noarch
+    - goss-servers-1.14.24-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This is a corner case that is being addressed in 1.3
Once the etcd cluster is created, it can take up to hour for the etcd backup crd to get created.
Once the etcd backup crd is created, the etcd backup occur every 24 hours
Thus it can actually take 25 hours after the cluster is created for the backup to exist.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3386](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3386)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

Tested on drax

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

```
ncn-m001 # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-etcd-backups-TMP.yaml validate
..

Total Duration: 2.658s
Count: 2, Failed: 0, Skipped: 0
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

