### PR TITLE
Provide CSM-1.3 compatible versions

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,7 +147,9 @@ spec:
       cray-import-config:
         catalog:
           image:
-            tag: 1.3.1
+            tag:
+	    - 1.3.1
+	    - 1.6.0
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
     version: 1.6.0
@@ -156,12 +158,16 @@ spec:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.6.0
+            tag:
+	    - 1.6.0
+	    - 3.1.0
 
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version: 1.3.1
+    version:
+    - 1.3.1
+    - 1.6.0
     namespace: services
   # Cray UAS Manager service
   - name: cray-uas-mgr


### PR DESCRIPTION
## Summary and Scope

Provide references to versions of the following software that can and
should be used in CSM-1.3. This is in addition to the versions for the
CSM-1.2 release, which are being retained in case software has not
switched to the newer verions.

Repositories:
cray-import-config
cray-import-kiwi-recipe-image
cray-product-catalog


## Issues and Related PRs



## Testing

None.
### Tested on:

### Test description:


## Risks and Mitigations

Slight.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

