### PR TITLE
CASMPET-5725 1.3 : postgres operator in 1.3 restarting all postgres pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-postgres-operator 1.0.0 to fix issue with postgres pods restarting (CASMPET-5725)
 - Released cray-opa 1.17.0 to add OPA rules for read-only monitoring role (CASMPET-5664)
 - Adding ceph versions 15.2.16 and 16.2.9
 - Adding k8s version 1.21.12, coredns v1.8.0, and pause 3.4.1

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,7 +220,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 0.14.0
+    version: 1.0.0
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The postgres operator in 1.3 is restarting all postgres pods due to changes in the container structure that was introduced by istio changes. This does not effect 1.0, 1.2 or 1.2.6. 
This change modifies the postgres operator image to not assume Containers[0] is the postgres container in the statefulset or pod, but instead find the correct index for the postgres container.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._
 
* Resolves [CASMPET-5725](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5725)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

_List the environments in which these changes were tested._ vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Install, Upgrade and Rollback.

On Install and Upgrade - the postgres pods remained in a Running state; previously they would Terminate and restart every ~5 minutes

```
$ kubectl get pods -A | grep postgres

services            cray-postgres-operator-65c6459f6f-s5khg                           2/2     Running     0          7m43s
services            cray-sls-postgres-0                                               3/3     Running     0          9m30s
services            cray-sls-postgres-1                                               3/3     Running     0          9m
services            cray-sls-postgres-2                                               3/3     Running     0          8m21s
services            cray-sls-wait-for-postgres-1-4lxlp                                0/3     Completed   0          19m
services            cray-smd-postgres-0                                               3/3     Running     0          9m30s
services            cray-smd-postgres-1                                               3/3     Running     0          9m
services            cray-smd-postgres-2                                               3/3     Running     0          8m8s
services            cray-smd-wait-for-postgres-1-gdnb9                                0/3     Completed   0          19m
services            gitea-vcs-postgres-0                                              3/3     Running     0          9m48s
services            gitea-vcs-postgres-1                                              3/3     Running     0          9m24s
services            gitea-vcs-postgres-2                                              3/3     Running     0          8m51s
services            gitea-vcs-wait-for-postgres-1-8vdvl                               0/2     Completed   0          18m
services            keycloak-postgres-0                                               3/3     Running     0          9m48s
services            keycloak-postgres-1                                               3/3     Running     0          8m8s
services            keycloak-postgres-2                                               3/3     Running     0          9m
services            keycloak-wait-for-postgres-1-7whdv                                0/2     Completed   0          20m
spire               spire-postgres-0                                                  3/3     Running     0          9m38s
spire               spire-postgres-1                                                  3/3     Running     0          8m40s
spire               spire-postgres-2                                                  3/3     Running     0          9m17s
spire               spire-postgres-pooler-695d4cd48f-b4jwj                            2/2     Running     0          16m
spire               spire-postgres-pooler-695d4cd48f-kmmjh                            2/2     Running     0          16m
spire               spire-postgres-pooler-695d4cd48f-nbd2r                            2/2     Running     0          16m

```

On Rollback - the postgres pods went back to the bad start of Terminating and restarting every ~5 minutes
```
$ kubectl get pods -A | grep postgres

services            cray-postgres-operator-6bd558dd5f-chhfw                           2/2     Running       0          25m
services            cray-sls-postgres-0                                               3/3     Running       0          4m52s
services            cray-sls-postgres-1                                               3/3     Terminating   0          3m42s
services            cray-sls-postgres-2                                               3/3     Running       0          4m20s
services            cray-sls-wait-for-postgres-1-4lxlp                                0/3     Completed     0          46m
services            cray-smd-postgres-0                                               3/3     Running       0          4m42s
services            cray-smd-postgres-1                                               3/3     Terminating   0          3m41s
services            cray-smd-postgres-2                                               3/3     Running       0          4m10s
services            cray-smd-wait-for-postgres-1-gdnb9                                0/3     Completed     0          46m
services            gitea-vcs-postgres-0                                              3/3     Running       0          5m
services            gitea-vcs-postgres-2                                              3/3     Running       0          4m22s
services            gitea-vcs-wait-for-postgres-1-8vdvl                               0/2     Completed     0          45m
services            keycloak-postgres-0                                               0/3     Terminating   0          3m56s
services            keycloak-postgres-1                                               3/3     Running       0          4m50s
services            keycloak-postgres-2                                               3/3     Running       0          4m28s
services            keycloak-wait-for-postgres-1-7whdv                                0/2     Completed     0          47m
spire               spire-postgres-0                                                  3/3     Terminating   0          4m57s
spire               spire-postgres-1                                                  3/3     Running       0          3m28s
spire               spire-postgres-2                                                  3/3     Running       0          4m12s
spire               spire-postgres-pooler-695d4cd48f-b4jwj                            2/2     Running       0          43m
spire               spire-postgres-pooler-695d4cd48f-kmmjh                            2/2     Running       0          43m
spire               spire-postgres-pooler-695d4cd48f-nbd2r                            2/2     Running       0          43m
```

The following errors are seen only when the previous postgres-operator image is in use
```
$ kubectl logs -l app.kubernetes.io/instance=cray-postgres-operator -n services -f | grep lazy
time="2022-06-23T16:57:36Z" level=info msg="not all pods were re-started when the lazy upgrade was enabled; forcing the rolling upgrade now" cluster-name=services/keycloak-postgres pkg=cluster
time="2022-06-23T16:57:36Z" level=info msg="not all pods were re-started when the lazy upgrade was enabled; forcing the rolling upgrade now" cluster-name=services/gitea-vcs-postgres pkg=cluster
time="2022-06-23T16:57:38Z" level=info msg="not all pods were re-started when the lazy upgrade was enabled; forcing the rolling upgrade now" cluster-name=services/cray-sls-postgres pkg=cluster
time="2022-06-23T16:57:38Z" level=info msg="not all pods were re-started when the lazy upgrade was enabled; forcing the rolling upgrade now" cluster-name=services/cray-smd-postgres pkg=cluster
time="2022-06-23T16:57:40Z" level=info msg="not all pods were re-started when the lazy upgrade was enabled; forcing the rolling upgrade now" cluster-name=spire/spire-postgres pkg=cluster
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? 
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
