### PR TITLE
Update pre-cache config map with correct 1.3 image versions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -53,12 +53,12 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:v1.8.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.21.12
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.21.12
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.21.12
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.21.12
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
       # OPA


### PR DESCRIPTION
## Summary and Scope

Some images that got version bumps need updates in the pre-cache image chart (goss test properly flagged these).

## Issues and Related PRs

* Resolves [CASMINST-4962](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4962)

## Testing

Applied on surtur -- no failures now:

```
surtur-ncn-m001-pit:~ # kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed
```

### Tested on:

  * `surtur`

### Test description:

Updated the cm on surtur and restarted the pods -- they pulled the newer images.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

