### PR TITLE
CASMPET-5817:  Add allowed-issues to customizations.yaml for istio-ingressgateway-hmn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Added auth.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5817)
+- Added allowed-issuers for istio-ingressgateway-hmn in cray-opa section customizations.yaml (CASMPET-5817)
 - Update craycli to 0.57.0
 - Added api.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5795)
 - Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -359,7 +359,7 @@ spec:
             loadBalancerIP: '{{ network.netstaticips.hmn_api_gw }}'
             serviceAnnotations:
               metallb.universe.tf/address-pool: hardware-management
-              external-dns.alpha.kubernetes.io/hostname: 'api.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
+              external-dns.alpha.kubernetes.io/hostname: 'api.hmnlb.{{ network.dns.external }},auth.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
           istio-ingressgateway-can:
             serviceAnnotations:
               metallb.universe.tf/address-pool: customer-access
@@ -728,6 +728,10 @@ spec:
               keycloak-can: https://auth.can.{{ network.dns.external }}/keycloak/realms/shasta
               shasta-chn: https://api.chn.{{ network.dns.external }}/keycloak/realms/shasta
               keycloak-chn: https://auth.chn.{{ network.dns.external }}/keycloak/realms/shasta
+          ingressgateway-hmn:
+            issuers:
+              shasta-hmn: https://api.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta
+              keycloak-hmn: https://auth.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta
       spire:
         trustDomain: shasta
         server:


### PR DESCRIPTION
## Summary and Scope

We will be adding the fabric-manager service to the HMN API gateway. This is the first REST API to be available on that gateway. That API will need to be authenticated by keycloak so we will need to add allowed-issuers to the cray-opa service in customizations.yaml like we have for the other ingress gateways.

While adding this, I also realized that we need to add the auth.hmnlb name to the istio-ingressgateway-hmn service.

Adding these items on upgrade will be handed by CASMPET-5811.

## Issues and Related PRs

* Resolves CASMPET-5817

## Testing

There is not much testing that can be done until CASMPET-5812 and CASMPET-5813 are done.  The allowed-issuers for istio-ingressgateway-hmn will not be used until the template for the HMN opa policy is completed in CASMPET-5813. 

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

