### PR TITLE
Bump cray-bos chart and associated RPMs to include a chart manifest

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.1+38203ae 
+    version: 2.0.0-beta.1+1e2f26c 
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.58.0-1.x86_64
-   
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/:
+  rpms:
+   - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,0 +1,3 @@
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -33,3 +33,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - pit-init-1.2.31-1.noarch
     - pit-nexus-1.1.5-1.x86_64
 
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,3 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.8.1-1.x86_64
     - cfs-trust-1.5.0-1.x86_64
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,3 +28,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.5.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
+
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/:
+  rpms:
+    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+


### PR DESCRIPTION
Updated BOA is compatible with CAPMC versioned endpoint changes.

## Summary and Scope

It was discovered that the previous version of BOS was launching a BOA image that was targetting capmc endpoints that no longer exist. These endpoints were deprecated in favor of their versioned endpoint compatible pieces (/v1/). Unfortunately, BOA changes that reflect this were not included with BOS because they were not published to a release branch.

This change adds that compatibility back, as well, adds RPMs that went missing from the manifest as a function of a perceived build issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5096](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5096)

## Testing

Built the associated helm chart and verified it referenced the new BOA version.


## Risks and Mitigations
Our previous manifest changes for RPMs were backed out because they were thought to cause release issues while packaging the CSM product media. Do not merge until we have a solid/green build.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
