### PR TITLE
CASMINST-4791: scan both sp2 and sp3 repos for rpms

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.88/kubernetes-0.2.88.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.88/5.3.18-150300.59.43-default-0.2.88.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.88/initrd.img-0.2.88.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.89/kubernetes-0.2.89.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.89/5.3.18-150300.59.43-default-0.2.89.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.2.89/initrd.img-0.2.89.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.88/storage-ceph-0.2.88.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.88/5.3.18-150300.59.43-default-0.2.88.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.88/initrd.img-0.2.88.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.89/storage-ceph-0.2.89.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.89/5.3.18-150300.59.43-default-0.2.89.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.2.89/initrd.img-0.2.89.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

The canu rpm was in the sp3 repo in nexus. However, cloud-init was
only looking for rpms in the sp2 repo. This commit links the NCN
images contain a code change to check both repos.

## Testing

Tested on rebull.