### PR TITLE
Add UUID to tenant status section (CASMINST-4907)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -297,5 +297,5 @@ spec:
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.4
+    version: 0.0.5
     namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Adding UUID to status section will allow us to differentiate between two tenants with the same name (one already deleted).

## Issues and Related PRs

* Resolves [CASMINST-4907](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4907)

## Testing

```
{
  "childnamespaces": [
    "vcluster-coke-user",
    "vcluster-coke-slurm"
  ],
  "state": "Deployed",
  "tenantresources": [
    {
      "enforceexclusivehsmgroups": true,
      "hsmgrouplabel": "coke",
      "type": "compute",
      "xnames": [
        "x0c3s5b0n0",
        "x0c3s6b0n0"
      ]
    }
  ],
  "uuid": "d6ffdf70-5ef0-4ed1-9f06-3059a30839a0"
}
```

### Tested on:

  * Virtual Shasta

### Test description:

Ran several chart updates -- created/modified/deleted tenants...

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


