### PR TITLE
CASMCMS-8085/8103: Fix BOS v2 bugs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.1+1e2f26c 
+    version: 2.0.0-beta.1
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes two bugs introduced in BOS v2.  One was a regression that made listing v1 sessiontemplates sometimes fail.  The other was a race condition where rebooting a node with the same CFS configuration could result in the BOS session completing before configuration was complete.

## Issues and Related PRs

* Resolves CASMCMS-8085
* Resolves CASMCMS-8103

## Testing

### Tested on:

  * Fanta

### Test description:

Tested know failure cases before and after the update.  See original PRs for more detail.

## Risks and Mitigations

No


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

