### PR TITLE
update to manifest for velero double upgrade in 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Adding velero upgrade to 1.6.3 and an additional manifest for further upgrade velero to 1.7.1
 - Released cray-postgres-operator 1.0.0 to fix issue with postgres pods restarting (CASMPET-5725)
 - Released cray-opa 1.17.0 to add OPA rules for read-only monitoring role (CASMPET-5664)
 - Adding ceph versions 15.2.16 and 16.2.9

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -136,7 +136,7 @@ spec:
     namespace: services
   - name: cray-velero
     source: csm-algol60
-    version: 0.1.0
+    version: 1.6.3
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60

--- a/manifests/velero-1.7-upgrade.yaml
+++ b/manifests/velero-1.7-upgrade.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: manifests/v1beta1
 metadata:
-  name: platform
+  name: velero-double-jump
 spec:
   sources:
     charts:

--- a/manifests/velero-1.7-upgrade.yaml
+++ b/manifests/velero-1.7-upgrade.yaml
@@ -1,0 +1,39 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: platform
+spec:
+  sources:
+    charts:
+    - name: csm
+      type: repo
+      location: https://arti.dev.cray.com/artifactory/csm-helm-stable-local/
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  - name: cray-velero
+    source: csm-algol60
+    version: 1.7.1
+    namespace: velero

--- a/manifests/velero-1.7-upgrade.yaml
+++ b/manifests/velero-1.7-upgrade.yaml
@@ -37,3 +37,4 @@ spec:
     source: csm-algol60
     version: 1.7.1
     namespace: velero
+    


### PR DESCRIPTION
## Summary and Scope
This will upgrade to 1.6.3 via the platform manifest, then we will need to apply another manifest to do the second upgrade.  this will get us within a  release of current upstream

## Issues and Related PRs

* Resolves CASMPET-5332

## Testing

### Tested on:

  * Virtual Shasta

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

