### PR TITLE
Update HSM and SLS chart versions

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,11 +12,11 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.4
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This updates the HSM and SLS chart versions for:
CASMHMS-5610 - Fixed POST /Inventory/RedfishEndpoints returning 500 instead of 409 for conflicts.
CASMHMS-5463 - Fixed smd-init job permissions issues
CASMHMS-5475 - Fixed sls-init job permissions issues

## Issues and Related PRs

* Resolves [CASMHMS-5610](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5610)
* Resolves [CASMHMS-5463](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5463)
* Resolves [CASMHMS-5475](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5475)

## Testing

For testing see:
https://github.com/Cray-HPE/hms-smd-charts/pull/22
https://github.com/Cray-HPE/hms-sls-charts/pull/13

## Risks and Mitigations

none.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

