### PR TITLE
Update chart versions for HMS charts affected by removing the HSM v1 API

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.5
+    version: 3.0.0
     namespace: services
     values:
       cray-service:
@@ -27,7 +27,7 @@ spec:
               memory: 8Gi
   - name: cray-hms-meds
     source: csm-algol60
-    version: 2.0.1
+    version: 2.0.2
     namespace: services
   - name: cray-hms-reds
     source: csm-algol60
@@ -35,7 +35,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: services
 
   # Cray DHCP Kea

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -40,11 +40,11 @@ spec:
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 2.1.1
+    version: 2.1.2
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 3.0.3
+    version: 3.0.4
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
@@ -52,23 +52,23 @@ spec:
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.3
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.3
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.6
+    version: 2.15.7
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.3
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

This updates:
hms-smd - v2.1.6
hms-bss - v2.1.2
hms-hmnfd - v2.1.3
hms-rts - v2.0.3
hms-scsd - v2.1.3
hms-hbtd - v2.1.3
hms-capmc - v3.0.4
hms-meds - v2.0.2
hms-discovery - v2.0.3
hms-hmcollector - v2.15.7

## Issues and Related PRs

* Resolves [CASMHMS-5616](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5616)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

