### PR TITLE
Add validation for xnames by type and refactor lib package so webhook can access

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -296,5 +296,5 @@ spec:
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.2
+    version: 0.0.3
     namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Add validation for xnames by type and refactor lib package so webhook can access

## Issues and Related PRs

* Resolves [CASMINST-4792](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4792)

## Testing

Validated create/update blocked when specifying a non-compute xname:

```
ncn-m001-48d9c509:/home/bklein/demo # kubectl -n tenants -f pepsi/tenant.yaml apply
Error from server (the following xname(s) do not have type Node and role Compute: [x0c3s2b0]): error when creating "pepsi/tenant.yaml": admission webhook "vtenant.kb.io" denied the request: the following xname(s) do not have type Node and role Compute: [x0c3s2b0]
```

### Tested on:

  * Virtual Shasta

### Test description:

Multiple iterations of create/modify/delete

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

