### PR TITLE
CASMCMS-8140 - correctly handle Hill nodes.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,15 +105,15 @@ spec:
         tag: 3.5.0
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
   - name: cray-crus
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

In csm-1.2, hsm changed so that the 'node class' can be either 'Mountain', 'River', or 'Hill'. The 'hill' types were not getting picked up by console services. This set of changes looks for records containing 'Hill' and treats them correctly.

Code PR's:
https://github.com/Cray-HPE/console-data/pull/28
https://github.com/Cray-HPE/console-node/pull/56
https://github.com/Cray-HPE/console-operator/pull/34

## Issues and Related PRs
* Resolves [CASMCMS-8140](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8140)

## Testing
### Tested on:
  * `Loki`

### Test description:
I installed the new version via helm and observed that Hill nodes were correctly picked up by console services and connections and logging were established.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a fairly low risk change, it just needs to handle the 'Hill' type in the existing records.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

