### PR TITLE
Fix Helm-chart image extract failure on CRD rendering

### DIFF
--- a/build/images/Makefile
+++ b/build/images/Makefile
@@ -22,10 +22,9 @@ docker/index.txt: ../../docker/index.yaml
 
 .PHONY: chartmap
 
-chartmap:
-	@echo "manifest,chart,image" >> chartmap.csv
-	@tac chartmap.csv > chartmap-tac.csv
-	@mv chartmap-tac.csv chartmap.csv
+chartmap: index.txt
+	@echo "manifest,chart,image" > chartmap.csv
+	@find . -type f -name chartmap.csv -exec cat {} \; | sort -u >> chartmap.csv
 
 .PHONY: clean
 

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -43,13 +43,25 @@ function extract-images() {
     customizations="$(get-customizations "$2")"
     [[ -n "$customizations" ]] && flags+=(--set "$customizations")
 
-    {   parallel --nonall --retries 5 --delay 5 helm show chart "${args[@]}" | docker run --rm -i "$YQ_IMAGE" e -N '.annotations."artifacthub.io/images"' -
-        echo '---'
-        parallel --nonall --retries 5 --delay 5 helm template "${args[@]}" --generate-name --dry-run --set "global.chart.name=${2}" --set "global.chart.version=${3}" "${flags[@]}" | tee "${cacheflags[@]}"
-    } | docker run --rm -i "$YQ_IMAGE" e -N '.. | .image? | select(.)' - \
-      | sort -u | sed -e '/^image: null$/d' -e '/^type: string$/d' \
-      | tee >(cat -n 1>&2) >(cat 2>&1 | xargs -n 1 ./inspect.sh 2> /dev/null | cut -f 1 | sed -e "s|^|$(basename $manifest | cut -d. -f 1),$1/$2:$VER,|g" >> $chartmap)
+    # Try to enumerate images via annotations and full manifest rendering
+	
+    {
+
+    images="$( bash <<EOF
+parallel --nonall --retries 5 --delay 5 helm show chart "${args[@]}" | docker run --rm -i "$YQ_IMAGE" e -N '.annotations."artifacthub.io/images"' -
+echo "---"
+parallel --nonall --retries 5 --delay 5 helm template "${args[@]}" --generate-name --dry-run --set "global.chart.name=${2}" --set "global.chart.version=${3}" "${flags[@]}" | tee "${cacheflags[@]}"
+EOF
+)"
+    images="$(printf "%s" "$images" | docker run --rm -i "$YQ_IMAGE" e -N '.. | .image? | .. style="tagged" | select(.)' - | egrep -v 'null|\!\!' | sort -u | xargs || true)"
+    for image in $images
+    do
+	 printf "%s\n" "$image" 
+	./inspect.sh "$image" 2> /dev/null \
+		| cut -f 1  | sed -e "s|^|$(basename $manifest | cut -d. -f 1),$1/$2:$VER,|g" >> $chartmap
+    done 
     
+    } | tee >(cat -n 1>&2)
 }
 
 
@@ -100,4 +112,3 @@ extract-charts "$manifest" | while read release repo chart version values; do
     filter-releases "$chart" "$@" || continue
     extract-images "$repo" "$chart" "$version" "$values" "$cachefile"
 done | sort -u
-cat "${cachedir}/chartmap.csv" >> "chartmap.csv"

--- a/security/snyk-aggregate-results/requirements.txt
+++ b/security/snyk-aggregate-results/requirements.txt
@@ -1,5 +1,5 @@
 et-xmlfile==1.1.0
-numpy==1.21.1
+numpy==1.22
 openpyxl==3.0.7
 pandas==1.3.1
 python-dateutil==2.8.2


### PR DESCRIPTION
## Summary and Scope

The ```extract.sh``` script failed to parse the recently added cray-kyverno Helm Chart due to the present of CRD fields that were not masked (e.g., previous fields masked were 'type' and image with a null RH value). This PR replaces use of ```grep -v``` for these types of issues, instead yq's ```style="tagged"``` for recursive listings, where the type is annotated. Then, any type annotations (that are not image RH values) are stripped out. There are Helm conventions for template rendering, but the upstream Kyverno chart doesn't follow them, it appears (at least in the release we're using). Given the current WARs in place here, others don't, either. 

Also addressed a potential (but unobserved) race condition with the building out of the chartmap.csv data (in images makefile), as well as updated numpy to address a CVE in the snyk aggregation image. 

Choosing not to back-port, but we may want it in ~ release 1.2 as well, notably if we ever introduce the cray-kyverno chart, there. 

This is a prerequisite to get the Kyverno feature set pulled in for CSM 1.3.

## Issues and Related PRs

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4864

## Testing

Tested image make stage, and security scans and aggregation. Verified 

### Tested on:

  * Local development environment (Ubuntu 22.04, x86)

## Risks and Mitigations

Local testing saw an increased runtime (~ 2x) in the make images step that will probably translate to larger build instances as well. Trade-off is in more robust chart parsing capability. If increased runtime is a bridge too far (shouldn't be), can look at tuning or replacing with a please-dont-break point solution to remove the 'description' field from parsed CRDs. 

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

