### PR TITLE
MTL-1864 add ca-cert role to csm-config

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.11.0-alpha.3+9d8917e
+    version: 1.11.0-alpha.4+c863b34
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Update the csm-config version. Adds the csm.ncn.ca_cert role for CFS.

## Issues and Related PRs
https://jira-pro.its.hpecorp.net:8443/browse/MTL-1864
https://github.com/Cray-HPE/csm-config/pull/66
https://github.com/Cray-HPE/docs-csm/pull/2163

## Testing

### Tested on:

  * Hermod

### Test description:

Created a new CFS configuration on Hermod and added the role. The play ran successfully and included the desired changes.

## Risks and Mitigations

Low risk.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

