### PR TITLE
bump version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -213,7 +213,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.22.4
+    version: 0.25.0
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

CASMMON-188: create switch state prometheus alerts
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-188
CASMMON-158:  create Prometheus Network Exporter grafana dashboard
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-158
CASMMON-187: Prometheus Network Exporter grafana dashboard bug 
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-187
CASMMON-189:Update Snmp stats dash board as hpcm dashboard which supports multiple switches
CASMMON-159:temperature hardware monitoring dashboards for NCNS in SHS
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-159


## Issues and Related PRs

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/73
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/72
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/74
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/75
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/76
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/77
## Testing

### Tested on: Mug

CASMMON-188: create switch state Prometheus alerts

![image](https://user-images.githubusercontent.com/22464568/183818213-fa5c2bf1-213e-4b91-bf6c-84f38c81cfa0.png)

CASMMON-158 & CASMMON-187::  create Prometheus Network Exporter grafana dashboard

![image](https://user-images.githubusercontent.com/22464568/183818419-ed49fba7-5c72-4a03-a654-59acb4892c7d.png)

CASMMON-189:Update Snmp stats dash board as hpcm dashboard which supports multiple switches

![image](https://user-images.githubusercontent.com/22464568/183818536-0ac1e4e3-8c78-45a6-b56b-5773efe2aa9b.png)

CASMMON-159:temperature hardware monitoring dashboards for NCNS in SHS

![image](https://user-images.githubusercontent.com/22464568/183818734-b0a415e9-9e2b-4e26-ab22-bdcfb1cb559f.png)

