### PR TITLE
CASMCMS-8120: Update cfs-operator for additional inventory bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cfs-operator 1.16.0 to fix issues with additional inventory
 - Released cray-keycloak-users-localize v1.11.2 to fix keycloak localize not copying all users to /etc/passwd (CASMPET-5743)
 - Released csm-utils v1.3.5 for recent ncnHealthChecks etcd fixes
 - Released goss-servers/csm-testing v1.14.36 for goss etcd fixes

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,7 +78,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.15.0
+    version: 1.16.0
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes two CFS issues found by NERSC around using additional inventory with image customization.

## Issues and Related PRs

* Resolves CASMCMS-8120
* Resolves CASMCMS-8121

## Testing

### Tested on:

  * Fanta

### Test description:

Ran image customization with and without additional inventory

## Risks and Mitigations

The CHANGELOG doesn't appear to have been updated for the 1.2 release.  I'm not sure if the comment needs to go in a new 1.2.1 section.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

