### PR TITLE
Use Controls.Deep PATCH for Olympus power capping

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -44,7 +44,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 3.0.5
+    version: 3.0.6
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Olympus hardware doesn't allow multiple power cap controls to be modified at the same time but there is something called a deep patch that is available. Converted CAPMC to use the deep patch mechanism for Olympus nodes.

### Issues and Related PRs

* Resolves [CASMHMS-5436](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5436)

### Testing

Tested on:

* `loki`

Upgraded to test CAPMC and verified power cap setting can be applied with the newer CAPMC using the deep patch.

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

