### PR TITLE
CASMPET-5795: Add api.hmnlb.SYSTEM_DOMAIN to the annotations for istio-ingressgateway-hmn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Added api.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5795)
 - Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)
 - Released cray-istio-deploy 1.27.2 and cray-istio 2.6.3 to increase istiod replica count (CASMPET-5621)
 - Update craycli to 0.56.0

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -359,7 +359,7 @@ spec:
             loadBalancerIP: '{{ network.netstaticips.hmn_api_gw }}'
             serviceAnnotations:
               metallb.universe.tf/address-pool: hardware-management
-              external-dns.alpha.kubernetes.io/hostname: 'hmcollector.hmnlb.{{ network.dns.external }}'
+              external-dns.alpha.kubernetes.io/hostname: 'api.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
           istio-ingressgateway-can:
             serviceAnnotations:
               metallb.universe.tf/address-pool: customer-access


### PR DESCRIPTION
## Summary and Scope

We will be adding the fabric-manager service to the hmn API gateway. This is the first REST API to be available on that gateway. Therefore, we will now need to have the name api.hmnlb.SYSTEM_DOMAIN on that gateway. 
This handles the addition of that annotation for 1.3 fresh installs.   There will be a separate Jira for upgrades.

## Issues and Related PRs

* Resolves CASMPET-5795

## Testing

### Tested on:

  * `mug`

### Test description:

Added api.hmnlb.mug.dev.cray.com annotation to the istio-ingressgateway-hmn service.  Verified that the name was created in powerdns and I was able to access the fabric-manager service via api.hmnlb.mug.dev.cray.com after manually adding the hmn-gateway to the slingshot-fabric-manager virtual service.

## Risks and Mitigations

Very low risk.  This is an addition.   Will not disrupt the other gateways.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

