### PR TITLE
CASMPET-5745 Bump cray-vault to 1.3.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -172,7 +172,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.1.0
+    version: 1.3.0
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Kubernetes 1.21+ updated the kubernetes serviceaccount JWT ISS, breaking kubernetes token access to vault. This updates the issuer in vault, which fixes the issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5745](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5745)
* https://github.com/Cray-HPE/cray-vault/pull/7

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that spire-intermediate was able to talk to vault after the update.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations



## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

