### PR TITLE
CASMNET-1063 - Add ability to exclude SLS networks from zone creation

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -64,5 +64,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.5.5
+    version: 0.6.6
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.10
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.7
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.6
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

SLS contains a "dummy" BICAN network which serves as the source of the bifurcated CAN systemDefaultRoute setting.

Unfortunately this network also has a CIDR of `0.0.0.0/0` which causes powerdns-manger to create `bican` and `0.in-addr.arpa` zones. Due to the bogus subnet records have erroneously been added to this zone.

This change implements the capability to exclude SLS networks from zone generation and excludes the SLS BICAN network by default.

## Issues and Related PRs

* Resolves [CASMNET-1063](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1063)

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

Deployed new chart and image, verified that the `bican` and `0.in-addr.arpa` zones are no longer created.

```
ncn-m001:~ # kubectl -n services exec -it cray-dns-powerdns-86c9685d78-8fdsq -- sh
Defaulting container name to cray-dns-powerdns.
Use 'kubectl describe pod/cray-dns-powerdns-86c9685d78-8fdsq -n services' to see all of the containers in this pod.
/ $ pdnsutil list-all-zones
mug.dev.cray.com
1.10.in-addr.arpa
107.10.in-addr.arpa
106.10.in-addr.arpa
hsn.mug.dev.cray.com
254.10.in-addr.arpa
5.101.10.in-addr.arpa
252.10.in-addr.arpa
253.10.in-addr.arpa
100.92.10.in-addr.arpa
mtl.mug.dev.cray.com
100.94.10.in-addr.arpa
hmn.mug.dev.cray.com
nmn.mug.dev.cray.com
hmnlb.mug.dev.cray.com
nmnlb.mug.dev.cray.com
cmn.mug.dev.cray.com
can.mug.dev.cray.com
```
Verified that new log message is observable when the logging level is increased to debug.
```
{"level":"debug","ts":1654777099.6251757,"msg":"Excluding the following SLS networks from zone generation","ignoreSLSNetworksArray":["BICAN"]}
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable