### PR TITLE
CASMISNT-5126 Prevent api calls to recreate an existing repository.

### DIFF
--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -5,7 +5,7 @@
 : "${PACKAGING_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.3}"
 : "${RPM_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/rpm-tools:1.0.0}"
 : "${SKOPEO_IMAGE:=quay.io/skopeo/stable:v1.4.1}"
-: "${CRAY_NEXUS_SETUP_IMAGE:=artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1}"
+: "${CRAY_NEXUS_SETUP_IMAGE:=artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.0}"
 : "${ARTIFACTORY_HELPER_IMAGE:=arti.hpc.amslabs.hpecorp.net/dst-docker-master-local/arti-helper:latest}"
 
 # Prefer to use docker, but for environments with podman


### PR DESCRIPTION
## Summary and Scope

With the updated CSM 1.3 version of Nexus, we will need to prevent api calls to recreate an existing repository. Full details in CASMINST-5136.

## Issues and Related PRs

* Resolves [CASMINST-5136](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5136)

## Testing

Tested on Fanta.
See https://github.com/Cray-HPE/nexus-setup/pull/11
