### PR TITLE
CASMTRIAGE-3657: change shebang to explicitly specify python3

### DIFF
--- a/chrony/csm_ntp.py
+++ b/chrony/csm_ntp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # MIT License
 #


### PR DESCRIPTION
## Summary and Scope

This script requires python3. While python2 has long been deprecated,
python2 is still required by the Mellanox software stack and may
be configured as the default python on the system.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3657](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3657)

## Testing

### Tested on:

  * `shandy`

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

