### PR TITLE
CASMHMS-5631 Update hms-mountain-discovery image to v0.7.0 built with GitHub Actions

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -35,7 +35,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 2.0.4
+    version: 2.0.5
     namespace: services
 
   # Cray DHCP Kea


### PR DESCRIPTION
### Summary and Scope

This PR updates hms-discovery to use the hms-mountain-discovery:0.7.0 image which includes the following changes:

- Updated hms-mountain-discovery to build using GitHub Actions instead of Jenkins.
- Pull images from artifactory.algol60.net instead of arti.dev.cray.com.
- Updated Alpine base image version.
- Updated and fixed runUnitTest.sh.

### Issues and Related PRs

* Resolves CASMHMS-5631.

### Testing

This change was tested by verifying that the new hms-mountain-discovery version was built successfully using GitHub Actions and the resulting image was pushed to the expected location in Algol60 Artifactory. The newly built hms-mountain-discovery was also spun up locally in a docker-compose environment. No integration or CT tests to run for hms-mountain-discovery or hms-discovery.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.