### PR TITLE
changes to restore bos v2 artifacts from https://github.com/Cray-HPE/…

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 1.10.23
+    version: 2.0.0-beta.1+468b18126ad3fd872bbac2980fe46c04955a2974 
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -28,4 +28,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.56.0-1.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+468b18126ad3fd872bbac2980fe46c04955a2974.x86_64.rpm 
+   
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -2,3 +2,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.3.94-1.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+468b18126ad3fd872bbac2980fe46c04955a2974.x86_64.rpm 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -35,4 +35,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.30-1.noarch
     - pit-nexus-1.1.5-1.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+468b18126ad3fd872bbac2980fe46c04955a2974.x86_64.rpm 
 


### PR DESCRIPTION
Updates to restore bos v2 manifest changes after reverting during debugging of failed v1.3.0-alpha.19 build attempt 7/13.