### PR TITLE
Re-add HSM v1 APIs

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.5
+    version: 2.1.6
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This re-adds the HSM v1 APIs to CSM and adds the bugfixes that came after the HSM v1 APIs had been removed.

## Issues and Related PRs

* Resolves [CASMHMS-5625](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5625)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/82

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

