### PR TITLE
CASMPET-5793 Update cray-opa to 1.18.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,7 +62,7 @@ spec:
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
       # OPA
-      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.11
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.8
@@ -168,7 +168,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.17.0
+    version: 1.18.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

- Update opa-envoy to 0.42.1
- Add opa rego strict check to validate opa code is written correctly for the current version
- Fix opa code that failed the strict check

## Issues and Related PRs


* Resolves [CASMPET-5793](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5793)
* https://github.com/Cray-HPE/cray-opa/pull/50


## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated pods started and didn't error. 
Further testing is needed on bare metal with all products installed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a major version bump and needs to be tested on a bare metal 1.3.0 system with all products installed to validate OPA is still functioning as expected.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

