### PR TITLE
CASMINST-4951: Extend test timeouts to avoid false failures, CASMINST-4961: Improvements to check_static_routes test script

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.56.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - csm-testing-1.14.28-1.noarch
+    - csm-testing-1.14.29-1.noarch
     - docs-csm-1.3.6-1.noarch
     - goss-servers-1.14.26-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.56.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - csm-testing-1.14.29-1.noarch
+    - csm-testing-1.14.30-1.noarch
     - docs-csm-1.3.6-1.noarch
     - goss-servers-1.14.26-1.noarch
     - hms-bss-ct-test-1.11.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

During the most recent csm-1.3 install attempt on surtur, there were false test failures due to test timeouts. This modifies our tests to be less aggressive about timing out.

In addition, problems were observed with manually running the check_static_routes test, and the logic it employed. This pulls in improvements to that test as well.

## Testing

I tested the modified tests on surtur.

## Risks and Mitigations

Low risk -- for the timeout change, the only change is to the timeout value for tests with low timeouts. For the static route test change, almost all of the changes are confined to a single Bash function.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
