### PR TITLE
CASMINST-4640/CASMINST-4774: Goss test improvements

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,9 +27,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.52.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - csm-testing-1.14.24-1.noarch
+    - csm-testing-1.14.25-1.noarch
     - docs-csm-1.13.16-1.noarch
-    - goss-servers-1.14.24-1.noarch
+    - goss-servers-1.14.25-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64
     - hms-capmc-ct-test-1.29.0-1.x86_64
     - hms-ct-test-base-1.11.0-1.x86_64


### PR DESCRIPTION
New test to replace manual install steps. See source PR for [CASMINST-4640](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4640) for details:
https://github.com/Cray-HPE/csm-testing/pull/314

This will also implicitly pull in this PR for [CASMINST-4774](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4774) which adds logging to more tests:
https://github.com/Cray-HPE/csm-testing/pull/330