### PR TITLE
Fix HSN NIC discovery in HSM for Proliant iLO redfish implementations

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.8
+    version: 2.1.9
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

HSM will now discover HSN NICs under `/redfish/v1/Chassis/<sysid>/Devices` instead of `/redfish/v1/Chassis/<sysid>/NetworkAdapters` for Proliant iLO redfish implementations and ignore non-HSN NICs.

## Issues and Related PRs

* Resolves [CASMHMS-5675](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5675)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/88

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

