### PR TITLE
CASMNET-1761 - powerdns-manger and externaldns-manager are updating the same record.

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.7.2
+    version: 0.7.4
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -70,7 +70,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.14
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.10
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.2
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

Certain services have aliases defined in SLS and ExternalDNS annotations.

### SLS
```
ncn-m001:~ # cray sls search networks list --name NMNLB --format json | jq '.[].ExtraProperties.Subnets[].IPReservations[] | select(.IPAddress=="10.92.100.71")'
{
  "Aliases": [
    "api-gw-service",
    "api-gw-service-nmn.local",
    "packages",
    "registry",
    "spire.local",
    "api_gw_service",
    "registry.local",
    "packages",
    "packages.local",
    "spire"
  ],
  "Comment": "api-gw-service,api-gw-service-nmn.local,packages,registry,spire.local,api_gw_service,registry.local,packages,packages.local,spire",
  "IPAddress": "10.92.100.71",
  "Name": "istio-ingressgateway"
}
```
### ExternalDNS
```
ncn-m001:~ # kubectl -n istio-system get svc istio-ingressgateway -o json | jq '.metadata.annotations,.status'
{
  "external-dns.alpha.kubernetes.io/hostname": "api.nmnlb.mug.dev.cray.com,auth.nmnlb.mug.dev.cray.com",
  "meta.helm.sh/release-name": "cray-istio",
  "meta.helm.sh/release-namespace": "istio-system",
  "metallb.universe.tf/address-pool": "node-management"
}
{
  "loadBalancer": {
    "ingress": [
      {
        "ip": "10.92.100.71"
      }
    ]
  }
}
```
This was causing powerdns-manager and externaldns-manager to "fight" over the record ownership and the record would flip/flop between the SLS and ExternalDNS name generating unnecessary AXFR notify messages.

Added a check to externaldns-manager so it only generates a PTR record for an IP if one does not already exist.

## Issues and Related PRs

* Resolves [CASMNET-1761](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1761)

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Deployed new code on mug, results in a much quieter externaldns-manager cycle as now it mostly does nothing unless a new ExternalDNS record appears.

```
{"level":"debug","ts":1660218932.4706423,"msg":"ProcessExternalDNSRecord: Found ExternalDNS TXT record","txt":"uai-alanm-e5aa36c5.can.mug.dev.cray.com.","content":"\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/user/uai-alanm-e5aa36c5-ssh\""}
{"level":"debug","ts":1660218932.4706519,"msg":"Found corresponding A record","name":"uai-alanm-e5aa36c5.can.mug.dev.cray.com.","ip":"10.101.5.162"}
{"level":"debug","ts":1660218932.4707108,"msg":"Generating PTR record","ipaddr":"162.5.101.10.in-addr.arpa"}
{"level":"debug","ts":1660218932.4707298,"msg":"Record already exits, nothing to do","rrSetReverse":{"name":"162.5.101.10.in-addr.arpa.","type":"PTR","ttl":3600,"changetype":"REPLACE","records":[{"content":"uai-alanm-e5aa36c5.can.mug.dev.cray.com.","disabled":false}]}}
{"level":"debug","ts":1660218932.4707406,"msg":"Processing zone","zone":"106.10.in-addr.arpa."}
{"level":"debug","ts":1660218932.470747,"msg":"Processing zone","zone":"107.10.in-addr.arpa."}
{"level":"debug","ts":1660218932.4707532,"msg":"Processing zone","zone":"254.10.in-addr.arpa."}
{"level":"debug","ts":1660218932.47076,"msg":"Processing zone","zone":"252.10.in-addr.arpa."}
{"level":"debug","ts":1660218932.4707682,"msg":"Processing zone","zone":"253.10.in-addr.arpa."}
{"level":"debug","ts":1660218932.470775,"msg":"Processing zone","zone":"mug.dev.cray.com."}
{"level":"debug","ts":1660218932.4707813,"msg":"Patch list","actionableRRSetMap":{"100.92.10.in-addr.arpa.":{},"100.94.10.in-addr.arpa.":{},"106.10.in-addr.arpa.":{},"107.10.in-addr.arpa.":{},"252.10.in-addr.arpa.":{},"253.10.in-addr.arpa.":{},"254.10.in-addr.arpa.":{},"5.101.10.in-addr.arpa.":{},"can.mug.dev.cray.com.":{},"cmn.mug.dev.cray.com.":{},"hmn.mug.dev.cray.com.":{},"hmnlb.mug.dev.cray.com.":{},"hsn.mug.dev.cray.com.":{},"mtl.mug.dev.cray.com.":{},"mug.dev.cray.com.":{},"nmn.mug.dev.cray.com.":{},"nmnlb.mug.dev.cray.com.":{}}}
```

powerdns-manager is also no longer updating the `100.92.10.in-addr.arpa` and `100.94.10.in-addr.arpa` zones and generating an AXFR notify each cycle.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable