### PR TITLE
CASMCMS-8068: Allow user to specify image used in barebones test

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.9-1.x86_64
-    - cray-cmstools-crayctldeploy-1.5.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.22.0-1.x86_64
     - csm-testing-1.14.33-1.noarch
     - goss-servers-1.14.33-1.noarch


### PR DESCRIPTION
## Summary and Scope

Adds the option for users to specify the image used in the barebones boot test. In some cases, the default of picking the first image with "barebones" in its name does not work. This allows a way to handle that, if it occurs.

## Related PRs

Source PR: https://github.com/Cray-HPE/cms-tools/pull/44
csm-rpms PR: https://github.com/Cray-HPE/csm-rpms/pull/518
Doc PR: https://github.com/Cray-HPE/docs-csm/pull/2134

## Testing

I tested this on rocket, both with and without an ID being specified, to make sure that both cases still work correctly. I also tested to make sure it behaved appropriately if an invalid ID is specified.

## Risks and Mitigations

Low risk -- the default behavior of the test is not changed. This only adds a new option. And this new option allows some people to be able to run the test who otherwise would not be able to.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
