### PR TITLE
CASMCMS-8156 - fix problem with handling hill nodes in console services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,7 +176,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added anti-affinty settings to cray-console-node pods.
 - Updated HMS CT tests for Helm test and removed old RPMs.
 - Updated IMS to provide a larger default image size (CASMCMS-8015)
-
+- Updated console services to handle Hill nodes.
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -113,7 +113,7 @@ spec:
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: services
   - name: cray-crus
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The last fix to incorporate Hill nodes into console services had a bug when it was concatenating node lists together which resulted in malformed sql queries.  This prevented the console services from acquiring nodes when there were mixed types in the same acquisition call. This fixes the node lists.

Code PR:
https://github.com/Cray-HPE/console-data/pull/31

## Issues and Related PRs
* Resolves [CASMCMS-8156](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8156)

## Testing
### Tested on:
  * `Loki`

### Test description:

I installed the new console-data service via helm, then cleared all console connections and information from the system.  I then watched as the mixed node types were acquired at the same time and successfully interacted with the database updates.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk change.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable