### PR TITLE
CASMPET-5837 1.3 : Break/Fix: Unable to determine a leader for the cray-console-data-postgres cluster

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -35,6 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.1-1.noarch
+    - platform-utils-1.3.3-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Add the postgres container to the kubectl exec commands for the ncnPostgresHealth script.
Related goss test and doc changes were done as part of [CASMPET-5786](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5786) and [CASMTRIAGE-3727](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3727)

## Issues and Related PRs

* Resolves [CASMPET-5837](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5837)

## Testing

Ran the script to verify the fix to add the container to `kubectl exec`

```
# ./ncnPostgresHealthChecks.sh
.
.
.
PASSED. All postgresql checks passed.
```

### Tested on:

surtur

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable