### PR TITLE
CASMPET-5664: Add OPA rules for read-only monitoring role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-opa 1.17.0 to add OPA rules for read-only monitoring role (CASMPET-5664)
 - Released cray-keycloak 3.5.0 to add a read-only monitoring role (CASMPET-5660)
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)
 - Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.11.0
+    version: 1.11.1
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Release cray-opa 1.11.1 to add OPA rules for read-only monitoring role. This PR allows the added read-only monitoring role to access telemetry APIs and access SMH and SMA Grafana and Kibana UIs.

## Issues and Related PRs

* Resolves [CASMPET-5664](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5664)
* Change will also be needed in `main`

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

Made sure that a user with read-only monitoring role can log into Grafana UI and have access to telemetry API.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

