### PR TITLE
Add indexes to speed up FRU history pruning

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,6 +19,10 @@ spec:
     version: 2.0.9
     namespace: services
     values:
+      global:
+        appVersion: 1.52.1
+      image:
+        tag: 1.52.1
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

This adds indexes for the hwinv_hist table in HSM's database to speed up the migration step that prunes redundant FRU history events.

## Issues and Related PRs

* Resolves [CASMHMS-5591](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5591)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/78

## Risks and Mitigations

Very low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

