### PR TITLE
CASMCMS-7830 - update base images for CVE remediation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated MEDS will now only make POST and PATCH a EthernetInterface in HSM when there is actually something to change.
 - Fixed RTS to have the correct pod security policies for the RTS Loader Job.
 - Updated power capping control for Olympus nodes
+- Added anti-affinty settings to cray-console-node pods.
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,15 +105,15 @@ spec:
         tag: 3.5.0
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.3.5
+    version: 1.4.0
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.3.11
+    version: 1.4.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.3.3
+    version: 1.4.0
     namespace: services
   - name: cray-crus
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update the alpine base image version and shift to the ones on algol60 that are being rebuilt nightly for better automatic CVE remediation and fix instances of using arti.dev.cray.com which will be inactive at the end of August.

This also picks up the anti-affinity settings in cray-console-node to keep multiple pods from residing on the same worker.

## Issues and Related PRs
* Resolves [CASMCMS-7830](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7830)
* Resolves [CASMCMS-8055](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8055)

## Testing
### Tested on:
  * `Drax`

### Test description:
Installed via helm on Drax with the other console services. Did complete test with flushing cached data and made sure all new services came up and operated as expected, including connecting to live console sessions on compute nodes. Rolled back to previous installed version when complete and re-tested.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
Fairly minor risk - there are no major dependencies on the base images and was completely tested on a live system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

