### PR TITLE
CASMTRIAGE-3756 - fix import of barebones image.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -150,13 +150,13 @@ spec:
             tag: 1.3.1
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.5.0
+            tag: 1.6.0
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
## Summary and Scope

Fix the import of the barebones image and recipe.  There was a change the base image that we use to build the barebones image from the recipe that resulted in file permissions that didn't allow the 'nobody' user to access the resulting boot image file.  This fixes the file permissions so the boot image can be transferred to the install image and installed on the system. 

Code PR's:
https://github.com/Cray-HPE/image-recipes/pull/25
https://github.com/Cray-HPE/ims-load-artifacts/pull/19

## Issues and Related PRs

* Resolves [CASMTRIAGE-3756](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3756)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I uploaded new versions of the images and helm charts, then used helm/loftsman to uninstall/re-install the package. This is not a running service, it just kicks off an import job that completes and exits. After it completed the data import I verified it was correctly present in IMS and was able to be accessed for the barebones image boot test. The boot test still failed, but that was due to BOA not having been updated for the new capmc API.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? N - not a service
- Was downgrade tested? If not, why? N - not a service
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a very low risk change - it just fixes the file permissions while the boot image file is being created from the recipe image, so the boot image can get copied into the install docker image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

