### PR TITLE
CASMPET-5785 Bump spire to 2.6.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,5 +179,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.6.1
+    version: 2.6.5
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This is pulling in a fix that's in the 1.2.0 build into release/1.2. This fixes an anti-affinity issue with the postgres-pooler and an issue where the connections between opa and spire-jwks could be exhausted when a large number of computes are running.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5785](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5785)

## Testing

This is pulling in a fix that's in the 1.2.0 build into release/1.2.
