### PR TITLE
CASMHMS-5628 Remove HSM v1 API calls from craycli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli to 0.58.0
 - Updated cfs-operator to 1.15.0 to fix kafka client initialization
 - Changed how sls search API generates SQL (CASMHMS-5488)
 - Fixed kafka errors in hms-trs-operator (CASMHMS-5525)

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.57.0-1.x86_64
+    - craycli-0.58.0-1.x86_64
    
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.57.0-1.x86_64
+    - craycli-0.58.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - csm-testing-1.14.31-1.noarch
     - docs-csm-1.3.14-1.noarch


### PR DESCRIPTION
## Summary and Scope

This removes deprecated HSM v1 API calls from craycli.

## Issues and Related PRs

* Resolves [CASMHMS-5628](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5628)

## Testing

For testing, see https://github.com/Cray-HPE/craycli/pull/55

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

