### PR TITLE
Add validation check for xname in two hsm exclusive groups

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -296,5 +296,5 @@ spec:
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.3
+    version: 0.0.4
     namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Add validation check for xname in two hsm exclusive groups

## Issues and Related PRs

* Resolves [CASMINST-5086](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5086)

## Testing

```
ncn-m001-48d9c509:/home/bklein/demo # kubectl -n tenants -f coke/tenant.yaml apply
Error from server (the following xname(s): '[x0c3s3b0n0]' already exist in an exclusive hsm group): error when creating "coke/tenant.yaml": admission webhook "vtenant.kb.io" denied the request: the following xname(s): '[x0c3s3b0n0]' already exist in an exclusive hsm group
```

### Tested on:

  * Virtual Shasta

### Test description:

Ran through create/modify/update

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

