### PR TITLE
CASMCMS-8104: Create SP3 zypper repo in NCN personalization; CASMINST-5090: Remove HMS CT test RPMs from csm config

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.10.1
+    version: 1.11.0-alpha.3+9d8917e
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.10.0
+    version: 1.10.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

CASMCMS-8104: Modify the CSM configuration play to define the csm-sle-sp15sp3 zypper repository on the NCNs, so that they can install RPMs from them.
CASMINST-5090: Remove the no-longer-existent HMS CT test RPMs from NCN personalization

## Issues and Related PRs

Resolves:
* https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8104
* https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5090

## Testing

CASMCMS-8104: Tested updated config on drax.
CASMCMS-8104+CASMINST-5090: Tested hotfix for both combined on tyr.

## Risks and Mitigations

Low risk, and necessary.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
