### PR TITLE
CASMCMS-6989: Update csm-config for new csm packages playbook (1.2.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.9.31
+    version: 1.10.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Updates the csm-config chart to pull in the new playbook that will install csm packages including the cfs-state-reporter

## Issues and Related PRs

* Resolves CASMCMS-6989

## Testing

### Tested on:

  * Playbook tested on groot

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

