### PR TITLE
CASMCMS-8016 - update the console services to use HSM v2 api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated MEDS will now only make POST and PATCH a EthernetInterface in HSM when there is actually something to change.
 - Fixed RTS to have the correct pod security policies for the RTS Loader Job.
 - Updated power capping control for Olympus nodes
+- Updated console services to use HSM v2 api.
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,11 +105,11 @@ spec:
         tag: 3.5.0
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.3.5
+    version: 1.5.0
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.3.11
+    version: 1.5.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The hsm v1 interface is being removed from the service, so we needed to switch to using the v2 interface. The endpoints that we are using are identical in both versions so this was a minimal change.

NOTE: this will conflict with the following manifest PR.  Make sure to merge the below PR first, then this one:
https://github.com/Cray-HPE/csm/pull/999

Code PR's:
https://github.com/Cray-HPE/console-operator/pull/30
https://github.com/Cray-HPE/console-node/pull/52

## Issues and Related PRs
* Resolves [CASMCMS-8016](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8016)

## Testing
### Tested on:
  * `Mug`

### Test description:

I used helm to upgrade the existing deployments of console-operator and console-node, forced a complete regeneration of the console connections, and verified the information needed is being pulled correctly from the new hsm interface and the console connections were correctly established. I then reverted to the original versions of the services and again forced a regeneration fo the connections and verified they worked correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a required change as the v1 interface is being removed shortly. Console services will break without this change being incorporated.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

