### PR TITLE
Revert "Provide CSM-1.3 compatible versions"

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,9 +147,7 @@ spec:
       cray-import-config:
         catalog:
           image:
-            tag:
-	    - 1.3.1
-	    - 1.6.0
+            tag: 1.3.1
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
     version: 1.6.0
@@ -158,16 +156,12 @@ spec:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag:
-	    - 1.6.0
-	    - 3.1.0
+            tag: 1.6.0
 
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version:
-    - 1.3.1
-    - 1.6.0
+    version: 1.3.1
     namespace: services
   # Cray UAS Manager service
   - name: cray-uas-mgr


### PR DESCRIPTION
Reverts Cray-HPE/csm#1119 until it can be tested for chart functionality.