### PR TITLE
CASMNET-1069 - Create PTR records that are not created by externaldns

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.6.9
+    version: 0.7.0
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.14
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.9
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.9
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.0
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

The External DNS service that creates DNS records for Kubernetes services does not support the generation of PTR records, only A records. Several customers require that PTR records exist for services for security purposes.

This PR introduces a new cray-externaldns-manager container that runs within the cray-powerdns-manager pod that scans PowerDNS for TXT records with an external-dns signature, if any are found the associated A record is identified and a PTR record is generated. An externaldns-manager TXT record is also generated to aid identification and removal of stale records.

## Issues and Related PRs

* Resolves [CASMNET-1069](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1069)
* Documentation changes required in [CASMNET-1753](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1753)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/2162

## Testing

### Tested on:

  * `mug`
  * Local development environment
  * Virtual Shasta

### Test description:

#### Record generation

1. Create a UAI
    ```
    ncn-m002:~ # cray uas create --publickey ~/.ssh/id_rsa.pub
    uai_age = "0m"
    uai_connect_string = "ssh vers@10.101.5.166"
    uai_host = "ncn-w007"
    uai_img = "artifactory.algol60.net/csm-docker/stable/cray-uai-sles15sp3:1.6.0"
    uai_ip = "10.101.5.166"
    uai_msg = "ContainerCreating"
    uai_name = "uai-vers-a20de3d8"
    uai_status = "Waiting"
    username = "vers"
    ```
2. Verify that the corresponding PTR and TXT records are created
    ```
    ncn-m002:~ # kubectl -n services exec -it deployment/cray-dns-powerdns -c cray-dns-powerdns -- bash
    bash-5.1$ pdnsutil list-zone 5.101.10.in-addr.arpa | grep uai-vers-a20de3d8
    166.5.101.10.in-addr.arpa	3600	IN	PTR	uai-vers-a20de3d8.can.mug.dev.cray.com
    166.5.101.10.in-addr.arpa	3600	IN	TXT	"externaldns-manager/uai-vers-a20de3d8.can.mug.dev.cray.com."
    ```

3. Verify that reverse DNS lookup works
    ```
    ncn-m002:~ # host 10.101.5.166
    166.5.101.10.in-addr.arpa domain name pointer uai-vers-a20de3d8.can.mug.dev.cray.com.
    ```
#### Record Removal

1. Delete a UAI
    ```
    ncn-m002:~ # cray uas delete --uai-list uai-vers-a20de3d8
    results = [ "Successfully deleted uai-vers-a20de3d8",]
    ```

2. Verify records have been deleted

    *  cray-externaldns-manager log file
       ```
        {"level":"info","ts":1659530370.8488965,"msg":"Processing records..."}
        {"level":"info","ts":1659530371.5904093,"msg":"ProcessManagerRecord: Stale records scheduled for deletion","txt":{"name":"166.5.101.10.in-addr.arpa.","type":"TXT","ttl":3600,"records":[{"content":"\"externaldns-manager/uai-vers-a20de3d8.can.mug.dev.cray.com.\"","disabled":false}]},"ptr":{"name":"166.5.101.10.in-addr.arpa.","type":"PTR","ttl":3600,"records":[{"content":"uai-vers-a20de3d8.can.mug.dev.cray.com.","disabled":false}]}}
        ```
    * Check PowerDNS records
       ```
       ncn-m002:~ # kubectl -n services exec -it deployment/cray-dns-powerdns -c cray-dns-powerdns -- bash
       bash-5.1$  pdnsutil list-zone 5.101.10.in-addr.arpa | grep uai-vers-a20de3d8
       bash-5.1$
       ```

#### Error case - Orphaned record removal

While this scenario should not occur, In the event that a PTR record is removed but the TXT record persists it will be automatically cleaned up.
```
{"level":"error","ts":1659530650.2604904,"msg":"ProcessManagerRecord: Cannot find PTR record for TXT record","txt":"166.5.101.10.in-addr.arpa."}
{"level":"error","ts":1659530650.2605307,"msg":"Deleting orphaned Manager TXT record","record":[{"name":"166.5.101.10.in-addr.arpa.","type":"TXT","ttl":3600,"changetype":"DELETE","records":[{"content":"\"externaldns-manager/uai-vers-a20de3d8.can.mug.dev.cray.com.\"","disabled":false}]}]}
```

## Risks and Mitigations

Known limitations
* Many different hostnames are bound to a single service IP for several of the web services.
  ```
  ncn-m002:~ # kubectl -n services get svc cray-oauth2-proxies-customer-management-ingress -o yaml
  apiVersion: v1
  kind: Service
  metadata:
    annotations:
      external-dns.alpha.kubernetes.io/hostname: opa-gpm.cmn.mug.dev.cray.com,jaeger-istio.cmn.mug.dev.cray.com,kiali-istio.cmn.mug.dev.cray.com,prometheus.cmn.mug.dev.cray.com,alertmanager.cmn.mug.dev.cray.com,grafana.cmn.mug.dev.cray.com,vcs.cmn.mug.dev.cray.com,sma-grafana.cmn.mug.dev.cray.com,sma-kibana.cmn.mug.dev.cray.com,csms.cmn.mug.dev.cray.com
  ...
  ```
  The PowerDNS API will not permit the submission of multiple PTR records in one transaction for the same IP as it considers it a duplicate. If duplicate PTR records are created by hand then the next update via the API will remove all other entries. It also responds to queries inconsistently if multiple PTR records are created by hand.
  ```
  ncn-m001:~ # host 10.101.5.66
  66.5.101.10.in-addr.arpa domain name pointer prometheus.cmn.mug.dev.cray.com.
  ncn-m001:~ # host 10.101.5.66
  66.5.101.10.in-addr.arpa domain name pointer alertmanager.cmn.mug.dev.cray.com.
  66.5.101.10.in-addr.arpa domain name pointer prometheus.cmn.mug.dev.cray.com.
  ```
  To avoid issues caused by DNS queries randomly returning multiple names for the same IP, only one PTR record is created. The name it points to is arbitrary and based the order in which the PowerDNS API returns the records. For example.

  ```bash
   ncn-m002:~ # host alertmanager.cmn.mug.dev.cray.com
  alertmanager.cmn.mug.dev.cray.com has address 10.101.5.66
  ncn-m002:~ # host 10.101.5.66
  66.5.101.10.in-addr.arpa domain name pointer prometheus.cmn.mug.dev.cray.com.
  ```

* The code currently does not search for and remove orphaned PTR records as without a TXT record breadcrumb this operation is expensive (for every pointer that exists, derive forward zone, and scan forward zone to see if an A record exists), the impact of this is that a stale record will exist until the IP address is re-used and the record updated. I do not anticipate this scenario occurring unless someone performs manual edits to the zone data and removes the externaldns-manager TXT records. This could be considered for future enhancement.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable