### PR TITLE
CASMINST-5161: Reduce excessive Goss script output

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.9-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
-    - csm-testing-1.14.39-1.noarch
-    - goss-servers-1.14.39-1.noarch
+    - csm-testing-1.14.40-1.noarch
+    - goss-servers-1.14.40-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.32-1.noarch


### PR DESCRIPTION
## Summary and Scope

Modify automated Goss scripts so that they only print failure information to screen, and successes to a log file.

## Issues and Related PRs

https://github.com/Cray-HPE/csm-rpms/pull/537
https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5161

## Testing

See source PR for testing details: https://github.com/Cray-HPE/csm-testing/pull/355

## Risks and Mitigations

Minor risk, but big payoff to usability.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
