### PR TITLE
CASMHMS-5525 Update hms-trs-operator to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Fixed kafka errors in hms-trs-operator (CASMHMS-5525)
 - Update craycli to 0.57.0
 - Added api.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5795)
 - Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-trs-operator
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

hms-trs-operator was failing to create trs-workers due to change in kafka. This changes to use the new kafka.strimzi.io version (v1beta2)

## Issues and Related PRs

* Resolves CASMHMS-5525

## Testing

### Tested on:

- mug (csm 2.0)
- Compared behavior with groot (csm 1.0)

Were the install/upgrade based validation checks/tests run? Y
Were continuous integration tests run? Y
Was an Upgrade tested? Y
Was a Downgrade tested? Y

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

