### PR TITLE
Release cray-velero-1.6.3-2

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: services
   - name: cray-velero
     source: csm-algol60
-    version: 1.6.3
+    version: 1.6.3-2
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60


### PR DESCRIPTION
Bumping velero to 1.6.3-2 to fix a sub chart image location

## Summary and Scope

This is to fix the sub chart image reference 

## Issues and Related PRs

* Resolves CASMINST-4952

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

