### PR TITLE
CASMINST-4829 Remove public access from artifactory.algol60.net

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -62,7 +62,7 @@ if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
     export REPOCREDSPATH="/tmp/"
     export REPOCREDSFILENAME="repo_creds.json"
     export REPOCREDSFULL=$REPOCREDSPATH$REPOCREDSFILENAME
-    jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/sles-mirror/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
+    jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSFULL
     trap "rm -f '${REPOCREDSFULL}'" EXIT
 fi
 


### PR DESCRIPTION
## Summary and Scope

Prepare to revoking anonymous access from following RPM repositories:

* https://artifactory.algol60.net/artifactory/csm-rpms/
* https://artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/
* https://artifactory.algol60.net/artifactory/hpe-mirror-hexane/

## Issues and Related PRs

* Resolves [CASMINST-4829](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4829)

## Testing

### Tested on:

  * Locally

### Test description:

Tested by running `gen-rpm-index.sh` script locally with updated credentials JSON file

## Risks and Mitigations

Low - build pipeline only
