### PR TITLE
Casmtriage 3674 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 - Released sealed-secrets 0.3.0 to use new image location (CASMPET-5602)
 - Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier
-- Adding velero upgrade to 1.6.3 and an additional manifest for further upgrade velero to 1.7.1
-- Released cray-postgres-operator 1.0.0 to fix issue with postgres pods restarting (CASMPET-5725)
 - Released cray-opa 1.17.0 to add OPA rules for read-only monitoring role (CASMPET-5664)
 - Released cray-keycloak 3.5.0 to add a read-only monitoring role (CASMPET-5660)
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 - Released sealed-secrets 0.3.0 to use new image location (CASMPET-5602)
-- Released sealed-secrets 0.3.0 to use new image location (CASMPET-5602)
+- Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier
+- Adding velero upgrade to 1.6.3 and an additional manifest for further upgrade velero to 1.7.1
+- Released cray-postgres-operator 1.0.0 to fix issue with postgres pods restarting (CASMPET-5725)
 - Released cray-opa 1.17.0 to add OPA rules for read-only monitoring role (CASMPET-5664)
 - Released cray-keycloak 3.5.0 to add a read-only monitoring role (CASMPET-5660)
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -11,7 +11,7 @@ spec:
   - name: cray-ceph-csi-rbd
     source: csm-algol60
     namespace: ceph-rbd
-    version: 3.5.1-1
+    version: 3.5.1-2
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs


### PR DESCRIPTION
## Summary and Scope

image feature layering was missing when upgrade from 1.0.x and earlier versions

## Issues and Related PRs

* Resolves CASMTRIAGE-3674

## Testing

### Tested on:

  * shandy

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

