### PR TITLE
CASMPET-5197 Bump cray-opa to 1.25.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.23.0
+    version: 1.25.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

CASMPET-5197 - This fixes an issue where the opa xname url was incorrectly set to /apis/hmnfd/hmi/v2/subscriptions/%v/agents$ instead of /apis/hmnfd/hmi/v2/subscriptions/%v.

CASMPET-5827 - hmcollector access should only be available on the hmn gateway. In addition to this, source restrictions aren't possible due to our double SNAT issue and are being removed.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5197](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5197)
* Resolves [CASMPET-5827 ](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5827 )
* https://github.com/Cray-HPE/cray-opa/pull/57
* https://github.com/Cray-HPE/cray-opa/pull/58

## Testing

### Tested on:
  * Local development environment

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?  Y
- Was upgrade tested? If not, why? N, tested locally via unit tests
- Was downgrade tested? If not, why? N, tested locally via unit tests
- Were new tests (or test issues/Jiras) created for this change? Tests were modified.

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

