### PR TITLE
CASMPET-5621: adjust istiod replicaCount and hpa setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-istio-deploy 1.27.2 and cray-istio 2.6.3 to increase istiod replica count (CASMPET-5621)
 - Update craycli to 0.56.0
 - Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier
 - Adding velero upgrade to 1.6.3 and an additional manifest for further upgrade velero to 1.7.1

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.27.1   # Update cray-precache-images above on proxyv2 tag change.
+    version: 1.27.2   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -200,7 +200,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.6.2
+    version: 2.6.3
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Increased istiod replica count from 1 to 3, and adjusted its hpa autoscale range to be 3 (min) to 8 (max) to better handle up pod bring-up surge.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5621](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5621)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Upgraded the cray-istio charts, and verified istiod with 3 pods by default, and hpa setting is now set to the range of 3 to 8.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

