### PR TITLE
CASMCMS-7970 - build automation updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated console services to use HSM v2 api.
 - Added anti-affinty settings to cray-console-node pods.
 - Updated HMS CT tests for Helm test and removed old RPMs.
+- Updated IMS to provide a larger default image size (CASMCMS-8015)
 
 
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -38,7 +38,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 1.4.0
+      - 1.5.0
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.5.0
+    version: 3.6.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Most of the changes here are related to the upcoming retirement of the dev.cray.com domain - artifacts still used in that domain needed to have server addresses updated to the new location in the hpe network.

This also pulls in a dependency update for ims-utils that was causing problems with python modules.

There is also a small change to the default ims job size to handle larger images.

## Issues and Related PRs
* Resolves [CASMCMS-7970](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7970)
* Resolves [CASMCMS-8093](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8093)
* Resolves [CASMCMS-8015](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8015)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I put the entire final package of changes together and upgraded the IMS installation on fanta via helm.  I then ran a recipe build job and an image customization job.  There were some problems with the recipe build centered around nexus access, but others were experiencing the same nexus issues, so I concluded that ims was working correctly.  I left the ims version on the system and it was used in conjunction with ongoing cfs image build testing and worked as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a low risk change - all the changes are either very simple or just updating to a new server address to point to the same base images.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

