### PR TITLE
CASMINST-4734/4742/4757 Update pod antiaffinity

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.13.0
+    version: 1.15.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60
@@ -192,7 +192,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.6.0
+    version: 2.6.2
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,5 +176,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.6.0
+    version: 2.7.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Adds UUID and pod disruption policies to allow us to use requiredDuringSchedulingIgnoredDuringExecution pod anti affinity policies without causing upgrade issues on clusters with 3 workers.

## Issues and Related PRs


* Resolves CASMINST-4734](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4734)
* Resolves CASMINST-4742](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4742)
* Resolves CASMINST-4757](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4757)
* https://github.com/Cray-HPE/cray-spire/pull/42
* https://github.com/Cray-HPE/cray-opa/pull/44
* https://github.com/Cray-HPE/cray-istio/pull/33

