### PR TITLE
CASMTRIAGE-3475: Update hpe-csm-scripts to 0.0.34

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.10-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64
-    - hpe-csm-scripts-0.0.33-1.noarch
+    - hpe-csm-scripts-0.0.34.noarch
     - loftsman-1.2.0-1.x86_64
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.10-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64
-    - hpe-csm-scripts-0.0.34.noarch
+    - hpe-csm-scripts-0.0.34-1.noarch
     - loftsman-1.2.0-1.x86_64
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch


### PR DESCRIPTION
## Summary and Scope

The newer version of K8s in CSM changed the output of some `kubectl get nodes` output. This broke some parsing that was attempting to get a list of all worker nodes in the script make_node_groups. As a result, master nodes were included in the list.

Use a more deterministic method of filtering the output to exclude the master nodes fixes the issue. 


## Issues and Related PRs

* Resolves [CASMTRIAGE-3475](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3475)

## Testing

mug

### Tested on:

  * `mug`
  * Local development environment
  * Virtual Shasta

### Test description:

The modified script created an HSM group that did not include the master nodes. Before the change master nodes were included in the HSM group `uai`.

## Risks and Mitigations

Low risk, small change that excludes master nodes


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

