### PR TITLE
CASMCMS-8149: Update cms-ipxe for build changes and binary cleanup

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -129,7 +129,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.10.0
+    version: 1.11.0
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes an issues were an old debug binary won't get cleaned up when upgrading from cms-ipxe 1.9.  Also includes build changes to switch from dev.cray.com

## Issues and Related PRs

* Resolves CASMCMS-8149
* Resolves CASMCMS-8141

## Testing

### Tested on:

  * Mug

### Test description:

Deployed new image and allowed the cleanup to run with and without the old binary present.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

