### PR TITLE
CASMNET-1710/CASMNET-1711/CASMNET-1758 - PowerDNS Manager bugfixes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.7.1
+    version: 0.7.2
     namespace: services

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.7.0
+    version: 0.7.1
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.14
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.10
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.0
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.1
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.14
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.10
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.1
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.2
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

* Fixed an issue where `cray-powerdns-manager` could intermittently crash on startup when trying to read existing TSIG keys via the PowerDNS API.
* Fixed an issue where `cray-powerdns-manager` did not retry the attempt to add the TSIG key.
* Fixed an issue where `cray-externaldns-manager` could panic on startup if the PowerDNS API connection couldn't be established.
* Applies consistent `go fmt` formatting to source files.

## Issues and Related PRs

* Resolves [CASMNET-1710](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1710)
* Resolves [CASMNET-1711](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1711)
* Resolves [CASMNET-1758](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1758)

## Testing

### Tested on:

  * `mug`

### Test description:

Deployed new artifacts on `mug`

`cray-powerdns-manager` no longer crashes and also retries the attempt to add the TSIG key  it if can't talk to PowerDNS on startup.
```
ncn-m001# kubectl -n services logs cray-powerdns-manager-6b58c5c7c7-qzfxr -c cray-powerdns-manager | head
{"level":"info","ts":1659969522.8951871,"msg":"Starting API server."}
{"level":"info","ts":1659969522.89529,"msg":"API server started."}
{"level":"info","ts":1659969522.8956025,"msg":"Parsed DNSSEC key","key":"Name: dummy"}
{"level":"info","ts":1659969522.8956232,"msg":"Parsed TSIG key","key":"Name: system-key"}
{"level":"error","ts":1659969522.8980353,"msg":"GET http://cray-dns-powerdns-api:8081/api/v1/servers/localhost/tsigkeys/system-key request failed: Get \"http://cray-dns-powerdns-api:8081/api/v1/servers/localhost/tsigkeys/system-key\": dial tcp 10.30.240.160:8081: connect: connection refused"}
{"level":"error","ts":1659969523.9002488,"msg":"GET http://cray-dns-powerdns-api:8081/api/v1/servers/localhost/tsigkeys/system-key request failed: Get \"http://cray-dns-powerdns-api:8081/api/v1/servers/localhost/tsigkeys/system-key\": dial tcp 10.30.240.160:8081: connect: connection refused"}
{"level":"info","ts":1659969526.104272,"msg":"Sending DNS NOTIFY for all zones"}
```
Previous behaviour
```
ncn-m001# kubectl -n services logs cray-powerdns-manager-7f8dcc887b-jzjnb -c cray-powerdns-manager
{"level":"info","ts":1657012854.807543,"msg":"Starting API server."}
{"level":"info","ts":1657012854.8076334,"msg":"API server started."}
{"level":"info","ts":1657012854.807811,"msg":"Parsed DNSSEC key","key":"Name: dummy"}
{"level":"info","ts":1657012854.807822,"msg":"Parsed TSIG key","key":"Name: hela"}
panic: interface conversion: error is *url.Error, not *powerdns.Error

goroutine 1 [running]:
main.AddOrUpdateTSIGKey({{0xc0002e0216, 0x4}, {0xc0005b8e70, 0x65}, 0x1})
	/build/cmd/manager/security.go:117 +0x20c
main.main()
	/build/cmd/manager/main.go:216 +0xa2b
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

