### PR TITLE
casmpet-5531: BREAK/FIX: etcd cluster restore needs to verify that et…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-utils v1.3.4 for recent changes
 - Released new cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.10.6 (CASMPET-5796)
 - Released cray-keycloak 3.6.0 to add keycloak service to hmn-gateway (CASMPET-5812)
 - Updated cfs-operator to 1.15.0 to fix kafka client initialization

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -35,6 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.3-1.noarch
+    - platform-utils-1.3.4-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.3.4 released version of csm-utils
Update changelog: - Released csm-utils v1.3.4 for recent changes

This pulls in changes for:
* CASMPET-5531
### Summary and Scope

Master - CASMPET-5531: BREAK/FIX: etcd cluster restore needs to verify that etcd-client gets created.

At times during an etcd cluster restore, the etcd operator fails to create the etcd-client service.
With this change, early detection of this failure now automatically repeats up to four attempts of the restore process before notifying the user of the failed restore.


