### PR TITLE
CASMNET-1741:  Update gateways tests to include HMN gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update update-uas to v1.7.4 - Update gateways tests to include HMN gateway (CASMNET-1741) 
 - Released new cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.10.6 (CASMPET-5796)
 - Released cray-keycloak 3.6.0 to add keycloak service to hmn-gateway (CASMPET-5812)
 - Updated cfs-operator to 1.15.0 to fix kafka client initialization

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -170,7 +170,7 @@ spec:
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.7.3
+    version: 1.7.4
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

Adding HMNLB network to the gateway tests now that the hmn-gateway has authN and authZ.

I added the cray-nls (argo) service to the set of tested services since that was added in 1.3.

I also changed the use-api-gw-override to false so the test is no longer using api-gw-service-nmn.local.   We are starting to move away from that name.

The HMNLB network is not accessible on the UAI so it only ends up trying to get a token and then moving on when it finds that it cannot get the token (as expected).

## Issues and Related PRs

* Resolves CASMNET-1741

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`

### Test description:

Ran the gateway tests on both NCN and UAI on surtur.   All UAI tests passed. 

I also ran the tests on an earlier install of surtur where the UAI did not have the HMN and HMNLB blocked.  The test caught this and CASMUSER-3050 was created.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

