### PR TITLE
CASMTRIAGE-3714 Bump spire to 2.8.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,5 +176,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.7.0
+    version: 2.8.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

This updates the request-ncn-join-tokens to support the new spire paths in CSM 1.3. It also adds a toggle to allow vshasta to work properly (default is off). 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3714](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3714)
* https://github.com/Cray-HPE/cray-spire/pull/45
* https://github.com/Cray-HPE/container-images/pull/449

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Validated that requests-ncn-join-token worked properly after upgrading the helm chart.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

