### PR TITLE
CASMTRIAGE-3526 - update cray-crus to run munge container with correct user.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -117,7 +117,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.11
+    version: 1.9.16
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
Merge of CASMTRIAGE-3526 to 1.3:
https://github.com/Cray-HPE/csm/pull/919
