### PR TITLE
CASMHMS-5612/CASMHMS-5593 HMS Helm CT test enhancements, CVE remediation, chart global.appVersion standardization

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -31,7 +31,7 @@ spec:
     namespace: services
   - name: cray-hms-reds
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.3
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.6
+    version: 2.1.7
     namespace: services
     values:
       cray-service:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -40,23 +40,23 @@ spec:
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 2.1.2
+    version: 2.1.3
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 3.0.4
+    version: 3.0.5
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.4
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.4
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.4
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
@@ -64,7 +64,7 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.4
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - docs-csm-1.3.14-1.noarch
     - goss-servers-1.14.31-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.0.36-1.noarch
+    - hpe-csm-scripts-0.0.37-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes for the Helm CT tests:

- kill the istio sidecar after the tests run to save wait time
- remove build dependencies from final test image that aren't needed to run the tests
- revert the test base image to alpine:3.15 to resolve CVEs
- improve log file readability

It also updates the cray-smd-init and cray-reds-vault-loader jobs to respect the global appVersion for overrides.

### Issues and Related PRs

* Resolves CASMHMS-5612.
* Resolves CASMHMS-5593.

Merge with:
- https://github.com/Cray-HPE/hpe-csm-scripts/pull/22
- https://github.com/Cray-HPE/csm-rpms/pull/510

### Testing

This change was tested by deploying a new version of an HMS service on Mug which pulled in the latest version of the hms-test image, executing its Helm CT tests, and verifying that they passed. Also verified that the test pod was no longer stuck in "NotReady" after the tests completed. Lastly, verified the change in the runCT environment and confirmed that it passed its Snyk checks that were previously failing.

In addition, used 'Helm template' commands to verify that the global.appVersion override was respected instead of ignored for the cray-reds-vault-loader job.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.