### PR TITLE
CASMPET-5840: whitelist keycloak for hmn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-opa 1.22.0 to whitelist keycloak for hmn (CASMPET-5860)
 - Released new cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.10.6 (CASMPET-5796)
 - Released cray-keycloak 3.6.0 to add keycloak service to hmn-gateway (CASMPET-5812)
 - Updated cfs-operator to 1.15.0 to fix kafka client initialization

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.20.0
+    version: 1.22.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Allow keycloak token to be retrieved for hmn in order to support fabric manager.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5840](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5840)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`
  
### Test description:

Verified that keycloak token can now be retrieved within hmn, after the chart is upgraded.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

