### PR TITLE
CASMINST-5162: Parallelize execution of remote Goss tests

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
-    - csm-testing-1.14.43-1.noarch
-    - goss-servers-1.14.43-1.noarch
+    - csm-testing-1.14.44-1.noarch
+    - goss-servers-1.14.44-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
-    - csm-testing-1.14.44-1.noarch
-    - goss-servers-1.14.44-1.noarch
+    - csm-testing-1.14.45-1.noarch
+    - goss-servers-1.14.45-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch


### PR DESCRIPTION
## Summary and Scope

Cut execution time of some of our automated Goss tests in half by running tests on multiple nodes in parallel.

## Issues and Related PRs

See source PR for details on changes and testing of those changes:
https://github.com/Cray-HPE/csm-testing/pull/363

Fixes: [CASMINST-5162](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5162)

Also pulled in the fixes for [CASMINST-5218](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5218). See its
source PR for the details on those small bug fixes:
https://github.com/Cray-HPE/csm-testing/pull/364

csm-rpms manifest PR: https://github.com/Cray-HPE/csm-rpms/pull/551

## Testing

See source PRs for details on changes and testing of those changes:
https://github.com/Cray-HPE/csm-testing/pull/363
https://github.com/Cray-HPE/csm-testing/pull/364

## Risks and Mitigations

Reduces the risk that we will not live long enough to see our tests complete execution on larger-scale systems.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
