### PR TITLE
CASMNET-1550 - powerdns-manager support for HSM v2 API

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.6.6
+    version: 0.6.8
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.11
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.8
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.6
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.8
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

Add HSM v2 API support to cray-powerdns-manager

Change is backwards compatible as HSM v2 API has existed since CSM 0.9.x

## Issues and Related PRs

* Resolves [CASMNET-1550](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1550)

## Testing

### Tested on:

  * `mug`
  * Local development environment
  * Virtual Shasta

### Test description:

Deployed code on mug and verified record generation.

Added an additional alias to the ncn-w001 hardware record

# cray sls search hardware list --xname x3000c0s7b0n0 --format json
[
  {
    "Parent": "x3000c0s7b0",
    "Xname": "x3000c0s7b0n0",
    "Type": "comptype_node",
    "Class": "River",
    "TypeString": "Node",
    "LastUpdated": 1657806665,
    "LastUpdatedTime": "2022-07-14 13:51:05.018704 +0000 +0000",
    "ExtraProperties": {
      "Aliases": [
        "ncn-w001",
        "cjs-test"
      ],
      "NID": 100004,
      "Role": "Management",
      "SubRole": "Worker"
    }
  }
]
Confirmed DNS records were generated for all networks identified from the ethernetInterfaces record

# cray hsm inventory ethernetInterfaces describe a4bf0138e936 --format json
{
  "ID": "a4bf0138e936",
  "Description": "Bond0 - bond0.nmn0- kea",
  "MACAddress": "a4:bf:01:38:e9:36",
  "LastUpdate": "2022-05-04T21:55:25.669557Z",
  "ComponentID": "x3000c0s7b0n0",
  "Type": "Node",
  "IPAddresses": [
    {
      "IPAddress": "10.252.1.7"
    },
    {
      "IPAddress": "10.254.1.10"
    },
    {
      "IPAddress": "10.1.1.5"
    },
    {
      "IPAddress": "10.101.5.22"
    }
  ]
}
Record generation

{"level":"info","ts":1657806666.7412524,"msg":"RRset does not exist, adding to patch list.","desiredRRset":{"name":"cjs-test.cmn.mug.dev.cray.com.","type":"CNAME","ttl":3600,"changetype":"REPLACE","records":[{"content":"x3000c0s7b0n0.cmn.mug.dev.cray.com.","disabled":false}]},"zoneRRset":{"records":null}}
{"level":"info","ts":1657806666.7417603,"msg":"RRset does not exist, adding to patch list.","desiredRRset":{"name":"cjs-test.hmn.mug.dev.cray.com.","type":"CNAME","ttl":3600,"changetype":"REPLACE","records":[{"content":"x3000c0s7b0n0.hmn.mug.dev.cray.com.","disabled":false}]},"zoneRRset":{"records":null}}
{"level":"info","ts":1657806666.7538457,"msg":"RRset does not exist, adding to patch list.","desiredRRset":{"name":"cjs-test.nmn.mug.dev.cray.com.","type":"CNAME","ttl":3600,"changetype":"REPLACE","records":[{"content":"x3000c0s7b0n0.nmn.mug.dev.cray.com.","disabled":false}]},"zoneRRset":{"records":null}}
{"level":"info","ts":1657806666.7547395,"msg":"RRset does not exist, adding to patch list.","desiredRRset":{"name":"cjs-test.mtl.mug.dev.cray.com.","type":"CNAME","ttl":3600,"changetype":"REPLACE","records":[{"content":"x3000c0s7b0n0.mtl.mug.dev.cray.com.","disabled":false}]},"zoneRRset":{"records":null}}
Also validated that code correctly handles invalid records that were discovered on mug

{"level":"debug","ts":1657806265.9127831,"msg":"Failed to parse ethernet interface IP address!","error":"invalid CIDR address: /32","ethernetInterface":{"ID":"a4bf0138f451","Description":"System NIC 2","MACAddress":"a4:bf:01:38:f4:51","LastUpdate":"2022-05-04T21:54:50.030721Z","ComponentID":"x3000c0s26b0n0","Type":"Node","IPAddresses":[{"IPAddress":""}]}}


## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

