### PR TITLE
CASMINST-5025: Numerous Goss testing fixes

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,9 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.57.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - csm-testing-1.14.31-1.noarch
     - docs-csm-1.3.13-1.noarch
-    - goss-servers-1.14.31-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-scripts-0.0.36-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,6 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.5-1.x86_64
     - cray-cmstools-crayctldeploy-1.4.0-1.x86_64
     - cray-site-init-1.22.0-1.x86_64
+    - csm-testing-1.14.32-1.noarch
+    - goss-servers-1.14.32-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.31-1.noarch


### PR DESCRIPTION
## Summary and Scope

This addresses a large number of problems related to the Goss tests. Without this fix, there are a number of failures we can expect to see.

I tested the changes on surtur.

This also switches us over to using the SP3 build of the RPM, since the NCNs are installed with SP3.

## Issues and Related PRs

See the source PR for details:
https://github.com/Cray-HPE/csm-testing/pull/345

## Testing

I tested the changes on surtur.

## Risks and Mitigations

Moderate risk in that there are a number of changes, but low risk in that without this there will be a lot of problems.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
