### PR TITLE
CASMCMS-8014: Update cfs-hwsync-agent to use hsm v2

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.7.1
+    version: 1.8.0
     namespace: services
   - name: gitea
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Switches cfs-hwsync-agent from the v1 hsm endpoints to the v2 endpoints

## Issues and Related PRs

* Resolves CASMCMS-8014

## Testing

### Tested on:

  * Hela

### Test description:

Deleted a component and allowed it to be recreated.  Also compared the data from all used endpoints to confirm that there were no changes.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

