### PR TITLE
CASMPET-5796: cray-istio and cray-kiali versions for istio 1.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released new cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.10.6 (CASMPET-5796)
 - Released cray-keycloak 3.6.0 to add keycloak service to hmn-gateway (CASMPET-5812)
 - Updated cfs-operator to 1.15.0 to fix kafka client initialization
 - Changed how sls search API generates SQL (CASMHMS-5488)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -61,7 +61,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.21.12
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
@@ -157,11 +157,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.24.0
+    version: 1.25.0
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.27.2   # Update cray-precache-images above on proxyv2 tag change.
+    version: 1.28.0   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -201,11 +201,11 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.6.3
+    version: 2.7.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.3.0
+    version: 0.4.0
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Upgrade to istio 1.10.6.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5796](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5796)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

In both vshasta and mug systems, upgraded the istio charts to use the new v1.10.6 images (as well as latest opa envoy plugin & kiali v1.36.7)and validated the following:

* capmc api call still works with an admin token
* kiali & grafana UIs still work and show the correct component versions
* can still log into keycloak UIs (after restarting keycloak-postgres & cray-keycloak statefulsets to run the new envoy sidecar for them) and create clients & users

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

