### PR TITLE
CASMPET-5812: add keycloak service to hmn-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak 3.6.0 to add keycloak service to hmn-gateway (CASMPET-5812)
 - Updated cfs-operator to 1.15.0 to fix kafka client initialization
 - Changed how sls search API generates SQL (CASMHMS-5488)
 - Fixed kafka errors in hms-trs-operator (CASMHMS-5525)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,7 +240,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.5.1
+    version: 3.6.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Add keycloak service to hmn-gateway for fabric_manager.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5812](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5812)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Verified that the cray-keycloak service is now exposed to hmn-gateway in addition to other gateways after upgrading.

$ kubectl get vs -A | grep keycloak
services keycloak ["services-gateway","customer-admin-gateway","customer-user-gateway","hmn-gateway"] ["*"]

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

