### PR TITLE
CASMPET-5838-1.3 : Break/Fix: Etcd health checks failing - need to specificy etcd container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released csm-utils v1.3.5 for recent ncnHealthChecks etcd fixes
+- Released goss-servers/csm-testing v1.14.36 for goss etcd fixes
 - Update update-uas to v1.7.4 - Update gateways tests to include HMN gateway (CASMNET-1741) 
 - Released cray-opa 1.22.0 to whitelist keycloak for hmn (CASMPET-5860)
 - Released csm-utils v1.3.4 for recent changes

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -35,6 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.4-1.noarch
+    - platform-utils-1.3.5-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.9-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.0-1.x86_64
-    - csm-testing-1.14.34-1.noarch
-    - goss-servers-1.14.34-1.noarch
+    - csm-testing-1.14.36-1.noarch
+    - goss-servers-1.14.36-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.31-1.noarch


### PR DESCRIPTION
## Summary and Scope

Adding the container (-c etcd) when exec'ing into the etcd pods.
This covers changes needed for:
** ncnHealthCHecks.sh (utils)
** goss tests (csm-testing)
** md docs (docs-csm)

This change is not needed for csm 1.0 or 1.2.

Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? bug fix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5838](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5838)
* Change will also be needed in NA (only needed for CSM 1.3 and beyond)
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after `<insert PR URL here>`

## Testing

drax

### Tested on:

  * `drax`

### Test description:

Ran ncnHealthChecks and goss test to verify no regressions in the fix.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
