### PR TITLE
CASMCMS-8073/CASMCMS-8074: cray-crus, cmstools stop using deprecated HSMv1 API

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -117,7 +117,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.9.16
+    version: 1.10.0
     namespace: services
   - name: cray-tftp
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
-    - cray-cmstools-crayctldeploy-1.3.3-1.x86_64
+    - cray-cmstools-crayctldeploy-1.4.0-1.x86_64
     - cray-site-init-1.21.0-1.x86_64
     - csm-ssh-keys-1.3.79-1.noarch
     - csm-ssh-keys-roles-1.3.79-1.noarch


### PR DESCRIPTION
## Summary and Scope

Move to updated cmstools and cray-crus that stop using the deprecated v1 HSM API and use v2 instead.

## Risks and Mitigations

Both of these things will be broken without this change, since v1 is gone in csm v1.3.

## Pull Request Checklist

- [X] Target branch correct
