### PR TITLE
CASMINST-5003

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.1/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.1-20220714173201-gf99267b.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.1/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.1-20220714173201-gf99267b.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.1/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.1-20220714173201-gf99267b.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.3/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.3-20220718191929.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.3/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.3-20220718191929.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.3/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.3-20220718191929.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -33,6 +33,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-ssh-keys-roles-1.3.79-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
-    - pit-init-1.2.30-1.noarch
+    - pit-init-1.2.31-1.noarch
     - pit-nexus-1.1.5-1.x86_64
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This brings in a new pit-init which adds `CSM_RELEASE` to the boot parameters for the NCNs, images will download into a directory that corresponds to the `CSM_RELEASE`. This aligns the install path with the recent changes ([CASMINST-4976](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4796)) in the upgrade path for supporting the
auto-wipe on storage nodes (while providing a feature enhancement to k8s nodes).

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5003](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5003)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `redbull`
  * Local development environment
  * Virtual Shasta

### Test description:

See test results and other information here: https://github.com/Cray-HPE/pit-init/pull/48

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No risks, if `CSM_RELEASE` is not set, changed, or unset after being set, then re-running `set-sqfs-links.sh` will fix the kernel parameters accordingly.

This also mitigates risk of skipping an image pull, if an image name is the same as what is already downloaded it won't matter. The new images are pulled into a new directory each time based on the `CSM_RELEASE`.

Specifically this sets `rd.live.dir=$CSM_RELEASE`, which translates to dracut to download the images into `/run/initramfs/live/$CSM_RELEASE` instead of `/run/initramfs/live/LiveOS`.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

