### PR TITLE
CASMINST-5187

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.11.0-alpha.4+c863b34
+    version: 1.11.0-alpha.7+7f99dbc
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

added conditional to csm.ncn.ca_cert to check for the existence of **certificate_authority.crt** before proceeding.
ncn-personalization halted because the cert didn't exist on disk. Fixes ncn-personalization.

## Issues and Related PRs

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5187

## Testing


### Tested on:

  * surtur

### Test description:

ncn-personalization executed successfully on surtur with this change

## Risks and Mitigations

Not aware of any risks.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

