### PR TITLE
CASMINST-3788: Bump SLS version

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.5
+    version: 2.1.6
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
* Add SLS Migrator to deal with malformed data from older CSM releases.
    * When malformed liquid-cooled Chassis data is encountered a corresponding ChassisBMC will be created.
    * When malformed xname derived fields (Parent, Type, TypeString) are encountered the object will be PUT back into SLS to recalculate the fields.
* Added CDUMgmtSwitch as an acceptable type to the SLS CT functional tests.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3788](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3788)

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No
Tested on Vshasta. For testing see: https://github.com/Cray-HPE/hms-sls/pull/52

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

