### PR TITLE
CASMPET-5501: Pulling in latest kyverno-policy

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -137,7 +137,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.0.0
+    version: 1.2.0
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Expand kyverno policy to include more BOS V2 pods.

## Issues and Related PRs

CASMPET-5501
## Testing

Yes. See https://github.com/Cray-HPE/cray-kyverno-policies/pull/2.

## Risks and Mitigations

Low. 


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

