### PR TITLE
CASMNET-1143/CASMNET-1674 - Record generation fixes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.6.8
+    version: 0.6.9
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.12
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.9
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.8
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.9
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

Resolves the following issues

* An SLS alias consisting of the node xname resulted in a bad CNAME record which was in conflict with the A record.

```
x3000c0s3b0n0.nmn.drax.dev.cray.com	3600	IN	CNAME	x3000c0s3b0n0.nmn.drax.dev.cray.com.
```

* Matching SLS static and HSM dynamic data could result in the same record being generated twice causing the PowerDNS API patch request to fail as the API does not permit duplicate records.

* Change chart `imagePullPolicy` to `IfNotPresent` to avoid negating the benefit of pre-caching the image on the NCNs.

## Issues and Related PRs

* Resolves [CASMNET-1674](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1674), [CASMNET-1143](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1143), and [CASMNET-1724](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1724).

## Testing

### Tested on:

  * `fanta`
  * Local development environment

### Test description:

Tested on fanta during a CSM 1.2 install, verified record generation was correct.

```
/ $ pdnsutil list-zone nmn.fanta.dev.cray.com | grep x3000c0s5b0n0
ncn-m003.nmn.fanta.dev.cray.com	3600	IN	CNAME	x3000c0s5b0n0.nmn.fanta.dev.cray.com.
ncn-m003-nmn.nmn.fanta.dev.cray.com	3600	IN	CNAME	x3000c0s5b0n0.nmn.fanta.dev.cray.com.
x3000c0s5b0n0.nmn.fanta.dev.cray.com	3600	IN	A	10.252.1.8
```

Verified duplicate checking code was filtering out duplicate RRsets

```
2022-07-20T08:03:43.500324566Z {"level":"debug","ts":1658304223.5003011,"msg":"Refusing to add duplicate RRset","rrSet":{"name":"3.1.254.10.in-addr.arpa.","type":"PTR","ttl":3600,"changetype":"REPLACE","records":[{"content":"x3000c0s36b0.hmn.fanta.dev.cray.com.","disabled":false}]}}
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable