### PR TITLE
Add SAT 3.18.0 image to CSM

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,6 +26,11 @@ quay.io:
     skopeo/stable:
       - v1.4.1
 
+artifactory.algol60.net/sat-docker/stable:
+  images:
+    cray-sat:
+      - 3.18.0
+
 artifactory.algol60.net/csm-docker/stable:
   images:
     cray-canu:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -57,6 +57,10 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 
 # Upload assets to existing repositories
 skopeo-sync "${ROOTDIR}/docker"
+# Tag SAT image as csm-latest
+sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
+sat_version="3.18.0"
+skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 


### PR DESCRIPTION
## Summary and Scope

* Add SAT image to CSM
* When installing SAT, use `skopeo-copy` function to tag it as `csm-latest`.
* Update vendor library to include `skopeo-copy` function.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1509](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1509)
* Resolves [CRAYSAT-1508](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1508)
* Relates to https://github.com/Cray-HPE/csm-rpms/pull/542

## Testing

Testing currently in progress

## Risks and Mitigations

This change should pose little risk as it is simply adding a container image to the install.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [TODO] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

