### PR TITLE
CASMINST-4968: ignore errors from create-kis-artifacts.sh for now

### DIFF
--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -405,6 +405,5 @@ verify_and_unsquash
 setup_ssh
 set_timezone
 create_new_squashfs
-cleanup
 
 echo -e "\nScript executed successfully"

--- a/ncn-image-modification.sh
+++ b/ncn-image-modification.sh
@@ -378,7 +378,12 @@ function create_new_squashfs() {
         fi
 
         echo -e "\nCreating new boot artifacts..."
-        chroot squashfs-root /srv/cray/scripts/common/create-kis-artifacts.sh squashfs-only
+        # There is an issue when running the following script on NCNs vs PIT nodes. On NCNs,
+        # the script throws an error because it can't unmount /mnt/squashfs from within the chroot
+        # environment. While that is being investigated, ignore the error for now...
+        chroot squashfs-root /srv/cray/scripts/common/create-kis-artifacts.sh squashfs-only || true
+        # ...and instead unmount it here:
+        umount -v squashfs-root/mnt/squashfs || true
 
         mkdir -vp old
         # get the names of the existing kernel/initrd


### PR DESCRIPTION
## Summary and Scope

For some reason, create-kis-artifacts.sh is unable to unmount a
bind mount within an NCN chroot environment, but *is* able to do
so in the PIT environment. This needs further investigation. The
change in this commit allows it to compensate for the error on
NCNs, while being a no-op on the PIT.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4968](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4968)
* Future work required by [CASMINST-4974](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4974)

## Testing

### Tested on:

Tested on drax on an NCN during an upgrade from 1.2 to 1.3.

Tested on the redbull PIT.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

