### PR TITLE
CASMNET-1757: CANU bugfixes including UAN VLAN as None

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220629214741-g941f5cd.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220629214741-g941f5cd.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220629214741-g941f5cd.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220810202700-g941f5cd.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220810202700-g941f5cd.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.5.9/cray-pre-install-toolkit-sle15sp3.x86_64-1.5.9-20220810202700-g941f5cd.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -31,7 +31,7 @@ artifactory.algol60.net/csm-docker/stable:
   images:
     # adding cray-canu image till there is a chart
     cray-canu:
-      - 1.6.5
+      - 1.6.13
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 1.3.59

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - canu-1.6.5-1.x86_64
+    - canu-1.6.13-1.x86_64
     - cf-ca-cert-config-framework-2.3.38-1.x86_64
     - cfs-state-reporter-1.7.50-1.x86_64
     - cfs-trust-1.4.4-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Overview

    BUGFIX: Fix UAN configuration templates producing None VLAN when CHN is enabled.
    BUGFIX: Enable 1.3 configuration templates in the pyinstaller binary.

Details

    Update docs generated from code.
    Change exception-handling in canu validate shcd and from network_modeling.
    Provide better next steps from errors reported while validating SHCDs.
    Add canu test to ping Kea DHCP.
    Update to release process doc


- Fixes: CASMNET-1757

#### Issue Type

- Bugfix [Release 1.6.13](https://github.com/Cray-HPE/canu/pull/196)

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
### Summary and Scope

Overview

    BUGFIX: Fix UAN configuration templates producing None VLAN when CHN is enabled.
    BUGFIX: Enable 1.3 configuration templates in the pyinstaller binary.

Details

    Update docs generated from code.
    Change exception-handling in canu validate shcd and from network_modeling.
    Provide better next steps from errors reported while validating SHCDs.
    Add canu test to ping Kea DHCP.
    Update to release process doc


- Fixes: CASMNET-1757

#### Issue Type

- Bugfix [Release 1.6.13](https://github.com/Cray-HPE/canu/pull/196)

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
