### PR TITLE
CASMHMS-5606 Bump CLI RPM version to 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli to 0.57.0
 - Added api.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5795)
 - Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)
 - Released cray-istio-deploy 1.27.2 and cray-istio 2.6.3 to increase istiod replica count (CASMPET-5621)

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -27,6 +27,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cfs-trust-1.3.94-1.x86_64
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.56.0-1.x86_64
+    - craycli-0.57.0-1.x86_64
    
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.56.0-1.x86_64
+    - craycli-0.57.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-testing-1.14.31-1.noarch
     - docs-csm-1.3.11-1.noarch


### PR DESCRIPTION
Taken from the CLI PR that created this new version:

## Summary and Scope

This change updates the scsd docs in the cray cli. It brings in the changes to scsd to support getting and setting TPM State in the bios. We plan to include these changes in CSM 1.3

Examples:
```
cray scsd bmc bios tpmstate list x3000c0s27b0n0
cray scsd bmc bios tpmstate update x3000c0s27b0n0 --future Disabled
cray scsd bmc bios tpmstate update x3000c0s27b0n0 --future Enabled
```

This change is backward compatible in the following way
* The existing command lines will continue to work as they did before
* The new command line `cray scsd bios tpmstate` will show up in the usage statements, but will fail when the new scsd is not present.

## Issues and Related PRs

* Resolves CASMHMS-5606

## Testing

### Tested on:

  * mug (1.2)
  * groot (1.0)

### Test description:

Tested on mug and groot with the latest SCSD.
Added unit tests.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? Yes

## Risks and Mitigations

low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
