### PR TITLE
CASMNET-1779 - PowerDNS record generation bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cray-powerdns-manager to 0.6.9 for various record generation fixes (CASMNET-1779)
 - Added all istio images to Nexus precache (CASMPET-5888)
 - Updated cfs-operator to 1.14.18 for CFS fixes around additional inventory
 - Fix for sma storage class missing image feature layering when upgraded from 1.0.x and earlier

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -64,5 +64,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.6.6
+    version: 0.6.9
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.10
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.7
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.6
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.6.9
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

Bump cray-powerdns-manager to 0.6.9 to include the following fixes.

[CASMNET-1631](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1631) - PTR records for the CAN subnet are missing
[CASMNET-1550](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1550) - powerdns-manager support for HSM v2 API
[CASMNET-1143](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1143) - BREAK/FIX: cray-powerdns-manager stuck updating the nmn zone.
[CASMNET-1674](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1674) - BREAK/FIX: PowerDNS - Missing A records before final NCN deployment

This release is 100% backwards compatible as it does not include the ExternalDNS PTR generation code.

## Issues and Related PRs

* Resolves [CASMNET-1779](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1779)

## Testing

### Tested on:

  * Various CSM 1.3 installs
  
### Test description:

This was the stable version of cray-powerdns-manager included in CSM 1.3 until the ExternalDNS PTR record generation code landed (CASMNET-1069).

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

