### PR TITLE
CASMINST-5051 Bump platform-utils to 1.3.1

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -37,6 +37,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.0-1.noarch
+    - platform-utils-1.3.1-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

The new spire-agent rpm uses /var/lib/spire instead of /root/spire. This
fixes the path issues.

## Issues and Related PRs


* Resolves [CASMINST-5051](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5051)
* https://github.com/Cray-HPE/utils/pull/53
* https://github.com/Cray-HPE/csm-rpms/pull/506

## Testing


### Tested on:

  * drax

### Test description:

Validated script ran successfully and storage nodes joined to spire.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not applictable
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

