### PR TITLE
Ceph and k8s version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Adding ceph versions 15.2.16 and 16.2.9
+- Adding k8s version 1.21.12, coredns v1.8.0, and pause 3.4.1
 - Released cray-keycloak 3.5.0 to add a read-only monitoring role (CASMPET-5660)
 - Released cray-node-problem-detector 1.9.0 to use a newer image (CASMPET-5555)
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -54,11 +54,11 @@ artifactory.algol60.net/csm-docker/stable:
     # Rebuilt third-party images below
 
     # Required by ceph
-    docker.io/ceph/ceph:
-      - v15.2.8
 
     quay.io/ceph/ceph:
       - v15.2.15
+      - v15.2.16
+      - v16.2.9
 
     # XXX See also k8s.gcr.io/coredns:1.7.0 below
     docker.io/coredns/coredns:
@@ -104,25 +104,25 @@ artifactory.algol60.net/csm-docker/stable:
     # CoreDNS required by platform
     # XXX See also docker.io/coredns/coredns:1.6.2 above
     k8s.gcr.io/coredns:
-      - 1.7.0
+      - v1.8.0
 
     # Kube images required by platform
     k8s.gcr.io/kube-apiserver:
-      - v1.19.9
       - v1.20.13
+      - v1.21.12
     k8s.gcr.io/kube-controller-manager:
-      - v1.19.9
       - v1.20.13
+      - v1.21.12
     k8s.gcr.io/kube-proxy:
-      - v1.19.9
       - v1.20.13
+      - v1.21.12
     k8s.gcr.io/kube-scheduler:
-      - v1.19.9
       - v1.20.13
+      - v1.21.12
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
     k8s.gcr.io/pause:
-      - 3.2
+      - 3.4.1
 
     # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L43


### PR DESCRIPTION
## Summary and Scope

container image version bumps for ceph and k8s

## Issues and Related PRs

* Resolves CASMPET-5719

## Testing

### Tested on:

  * craystack
  * Virtual Shasta
  * redbull

### Test description:

fresh install of vshasta/craystack/redbull with the new images

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

