### PR TITLE
Revert HSM v1 API deprecation

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 3.0.1
+    version: 2.1.5
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This temporarily re-adds HSM v1 APIs into CSM 1.3 because other services need more time to change over to the v2 APIs. This mod will need to be reverted later to re-remove HSM v1 APIs for CSM 1.3.

## Issues and Related PRs

* Resolves [CASMHMS-5621](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5621)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

