### PR TITLE
CASMTRIAGE-3616 Revert CASMINST-3979

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.10.5
+    version: 1.10.6
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,5 +179,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.6.0
+    version: 2.6.5
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This reverts the change done in CASMINST-3979 (965cecec9d69a6ed43b04b4f05931d506b425ff4). This fixes an issue where the opa pods were failing to properly cache spire-jwks requests, causing port exhaustion which breaks the ingress gateways after a few minutes.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3616](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3616)
* https://github.com/Cray-HPE/cray-spire/pull/44
* https://github.com/Cray-HPE/cray-opa/pull/49

## Testing

### Tested on:

  * shandy

### Test description:

validated that connections from opa to spire-jwks no longer ran out of ports.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, downgrade is broken.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This exposes the JWKS public keys. However, these are only useful to validate JWTs and there is no risk associated with this.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

