### PR TITLE
Change CAPMC URL for uai-images

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -170,7 +170,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.7.2
+    version: 1.7.3
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

The URL being used to test communication with CAPMC was removed. Changed it to the health CAPMC health URL.

## Issues and Related PRs

* Resolves [CASMINST-5031](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5031)

## Testing

### Tested on:

  * `surtur`

### Test description:

Validated similar test for gateway testing with new CAPMC health URL on surtur.

PASS - [cray-capmc]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 200

Overall Gateway Test Status: PASS

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? goss test passed
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N - N/A
- Was downgrade tested? If not, why? N - N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

