### PR TITLE
CASMINST-4950 Use vShasta to run helm tests during csm builds

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -23,7 +23,7 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  *
  */
-@Library('csm-shared-library') _
+@Library('csm-shared-library@main') _
 def credentialsId = 'artifactory-algol60'
 pipeline {
     agent {
@@ -35,6 +35,23 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '5'))
         timestamps()
         disableConcurrentBuilds()
+    }
+
+    environment {
+        RELEASE_NAME = "csm"
+        SLACK_CHANNEL_NOTIFY = "casm_release_management"
+        SLACK_CHANNEL_ALERTS = "csm-release-alerts"
+        // See https://githubmemory.com/repo/jenkinsci/snyk-security-scanner-plugin/issues/107
+        SNYK_TOKEN = credentials('SNYK_TOKEN')
+    }
+
+    parameters {
+        booleanParam(name: 'SKIP_VALIDATE', defaultValue: false, description: "Skip Validate stage")
+        booleanParam(name: 'FORCE_BUILD', defaultValue: false, description: "Force building release tarball, even if not on a tag")
+        booleanParam(name: 'FORCE_TEST', defaultValue: false, description: "Force running Helm tests, even if not on a tag")
+        booleanParam(name: 'FORCE_PUBLISH', defaultValue: false, description: "Force publish to Artifactory, even if not on a tag")
+        booleanParam(name: 'FORCE_REPORT', defaultValue: false, description: "Force reporting to Slack, even if not on a tag")
+        booleanParam(name: 'FORCE_CLEANUP', defaultValue: false, description: "Cleanup vShasta instance after running tests. If not cleaned up, instance will be automatically shut down by scheduler at 8PM ET.")
     }
 
     stages {
@@ -53,6 +70,11 @@ pipeline {
         }
 
         stage('Validate') {
+            when {
+                not {
+                    environment(name: "SKIP_VALIDATE", value: "true")
+                }
+            }
             parallel {
                 stage('Assets') {
                     steps {
@@ -85,33 +107,47 @@ pipeline {
         }
 
         stage('Release') {
-            when { tag "v*" }
-
-            environment {
-                RELEASE_NAME = "csm"
-                SLACK_CHANNEL_NOTIFY = "casm_release_management"
-                SLACK_CHANNEL_ALERTS = "csm-release-alerts"
-            }
-
-            stages {
-                stage('Init') {
-                    steps{
-                        script {
-                            env.RELEASE_VERSION = sh(script: './version.sh', returnStdout: true).trim()
-                            slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting, see #${env.SLACK_CHANNEL_ALERTS} for details")
-                            slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting")
+            parallel {
+                stage('Run Helm Tests in vShasta') {
+                    when {
+                        anyOf {
+                            tag "v*"
+                            environment(name: "FORCE_TEST", value: "true")
                         }
-                    }
-                }
-
-                stage('Build') {
-                    environment {
-                        // See https://githubmemory.com/repo/jenkinsci/snyk-security-scanner-plugin/issues/107
-                        SNYK_TOKEN = credentials('SNYK_TOKEN')
                     }
                     steps {
                         script {
-                            slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
+                            try {
+                                deployVshasta(
+                                    forceRecreate: true,
+                                    overrideManifests: sh(returnStdout: true, script: "find \$(realpath manifests/) -name '*.yaml'").split("\n")
+                                )
+                                withEnv(["KUBECONFIG=${env.HOME}/.config/ahoy/kubeconfig.yaml"]) {
+                                    runHelmTests()
+                                }
+                                if ( env.FORCE_CLEANUP == "true" ) {
+                                    println "Cleaning up vShasta"
+                                    deployVshasta.vshastaOperation("destroy", true)
+                                }
+                            } catch (Throwable e) {
+                                println "Error happened while running Helm tests on vShasta: ${e}"
+                            }
+                        }
+                    }
+                }
+                stage('Build Release Tarball') {
+                    when {
+                        anyOf {
+                            tag "v*"
+                            environment(name: "FORCE_BUILD", value: "true")
+                        }
+                    }
+                    steps {
+                        script {
+                            env.RELEASE_VERSION = sh(script: './version.sh', returnStdout: true).trim()
+                            slackSendIf(channel: env.SLACK_CHANNEL_NOTIFY, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting, see #${env.SLACK_CHANNEL_ALERTS} for details")
+                            slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting")
+                            slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Running release.sh")
                             withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
                                 sh """
                                     . build/.env/bin/activate
@@ -125,80 +161,91 @@ pipeline {
                     post {
                         success {
                             script {
-                                slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Built release distribution")
+                                slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Built release distribution")
                             }
-                            
                         }
-                        unsuccessful {
+                        failure {
                             script {
-                                slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: release.sh did not exit successfully")
+                                slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: release.sh did not exit successfully")
                             }
                         }
-                    }
-                }
-
-                stage('Publish') {
-                    steps {
-                        script {
-                            slackSend(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Publishing distributions")
-                            env.RELEASE_MAJOR_MINOR = sh(script: 'echo $RELEASE_VERSION | cut -d . -f 1,2', returnStdout: true).trim()
-                        }
-                        rtUpload (
-                            serverId: 'ARTIFACTORY_ALGOL60',
-                            failNoOp: true,
-                            spec: """{
-                                "files": [
-                                    {
-                                    "pattern": "dist/*.tar.gz",
-                                    "target": "csm-releases/${RELEASE_NAME}/${RELEASE_MAJOR_MINOR}/"
-                                    },
-                                    {
-                                    "pattern": "dist/*-snyk-results.xlsx",
-                                    "target": "csm-releases/${RELEASE_NAME}/${RELEASE_MAJOR_MINOR}/"
-                                    }
-                                ]
-                            }""",
-                        )
-                    }
-                    post {
-                        success {
-                            script {
-                                env.RELEASE_BASEURL = "https://artifactory.algol60.net/artifactory/csm-releases/${env.RELEASE_NAME}/${env.RELEASE_MAJOR_MINOR}"
-                                env.RELEASE_FILENAME = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz"
-                                env.RELEASE_URL = "${env.RELEASE_BASEURL}/${env.RELEASE_FILENAME}"
-                                slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Release distribution at ${env.RELEASE_URL}")
-                            }
-                        }
-                        unsuccessful {
-                            script {
-                                slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: Publishing distributions was not successful")
-                            }
-                        }
-                    }
-                }
-            }
-            post {
-                success {
-                    script {
-                        env.SNYK_RESULTS_FILENAME = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-scans.tar.gz"
-                        env.SNYK_RESULTS_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_FILENAME}"
-                        env.SNYK_RESULTS_SHEET = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-snyk-results.xlsx"
-                        env.SNYK_RESULTS_SHEET_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_SHEET}"
-                        slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Success!\n- Release distribution: <${env.RELEASE_URL}|${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz>\n- Snyk results: <${env.SNYK_RESULTS_SHEET_URL}|${env.SNYK_RESULTS_SHEET}> (raw scan results: <${env.SNYK_RESULTS_URL}|${env.SNYK_RESULTS_FILENAME}>)")
-                    }
-                }
-                failure {
-                    script {
-                        slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: Build did not complete successfully")
-                    }
-                }
-                aborted {
-                    script {
-                        slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "warning", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :warning: Job was aborted")
-                        slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "warning", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :warning: Job was aborted")
                     }
                 }
             }
         }
+
+        stage('Publish') {
+            when {
+                anyOf {
+                    tag "v*"
+                    environment(name: "FORCE_PUBLISH", value: "true")
+                }
+            }
+            steps {
+                script {
+                    slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Publishing distributions")
+                    env.RELEASE_MAJOR_MINOR = sh(script: 'echo $RELEASE_VERSION | cut -d . -f 1,2', returnStdout: true).trim()
+                }
+                rtUpload (
+                    serverId: 'ARTIFACTORY_ALGOL60',
+                    failNoOp: true,
+                    spec: """{
+                        "files": [
+                            {
+                            "pattern": "dist/*.tar.gz",
+                            "target": "csm-releases/${RELEASE_NAME}/${RELEASE_MAJOR_MINOR}/"
+                            },
+                            {
+                            "pattern": "dist/*-snyk-results.xlsx",
+                            "target": "csm-releases/${RELEASE_NAME}/${RELEASE_MAJOR_MINOR}/"
+                            }
+                        ]
+                    }""",
+                )
+            }
+            post {
+                always {
+                    script {
+                        env.RELEASE_BASEURL = "https://artifactory.algol60.net/artifactory/csm-releases/${env.RELEASE_NAME}/${env.RELEASE_MAJOR_MINOR}"
+                        env.RELEASE_FILENAME = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz"
+                        env.RELEASE_URL = "${env.RELEASE_BASEURL}/${env.RELEASE_FILENAME}"
+                        slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Release distribution at ${env.RELEASE_URL}")
+                        env.SNYK_RESULTS_FILENAME = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-scans.tar.gz"
+                        env.SNYK_RESULTS_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_FILENAME}"
+                        env.SNYK_RESULTS_SHEET = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-snyk-results.xlsx"
+                        env.SNYK_RESULTS_SHEET_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_SHEET}"
+                        def message = """
+                            <${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Success!
+                            - Release Distribution: <${env.RELEASE_URL}|${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz>
+                            - Snyk Test Results: <${env.SNYK_RESULTS_SHEET_URL}|${env.SNYK_RESULTS_SHEET}> (raw scan results: <${env.SNYK_RESULTS_URL}|${env.SNYK_RESULTS_FILENAME}>)
+                        """.stripIndent().trim()
+                        def testResults = jenkinsUtils.getTestResults()
+                        if ( testResults && testResults.executedCount > 0 ) {
+                            message += "\n- Helm Test Results: <${env.BUILD_URL}/testReport|passed ${testResults.passCount}/${testResults.executedCount} (rate ${testResults.passRateFormatted}%>)"
+                        }
+                        slackSendIf(channel: env.SLACK_CHANNEL_NOTIFY, color: (testResults && testResults.failCount > 0) ? "warning" : "good", message: message)
+                    }
+                }
+                failure {
+                    script {
+                        slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: Publishing distributions was not successful")
+                        slackSendIf(channel: env.SLACK_CHANNEL_NOTIFY, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: Build did not complete successfully")
+                    }
+                }
+                aborted {
+                    script {
+                        slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :x: Publishing distributions was not successful")
+                        slackSendIf(channel: env.SLACK_CHANNEL_ALERTS, color: "warning", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :warning: Job was aborted")
+                        slackSendIf(channel: env.SLACK_CHANNEL_NOTIFY, color: "warning", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :warning: Job was aborted")
+                    }
+                }
+            }
+        }
+    }
+}
+
+def slackSendIf(params) {
+    if ( env.GIT_TAG?.startsWith("v") || env.FORCE_REPORT == "true" ) {
+        slackSend(channel: params.channel, color: params.color, message: params.message)
     }
 }


### PR DESCRIPTION
## Summary and Scope

Introduce additional stage, which runs in parallel with main release. This stage spins up vShasta v1 instance, installs all Helm charts from current csm manifest and runs Helm tests against installed charts. If stage succeeds, test result is included into final Slack message published in `#casm_release_management` channel. If stage fails for some reason, test result just not reported.

Current flow:
![image](https://user-images.githubusercontent.com/320082/182251344-69a5a22b-e6c0-497f-9134-189d910cf5f6.png)

Suggested flow (new stage is marked unstable, because of test failures):
![image](https://user-images.githubusercontent.com/320082/182251622-d9b5d82e-e7b0-4b05-be00-cefcbfdc8b2a.png)

Slack report sample:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/320082/182251534-de5557c1-14df-4dd1-96c7-1b1a553b305e.png">

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4950](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4950)

## Testing

### Tested on:

  * Jenkins

### Test description:

Tested on feature branch, by temporarily overriding run conditions and Slack channel.

## Risks and Mitigations

Low - in case of failure result is ignored.