### PR TITLE
CASMNET-1757: CANU bugfixes including UAN VLAN as None

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.5/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.5-20220804192521.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.5/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.5-20220804192521.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.5/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.5-20220804192521.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.5/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.5-20220810201418.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.5/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.5-20220810201418.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.5/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.5-20220810201418.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/csm-docker/stable:
   images:
     cray-canu:
-      - 1.6.9
+      - 1.6.13
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - canu-1.6.9-1.x86_64
+    - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
     - csm-testing-1.14.40-1.noarch


### PR DESCRIPTION
### Summary and Scope

Overview

    BUGFIX: Fix UAN configuration templates producing None VLAN when CHN is enabled.
    BUGFIX: Enable 1.3 configuration templates in the pyinstaller binary.

Details

    Update docs generated from code.
    Change exception-handling in canu validate shcd and from network_modeling.
    Provide better next steps from errors reported while validating SHCDs.
    Add canu test to ping Kea DHCP.
    Update to release process doc


- Fixes: CASMNET-1757

#### Issue Type

- Bugfix [Release 1.6.13](https://github.com/Cray-HPE/canu/pull/196)

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
