### PR TITLE
CASMHMS-5646 Update FAS for arti.dev.cray.com domain retirement

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -48,7 +48,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.1.4
+    version: 2.1.5
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

This PR updates FAS to the v1.23.0 image which includes the following changes:

- Removed unused integration test Pipfile and Dockerfiles (contained reference to arti.dev.cray.com)
- Updated to stable, nightly algol60 images.
- Updated Alpine base image version.

### Issues and Related PRs

* Resolves [CASMHMS-5646](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5646).

### Testing

This change was tested by building and running the FAS unit, integration, and CT tests and verifying that they continued to pass.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.