### PR TITLE
canu 1.6.4 release

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -30,7 +30,7 @@ quay.io:
 artifactory.algol60.net/csm-docker/stable:
   images:
     cray-canu:
-      - 1.6.1
+      - 1.6.4
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - canu-1.6.1-1.x86_64
+    - canu-1.6.4-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64


### PR DESCRIPTION
## Summary and Scope

[1.6.4]

    Documentation updates to docs/network_configuration_and_upgrade

[1.6.3]

    Use full show run commands to retrieve running config from canu network backup
    UAN CAN ports are now shutdown if CHN is enabled.
    Mellanox UAN CAN ports now only allow the CAN vlan.
    Added CMC subrack port configuration.
    Documentation updates to docs/network_configuration_and_upgrade

[1.6.2]

    Correct the 'slot warning' to specify more accurate options

## Issues and Related PRs

[_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-1591](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1591)

## Testing

Nox

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

