### PR TITLE
CASMCMS-8065 - update csm-1.3 manifest with csm-1.2.6 changes.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -82,7 +82,7 @@ spec:
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.10.3
+    version: 1.10.5
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60
@@ -90,7 +90,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.4.1
+    version: 1.4.4
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
@@ -109,7 +109,7 @@ spec:
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.3.9
+    version: 1.3.11
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Pick up changes from the csm-1.2.6 manifest that were missed in moving to csm-1.3 manifests.

The services with updated versions are:
cray-cfs-api
cfs-trust
cray-console-node

## Testing

These were tested as part of inclusion in csm-1.2.6.

## Risks and Mitigations

The risk is in not keeping the versions up to date - if not included fixes in csm-1.2.6 will regress in csm-1.3.0.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

