### PR TITLE
Increase loftsman timeout for precache images chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -46,6 +46,7 @@ spec:
     source: csm-algol60
     version: 0.5.1
     namespace: nexus
+    timeout: 20m0s
     values:
       cacheRefreshSeconds: "120"
       cacheImages:


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5107 -- bump chart timeout for pre-cache images daemonset.

# Testing (vshasta)

```
apiVersion: manifests/v1beta1
metadata:
  name: brad
spec:
  charts:
  - name: cray-precache-images
    namespace: nexus
    version: 0.5.6
    timeout: 20m0s  <-----
    values:
      cacheImages:
      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
      - artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
      . 
      . 
      . 
```

```
bash-5.1# /tmp/loftsman  ship --manifest-path /workspace/.cache/manifest.yaml --charts-path /workspace/.cache/charts --json-log-path /workspace/.cache/loftsman.json.log
2022-07-25T18:45:33Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2022-07-25T18:45:33Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2022-07-25T18:45:33Z INF Ensuring that the loftsman namespace exists command=ship
2022-07-25T18:45:34Z INF Loftsman will use the packaged charts at /workspace/.cache/charts as the Helm install source command=ship
2022-07-25T18:45:34Z INF Running a release for the provided manifest at /workspace/.cache/manifest.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-precache-images v0.5.6
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2022-07-25T18:45:34Z INF Found value overrides for chart, applying:
cacheImages:
- artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
- artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
- artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
- artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
- artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
- artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.7
- artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.6
- artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
- artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5
- artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
- artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
- artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
- artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
cacheRefreshSeconds: "120"
 chart=cray-precache-images command=ship namespace=nexus version=0.5.6
2022-07-25T18:45:34Z INF Running helm install/upgrade with arguments: upgrade --install cray-precache-images /workspace/.cache/charts/cray-precache-images-0.5.6.tgz --namespace nexus --create-namespace --set global.chart.name=cray-precache-images --set global.chart.version=0.5.6 --timeout 20m0s -f /tmp/loftsman-1658774733/cray-precache-images-values.yaml chart=cray-precache-images command=ship namespace=nexus version=0.5.6
2022-07-25T18:51:39Z INF Release "cray-precache-images" has been upgraded. Happy Helming!
NAME: cray-precache-images
LAST DEPLOYED: Mon Jul 25 18:45:35 2022
NAMESPACE: nexus
STATUS: deployed
REVISION: 13
TEST SUITE: None
 chart=cray-precache-images command=ship namespace=nexus version=0.5.6
2022-07-25T18:51:39Z INF Ship status: success. Recording status, manifest to configmap loftsman-brad in namespace loftsman command=ship
2022-07-25T18:51:39Z INF Recording log data to configmap loftsman-brad-ship-log in namespace loftsman command=ship
```

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.
