### PR TITLE
initialize cray-k8s-encryption daemonset at 0.0.3

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -299,3 +299,7 @@ spec:
     source: csm-algol60
     version: 0.0.6
     namespace: tapms-operator
+  - name: cray-k8s-encryption
+    source: csm-algol60
+    version: 0.0.3
+    namespace: kube-system


### PR DESCRIPTION
## Summary and Scope

Adds a new daemonset that will mostly do nothing unless a user turns encryption on. The daemonset simply reads/mounts /etc/cray/kubernetes/encryption and reads the current.yaml file to know if/when data, in this case secrets need to be rewritten with a new encryption key.

It will work anywhere technically, even non cray systems, just isn't very useful without the appropriate data.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5845
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in TBD Will doc this once in and get to validate/test.
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested in vshasta, on mug with manual setup/hacks, as well as k3s/regular k8s clusters to ensure everything is ok.

Also has a shellspec test suite for all internal logic aka has unit tests.

### Tested on:

  * Ye olde k3s k8s clusters in openstack
  * vshasta
  * Mug by deploying the helm chart manually.

### Test description:

Largely just developed this via unit tests. Deploying in k3s and vshasta "just worked" though I've found a few more enhancements that can be made/tested/added to the unit test suite this is an MVP release.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yeah but this doesn't affect anything else really.
- Were continuous integration tests run? It was basically developed with CI in mind.
- Was upgrade tested? No, this is intended to be setup after an upgrade, though technically it could happen at upgrade time.
- Was downgrade tested? Also not really applicable, would need image changes and to back out the encryption to downgrade, though thats more due to the encryption on the etcd data itself.
- Were new tests (or test issues/Jiras) created for change. Mostly unit tests to ensure logic was sane. https://github.com/Cray-HPE/cray-k8s-encryption/blob/main/spec/node_encryption_annotation_spec.sh

## Risks and Mitigations

On its own, without setting up the encryption configuration file this largely doesn't do much except sit around and check a file every 600 seconds to determine if work needs to happen. Without that its effectively a no op.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

