### PR TITLE
Add BOS v2 feature work to 1.3 installs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 1.10.23
+    version: 2.0.0-beta.1_468b18126ad3fd872bbac2980fe46c04955a2974 
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -28,4 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.56.0-1.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/:
+  rpms:
+   - bos-reporter-2.0.0-beta.1+468b18126ad3fd872bbac2980fe46c04955a2974.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -2,3 +2,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
+https://artifactory.algol60.net/ui/native/csm-rpms/hpe/unstable/sle-15sp3/:
+  rpms:
+    - bos-reporter-2.0.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -35,3 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.30-1.noarch
     - pit-nexus-1.1.4-1.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+468b18126ad3fd872bbac2980fe46c04955a2974.x86_64


### PR DESCRIPTION
## Summary and Scope
This manifest change adds the BOS v2 service to the 1.3 release. Contained in this helm chart change are both versions of BOS (v1 and v2). This manifest change represents the culmination of work accomplished under the CASM-2270 epic.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Promotes [CASM-2270](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2270) to the 1.3 release (when its cut).
* Depending on when release/1.3 is made, It will also require promotion to this release.

## Testing

Installed on groot for testing; because groot is a 1.1/1.2 system, additional manual changes to the deployed manifest were also required.

### Tested on:

  * groot (install and functional boot testing)
  * wasp ( historical functional testing against an older release).

Both systems required simultaneous additional, backwards compatible features pulled forward.

### Test description:
Please see individual testing tickets for feature work, including stage testing, happy path and sad path/recovery testing.

## Risks and Mitigations

v1 API is preserved and should continue to function should there be issues with v2.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

