### PR TITLE
CASMPET-5888: add all istio images to precache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Added all istio images to Nexus precache (CASMPET-5888)
 - Updated cfs-operator to 1.14.18 for CFS fixes around additional inventory
 - Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier
 - Update csm-config v1.9.31 for bifurcated CAN enablement play (CASMNET-1528)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -61,6 +61,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.8.6-cray2-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.8.6-cray2-distroless
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
       # DNS


### PR DESCRIPTION
## Summary and Scope

During some upgrade scenarios, istio pods failed to pull images from Nexus. Adding them to precache will prevent it from happening.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5888](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5888)
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

