### PR TITLE
CASMCMS-8090: Update craycli for latest BOS v2 changes

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.58.0-1.x86_64
+    - craycli-0.60.0-1.x86_64
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/:
   rpms:
    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.58.0-1.x86_64
+    - craycli-0.60.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.3.30-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch


### PR DESCRIPTION
## Summary and Scope

This updates the cli to match the final api for BOS v2, and switches the cli to start hitting the v2 endpoint if no version is specified.

## Issues and Related PRs

* Resolves CASMCMS-8090

## Testing

### Tested on:

  * Local

### Test description:

Verified that all flags/attributes were available and that cli commands translated to the correct endpoints.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

