### PR TITLE
CASMCMS-7876 craycli

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -27,5 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.48.0-1.x86_64
+    - craycli-0.53.0-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.52.0-1.x86_64
+    - craycli-0.53.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-testing-1.14.25-1.noarch
     - docs-csm-1.13.16-1.noarch
@@ -48,7 +48,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.0-1.x86_64
     - loftsman-1.2.0-1.x86_64
-    - manifestgen-1.3.5-1~development~9299ac1.x86_64
+    - manifestgen-1.3.6-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
     - platform-utils-1.2.10-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch


### PR DESCRIPTION
Also brings in the same manifestgen but with fixed RPM metadata, and a
stable RPM name.
