### PR TITLE
Fix missing image feature for sma storage class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+<<<<<<< HEAD
+=======
+- Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)
 - Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)
 - Update update-uas to v1.6.1 - Updated test in cray-uai-gateway-test image

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -11,7 +11,7 @@ spec:
   - name: cray-ceph-csi-rbd
     source: csm-algol60
     namespace: ceph-rbd
-    version: 3.5.1-1
+    version: 3.5.1-2
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs


### PR DESCRIPTION
## Summary and Scope

image feature layering was missing when upgrade from 1.0.x and earlier versions

## Issues and Related PRs

* Resolves CASMTRIAGE-3674

## Testing

### Tested on:

  * shandy

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

