### PR TITLE
CASMHMS-5488 Changed how sls search API generates SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Changed how sls search API generates SQL (CASMHMS-5488)
 - Fixed kafka errors in hms-trs-operator (CASMHMS-5525)
 - Added auth.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5817)
 - Added allowed-issuers for istio-ingressgateway-hmn in cray-opa section customizations.yaml (CASMPET-5817)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.4
+    version: 2.1.5
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Changed the hardware and network search APIs to build the sql requests with parameters.

## Issues and Related PRs

* Resolves CASMHMS-5488

## Testing

### Tested on:

* mug

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested? Y
Was a Downgrade tested? Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? NA

### Test description:

Compared the results of these queries with and without this PRs changes:
/v1/search/hardware?parent=s0
/v1/search/hardware?xname=x3000c0h42s1
/v1/search/hardware?type=comptype_node
/v1/search/hardware?class=River
/v1/search/hardware?extra_properties.NID=100007
/v1/search/hardware?extra_properties.VendorName=ethernet1/1/23
/v1/search/hardware?node_nics=x3000c0s7b0
/v1/search/hardware?networks=ncn

/v1/search/networks?name=HMN_RVR
/v1/search/networks?name=HMNLB
/v1/search/networks?full_name=Hardware+Management+Network+LoadBalancers
/v1/search/networks?ip_address=10.101.5.0/25
/v1/search/networks?ip_address=10.101.5.0
/v1/search/networks?ip_address=10.101.5.0/32

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

