### PR TITLE
Add New state and fix erroneus Deploying state for tapms

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -297,5 +297,5 @@ spec:
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.5
+    version: 0.0.6
     namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Use mutating webhook to publish correct state for dependent operators, as well as adding new state.  This change moves the 'state' field form the status section to spec.

## Issues and Related PRs

* Resolves [CASMINST-4908](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4908)

## Testing


```
    "spec": {
        "childnamespaces": [
            "user",
            "slurm"
        ],
        "state": "Deployed",    <----------- moved from 'status' section
        "tenantname": "vcluster-pepsi",
        "tenantresources": [
            {
                "enforceexclusivehsmgroups": true,
                "hsmgrouplabel": "pepsi",
                "type": "compute",
                "xnames": [
                    "x0c3s2b0n0",
                    "x0c3s3b0n0"
                ]
            }
        ]
    },
```

### Tested on:

  * Virtual Shasta

### Test description:

Ran through CRUD operations, observed good state for appropriate deployment status.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
