### PR TITLE
CASMPET-5813 Bump cray-opa to 1.19.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -168,7 +168,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.18.0
+    version: 1.19.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Switches will be talking to the fabric manager through the hmn gateway via a keycloak JWT. This requires a new hmn opa policy to be added for this to work properly.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5813](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5813)
* https://github.com/Cray-HPE/cray-opa/pull/52

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that the hmn opa pods and envoyfilter was created properly. This needs additional testing on a bare metal system.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? YB
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

