### PR TITLE
CASMTRIAGE-3526: update cray-crus to run munge container with correct user.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.11
+    version: 1.9.16
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

he munge container needs to run as the 'munge' user to successfully start the munged process - running as the default 'nobody' user does not work in this context. This is still a non-root user so the security concerns are met while running as the munge user.

NOTE: there was also a change to the munge-munge image that must be picked up for this change to fix the issue.
https://github.com/Cray-HPE/container-images/pull/443

Code PR:
https://github.com/Cray-HPE/cray-crus/pull/23

PR to csm-1.2.6:
https://github.com/Cray-HPE/csm/pull/918

## Issues and Related PRs
* Resolves [CASMTRIAGE-3526](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3526)

## Testing
### Tested on:
  * `Hela`

### Test description:

I used helm to deploy the new cray-crus version and updated the munge-munge image already on the system. The cray-crus pods all started up correctly and ended in a 'ready' state. I then exec'd into the munge container and tested that munge is working as expected.

There are not bootable compute nodes on Hela at this time, so the full functionality of cray-crus could not be tested, but I have insured that this issue with the munge container is resolved.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a low-risk change - just changing the user the munge sidecar is running under and it will not start correctly as-is and updating the munge image which is not used by anything else on the system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

