### PR TITLE
Update HSM manifest version

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.4
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This updates the HSM chart version for:

CASMHMS-5591 - Add indexes to the FRU history table in HSM's database
CASMHMS-4972 - Ignore Baseboard when discovering GPUs
CASMHMS-4973 - ignore NV Switch when discovering GPUs

## Issues and Related PRs

* Resolves [CASMHMS-5591](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5591)
* Resolves [CASMHMS-4972](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-4972)
* Resolves [CASMHMS-4973](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-4973)

## Testing

For testing see:
https://github.com/Cray-HPE/hms-smd/pull/78
https://github.com/Cray-HPE/hms-smd/pull/77

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

