### PR TITLE
CASMNET-1671 - all cray-dns-unbound pods on same worker node preventing clean rolling reboot

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.7 # update platform.yaml cray-precache-images with this
+    version: 0.7.8 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.7
+        appVersion: 0.7.8
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -65,7 +65,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.10
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.7
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.8
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.6
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

`cray-dns-unbound` does not configure anti-affinity so all pods and end up on the same worker.
```
ncn-m001:~ # kubectl get pods -o wide -A | grep dns-unbound
services            cray-dns-unbound-6d7cdf6cdb-qcz9l                                 2/2     Running     0          34d     10.36.0.31     ncn-w009   <none>           <none>
services            cray-dns-unbound-6d7cdf6cdb-r2gtk                                 2/2     Running     0          53d     10.36.0.13     ncn-w009   <none>           <none>
services            cray-dns-unbound-6d7cdf6cdb-s2vwr                                 2/2     Running     0          3d22h   10.36.0.50     ncn-w009   <none>           <none>
```

Configured pod AntiAffinity to distribute the pods over the workers.

## Issues and Related PRs

* Resolves [CASMNET-1671](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1671)
all cray-dns-unbound pods on same worker node preventing clean rolling reboot
* Change will also be needed in `main`

## Testing

### Tested on:

  * `fanta`

### Test description:

Rolled out new chart on fanta, verified that pods are now distributed across available workers
```
ncn-m001:~/cspiller # kubectl get pod -A -o wide | grep unbound
services            cray-dns-unbound-5b7c5c8498-54jlf                                 2/2     Running       0          2m42s   10.33.0.40     ncn-w002   <none>           <none>
services            cray-dns-unbound-5b7c5c8498-qp7t4                                 2/2     Running       0          2m42s   10.38.0.12     ncn-w001   <none>           <none>
services            cray-dns-unbound-5b7c5c8498-wb9r9                                 2/2     Running       0          2m43s   10.47.192.38   ncn-w004   <none>           <none>
```

## Risks and Mitigations

N/A

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
