### PR TITLE
CASMPET-5697: Updated cray-oauth2-proxies for CVE remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)
 - Released cray-istio-deploy 1.27.2 and cray-istio 2.6.3 to increase istiod replica count (CASMPET-5621)
 - Update craycli to 0.56.0
 - Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -284,7 +284,7 @@ spec:
     namespace: services
   - name: cray-oauth2-proxies
     source: csm-algol60
-    version: 0.2.0
+    version: 0.3.0
     namespace: services
   - name: cray-nls
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update cray-oauth2-proxies chart to use the new oauth2-proxy v7.3.0 image for CVE remediation.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5697](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5697)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
 
### Test description:

Deployed the new helm chart, and verified the following test script still PASS as it uses oauth2-proxy:

tests/install/livecd/scripts/monitoring_check.sh

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

