### PR TITLE
Casminst 5145

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -113,7 +113,7 @@ spec:
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.4.0
+    version: 1.5.0
     namespace: services
   - name: cray-crus
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -98,7 +98,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.3.11
+    version: 2.4.0
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

A few CMS deployments that use the PET provided postgres operator to provision SQL clusters was impacted by a recent change to istio. This change impacted the ability to communicate between pods without an additional SSL/TLS layer, and both of these deployments expect a "no-ssl" configuration (for reasons of performance). The use of the updated base chart provides istio with the necessary configuration options to allow these deployments to function once again.

## Issues and Related PRs
* Resolves [CASMINST-5145]
* Resolves [CASMINST-5147]

## Testing
Dev built branches with this code were applied to the system, however the system did not have an updated istio controller. These tests that were performed showed that existing integration with older istio functioned to ensure backwards compatibility. For 8.2.0 specific changes, the PET team performed additional testing on vshasta specific to the gitea deployment to ensure continued service.

### Tested on:

  * `groot`
  * Local development environment
  * Virtual Shasta

### Test description:
Helm chart and image sync to local systems for testing and install, rollback applied to these systems afterwards.
