### PR TITLE
CASMINST-5124/CASMINST-5129: Fix NCN image build issue, Fix typo in ncn-healthcheck-master script

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.9-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.0-1.x86_64
-    - csm-testing-1.14.33-1.noarch
-    - goss-servers-1.14.33-1.noarch
+    - csm-testing-1.14.34-1.noarch
+    - goss-servers-1.14.34-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.31-1.noarch


### PR DESCRIPTION
## Summary and Scope

See source PRs for details:
https://github.com/Cray-HPE/csm-testing/pull/348
https://github.com/Cray-HPE/csm-testing/pull/347

## Issues and Related PRs

Fixes: [CASMINST-5124](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5124)
Fixes: [CASMINST-5129](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5129)

## Testing

Tested changes on surtur.

## Risks and Mitigations

Without these changes, one of the goss test scripts does not work, and the goss-servers RPM cannot be updated to a new version in the NCN images.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
