### PR TITLE
CASMCMS-8102, CASMCMS-7551

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.1
+    version: 2.0.0-beta.2
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.60.0-1.x86_64
-    - bos-reporter-2.0.0-beta.2
+    - bos-reporter-2.0.0
 

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.60.0-1.x86_64
-    - bos-reporter-2.0.0
+    - bos-reporter-2.0.0-beta.2.x86_64
 

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,7 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.60.0-1.x86_64
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/:
-  rpms:
-   - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+    - bos-reporter-2.0.0-beta.2
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.2
+    - bos-reporter-2.0.0

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+    - bos-reporter-2.0.0-beta.2

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0
+    - bos-reporter-2.0.0-beta.2.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,4 +32,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-    - bos-reporter-2.0.0
+    - bos-reporter-2.0.0-beta.2.x86_64
+

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,7 +32,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/:
-  rpms:
-    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+    - bos-reporter-2.0.0.beta2

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,4 +32,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-    - bos-reporter-2.0.0.beta2
+    - bos-reporter-2.0.0

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,7 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/:
-  rpms:
-    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+    - bos-reporter-2.0.0-beta.2
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.0.0
+    - bos-reporter-2.0.0-beta.2.x86_64
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.0.0-beta.2
+    - bos-reporter-2.0.0
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,5 +28,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.0
+    - bos-reporter-2.0.0-beta.2.x86-64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,8 +28,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/:
-  rpms:
-    - bos-reporter-2.0.0-beta.1+1e2f26c.x86_64
+    - bos-reporter-2.0.0-beta2
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,5 +28,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.0-beta2
+    - bos-reporter-2.0.0
 


### PR DESCRIPTION
## Summary and Scope

This PR updates the BOS v1 BOA component to become compatible with changes made in CAPMC endpoint deprecation. Without this, BOA will fail preflight checks while attempting to resolve health of the capmc service before continuing.

Additionally, this contains a small fix to BOS v2 that effectively zeros component errors during new session instantiation. As a result, previous attempts on hardware that have failed to be provisioned for any reason are re-attempted on new session creation. Without this fix, hardware components will be skipped until the error field is manually zero'd out.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8102](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8102)
* Resolves [CASMCMS-7551](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7551)

## Testing
Tested on a combination of drax and wasp (when wasp was available)

### Tested on:

  * `drax` and `wasp`
  * Local development environment

### Test description:

Manually set error status on a component using craycli; verified that the error field was removed during session creation and the requested action was completed as a result.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
