### PR TITLE
CASMTRIAGE-3922: Use stable csm-config artifact

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.11.0-alpha.7+7f99dbc
+    version: 1.11.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This will correct the problem seen trying to deploy the unstable csm-config chart. 

## Testing

I deployed this on drax and verified that it corrected the problem.

## Risks and Mitigations

Without this, the chart cannot be deployed.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
