### PR TITLE
CASMPET-5397: Upgrade the image version of nexus

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.10.2
+    version: 0.11.0
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -77,7 +77,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
+      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
   - name: gatekeeper
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This change will update the nexus image to a much more recent version released. The change is not easily downgraded however documentation updates will allow for ability to rollback. The only change in this nexus update is to bring the image up to a version that is much newer. The impact is low and there has been much testing to ensure update works well as well as upgrade.

## Issues and Related PRs

* Resolves [CASMPET-5397](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5397)

## Testing

### Tested on:

  * Drax - Full backup upgrade and restore
  * Surtur - Just backup and restore
  * Virtual Shasta

### Test description:

- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

The only risk is with a rollback to old versions. That is solved by using the export/restore procedure that will be written up in CASMPET-5646


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

