### PR TITLE
CASMCMS-8162 - correct missed update to cray-ims-load-artifacts version.

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 1.5.0
+      - 1.6.0
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
## Summary and Scope

On a previous manifest change, this location for cray-ims-load-artifacts was missed, so the nightly CVE rebuild was rebuilding the previous version instead of the currently used version.  This captures the correct version that is being used with cray-csm-barebones-recipe-install.

## Issues and Related PRs
* Resolves [CASMCMS-8162](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8162)

## Testing
### Tested on:
  * Build system and local environment

### Test description:

I checked the image cray-ims-load-artifacts and confirmed 1.6.0 was not being rebuilt nightly, manually triggered a rebuild, and verified the rebuilt image does not contain CVE vulnerabilities.  This change to the manifest will insure the correct version is getting built from now on.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just fixing a missed version update from a previous release.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
