### PR TITLE
HSM Locking and Discovery Improvements

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.7
+    version: 2.1.8
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This mod updates the HSM chart version to 2.1.8 for:
- CASMHMS-5355 - Changes the `/hsm/v2/locks/reservations/check` API to return failures for reservations that don't exist.
- CASMHMS-5387 - Enhances discovery to properly discover power URLs and control info for Intel nodes.

## Issues and Related PRs

* Resolves [CASMHMS-5355](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5355)
* Resolves [CASMHMS-5387](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5387)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/86

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

