### PR TITLE
CASMPET-5835 Enable heartbeat spire auth

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.19.0
+    version: 1.20.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,5 +176,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.8.1
+    version: 2.9.0
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

heartbeat is now using spire tokens by default. This disabled the spire authentication bypass for heartbeats and fixes issues with heartbeat spire access.

## Issues and Related PRs


* Resolves [CASMPET-5835](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5835)
* https://github.com/Cray-HPE/cray-opa/pull/53
* https://github.com/Cray-HPE/cray-spire/pull/47

## Testing

### Tested on:

  * `fanta`

### Test description:

Validated that storage nodes started heartbeating properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

heartbeats with xname filtering enabled needs to be tested to validate the API URLs are correct.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

