### PR TITLE
CASMPET-5856 Bump cray-opa to 1.23.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.22.0
+    version: 1.23.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This allows the heartbeat spire JWT to have access to `/apis/hbtd/hmi/v1/params`. This is used in the cray-heartbeat.sh script to request the heartbeat warning wait timeout.

## Issues and Related PRs


* Resolves [CASMPET-5856](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5856)
* https://github.com/Cray-HPE/cray-opa/pull/56

## Testing

### Tested on:

  * shandy

### Test description:

Validated that the cray-heartbeat script could successfully request the warning timeout from `/apis/hbtd/hmi/v1/params`.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed for this change.
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

