### PR TITLE
CASMCMS-8075 - update barebones image to use sles15sp4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated HMS CT tests for Helm test and removed old RPMs.
 - Updated IMS to provide a larger default image size (CASMCMS-8015)
 - Updated console services to handle Hill nodes.
+- Updated barebones image to use slessp4.
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -150,13 +150,13 @@ spec:
             tag: 1.3.1
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.6.0
+    version: 1.7.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.6.0
+            tag: 1.7.0
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
## Summary and Scope

Update the barebones image/recipe to use sles 15sp4 - also migrate to using the algol60 sles zypper repos.

## Issues and Related PRs
* Resolves [CASMCMS-8075](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8075)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Most of the changes were with building the image that is packaged up and contained in the install image - getting that building correctly with the new recipe and sp4 repos was most of the work.  I did use Surtur, removed the old barebones image and recipe, used the new package to install the updated one, then successfully ran the barebones image boot test using the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - it is a job, not a service
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a minor risk as the image is successfully building in Jenkins and booting like it is supposed to a real system with the barebones image boot test.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

