### PR TITLE
CASMCMS-8120: Update cfs-operator for additional inventory bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
-<<<<<<< HEAD
-=======
+- Updated cfs-operator to 1.14.18 for CFS fixes around additional inventory
 - Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)
 - Released spire 2.5.0 for sec vulnerability and image auto rebuild (CASMINST-4505)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -81,7 +81,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.14.15
+    version: 1.14.18
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes two CFS issues found by NERSC around using additional inventory with image customization.

## Issues and Related PRs

* Resolves CASMCMS-8120
* Resolves CASMCMS-8121

## Testing

### Tested on:

  * Fanta

### Test description:

Ran image customization with and without additional inventory

## Risks and Mitigations

The CHANGELOG doesn't appear to have been updated for the 1.2 release.  I'm not sure if the comment needs to go in a new 1.2.1 section.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

