### PR TITLE
Add hnc/tapms charts, update others for namespace configuration

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.14.1
+    version: 2.14.2
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60
@@ -140,7 +140,7 @@ spec:
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60
-    version: 0.4.0
+    version: 0.4.1
     namespace: services
   - name: cray-velero
     source: csm-algol60
@@ -180,7 +180,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.3.0
+    version: 1.3.1
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
@@ -196,7 +196,7 @@ spec:
     namespace: ceph-rgw
   - name: cray-certmanager-issuers
     source: csm-algol60
-    version: 0.6.0
+    version: 0.6.1
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
@@ -290,3 +290,11 @@ spec:
     source: csm-algol60
     version: 1.3.1
     namespace: argo
+  - name: cray-hnc-manager
+    source: csm-algol60
+    version: 0.0.2
+    namespace: hnc-system
+  - name: cray-tapms-operator
+    source: csm-algol60
+    version: 0.0.2
+    namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Refactor namespaces controlled by hnc controller, create specific namespaces for tapms and slurm.

## Issues and Related PRs

* Resolves [CASMINST-4841](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4841)
* Resolves [CASMINST-4843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4843)

## Testing

```
multi-tenancy
├── slurm-operator
├── tapms-operator
└── tenants
    ├── [s] vcluster-coke
    │   └── [s] vcluster-coke-user
    └── [s] vcluster-pepsi
        └── [s] vcluster-pepsi-user

[s] indicates subnamespaces
```

```
ncn-m001-48d9c509:/home/bklein # kubectl get secrets -n slurm-operator
NAME                  TYPE                                  DATA   AGE
default-token-vt5br   kubernetes.io/service-account-token   3      4m2s
wlm-s3-credentials    Opaque                                7      2m23s
```


### Tested on:

  * Virtual Shasta

### Test description:

Installed/uninstalled the following charts in concert:

```
   - name: cray-drydock
     version: 2.14.5
     namespace: loftsman
   - name: cray-vault
     version: 1.3.6
     namespace: vault
   - name: cray-psp
     version: 0.4.3
     namespace: services
   - name: cray-certmanager-issuers
     version: 0.6.5
     namespace: cert-manager
   - name: cray-hnc-manager
     version: 0.0.1
     namespace: hnc-system
   - name: cray-tapms-operator
     version: 0.0.1
     namespace: tapms-operator
   - name: cray-sample-subtenant-operator
     version: 0.0.1
     namespace: tenants
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
