### PR TITLE
"CASMINST-5005,CASMNET-1552,CASMNET-1713,CASMNET-1551,CASMNET-1677 - update unbound-manager to support SMD/HSM v2 api,update dhcp-helper to use SMD/HSM v2 api, fix auto repair bug, gracefully handle empty cray-bss data

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -41,17 +41,17 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.11 # update platform.yaml cray-precache-images with this
+    version: 0.10.12 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.8 # update platform.yaml cray-precache-images with this
+    version: 0.7.9 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.8
+        appVersion: 0.7.9
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -64,8 +64,8 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.11
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.8
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.12
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.9
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.8
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
…pdate unbound-manager to support SMD/HSM v2 api,update dhcp-helper to use SMD/HSM v2 api, fix auto repair bug, gracefully handle empty cray-bss data

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- update unbound-manager to support SMD/HSM v2 api,update 
- dhcp-helper to use SMD/HSM v2 api
- fix auto repair bug
- gracefully handle empty cray-bss data

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

- CASMINST-5005
- CASMNET-1552
- CASMNET-1713
- CASMNET-1551
- CASMNET-1677 

## Testing

_List the environments in which these changes were tested._

### Tested on:

Mug
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?n
- Were continuous integration tests run? If not, why?n
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

none i know of
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

