### PR TITLE
CASMTRIAGE-3754 Bump spire to 2.8.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,5 +176,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.8.0
+    version: 2.8.1
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Update pause image to 3.4.1. This fixes an issue where the pause container fails to start due to Kyverno modifying its security context to run as nonroot.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3754](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3754)
* https://github.com/Cray-HPE/cray-spire/pull/46


## Testing

### Tested on:

  * surtur

### Test description:

Validated that the request-ncn-join-token pods came up correctly after the updated spire chart was applied.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

