### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,11 +12,11 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.1
+    version: 2.1.2
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.4
+    version: 2.1.5
     namespace: services
     values:
       cray-service:
@@ -31,7 +31,7 @@ spec:
     namespace: services
   - name: cray-hms-reds
     source: csm-algol60
-    version: 2.1.1
+    version: 2.1.2
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -40,23 +40,23 @@ spec:
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 2.1.0
+    version: 2.1.1
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 3.0.2
+    version: 3.0.3
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.3
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.1.1
+    version: 2.1.2
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 2.1.1
+    version: 2.1.2
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
@@ -64,7 +64,7 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.1.1
+    version: 2.1.2
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update HMS CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the services and charts onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test updates.