### PR TITLE
CASMCLOUD-1208 Update craycli to 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli to 0.56.0
 - Released cray-opa 1.17.0 to add OPA rules for read-only monitoring role (CASMPET-5664)
 - Adding ceph versions 15.2.16 and 16.2.9
 - Adding k8s version 1.21.12, coredns v1.8.0, and pause 3.4.1

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -27,5 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.53.0-1.x86_64
+    - craycli-0.56.0-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.53.0-1.x86_64
+    - craycli-0.56.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-testing-1.14.26-1.noarch
     - docs-csm-1.14.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update craycli to 0.56.0

This brings the BOS comands up to date (0.54.0), removes the obsolete `cray network` subcommand from the CLI (0.55.0), and finishes the BOS changes (0.56.0).

These changes are backward compatible.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-8064 (0.56.0)
* Resolves [CASMCLOUD-1208](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1208) (0.55.0)
* Resolves CASMCMS-7876/CASMCMS-7848 (0.54.0)

## Testing

### Tested on:

  * Local development environment

### Test description:

The changes for 0.55.0 were tested by linting the code and running unit tests, then running the `cray network --help` command and verifying that there was no `network` sub-command supported.

The changes for 0.54.0 and 0.56.0 (per the description provided by @rbak-hpe ) were tested as follows:

> Confirmed that the new fields were present in the api and that using them generated the correct json payload. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

There are no known risks with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

