### PR TITLE
CASMINST-5058:  Revert part of CASMINST-5817 until CASMINST-5813 is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed how sls search API generates SQL (CASMHMS-5488)
 - Fixed kafka errors in hms-trs-operator (CASMHMS-5525)
 - Added auth.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5817)
-- Added allowed-issuers for istio-ingressgateway-hmn in cray-opa section customizations.yaml (CASMPET-5817)
 - Update craycli to 0.57.0
 - Added api.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5795)
 - Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -728,10 +728,6 @@ spec:
               keycloak-can: https://auth.can.{{ network.dns.external }}/keycloak/realms/shasta
               shasta-chn: https://api.chn.{{ network.dns.external }}/keycloak/realms/shasta
               keycloak-chn: https://auth.chn.{{ network.dns.external }}/keycloak/realms/shasta
-          ingressgateway-hmn:
-            issuers:
-              shasta-hmn: https://api.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta
-              keycloak-hmn: https://auth.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta
       spire:
         trustDomain: shasta
         server:


### PR DESCRIPTION
## Summary and Scope

There were issuers values added to customizations.yaml in anticipation of [CASMPET-5813](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5813). It was expected that the values would be ignored until the ingressgateway-hmn.policy was created but that is not the cases. Those values cause opa to look for the template for that policy.

Reverting the change that added those issuers to customizations.yaml until CASMPET-5813 is ready.

## Issues and Related PRs

* Resolves CASMINST-5058

## Testing

### Tested on:

  * `surtur`

### Test description:

Manually removed the ingressgateway-hmn issuers from the site-init secret on surtur.   The cray-opa chart installed successfully after they were removed.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

