### PR TITLE
CASMPET-5743: Update keycloak-localize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak-users-localize v1.11.2 to fix keycloak localize not copying all users to /etc/passwd (CASMPET-5743)
 - Released csm-utils v1.3.5 for recent ncnHealthChecks etcd fixes
 - Released goss-servers/csm-testing v1.14.36 for goss etcd fixes
 - Update update-uas to v1.7.4 - Update gateways tests to include HMN gateway (CASMNET-1741) 

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -245,7 +245,7 @@ spec:
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.1
+    version: 1.11.2
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This solves the issue with the keycloak-localize job failing to copy all the keycloak users to the local systems. It solves the issue seen by ensuring that all the users keycloak has are received for processing extending the loop if a less than full page is returned by keycloak.

## Issues and Related PRs

* Resolves [CASMPET-5743](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5743)

## Testing

### Tested on:

  * vale
  * rocket

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?no there is no downgrade for the job
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No known risks


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

