### PR TITLE
CASMTRIAGE-3657: change shebang to explicitly specify python3

### DIFF
--- a/chrony/csm_ntp.py
+++ b/chrony/csm_ntp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # MIT License
 #


### PR DESCRIPTION
## Summary and Scope

This script requires python3. While python2 has long been deprecated,
python2 is still required by the Mellanox software stack and may
be configured as the default python on the system.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3657](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3657)
* Change will also be needed in `release/1.2`, `main`

## Testing

### Tested on:

  * `shandy`
  
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

