### PR TITLE
CASMCMS-8099 - enable automatic updates to csm-config base image.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.11.0
+    version: 1.12.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

The base image for the final layer may or may not have security patches applied, so each time this is built, apply any security patches directly to it here.  This does not rely on the base image being updated to get all patches at the time of the build.

Code PR:
https://github.com/Cray-HPE/csm-config/pull/70

## Issues and Related PRs

* Resolves [CASMCMS-8099](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8099)

## Testing
### Tested on:
  * Build system

### Test description:

The image built with the Jenkins pipeline failed the CVE scan before the changes, and passes after the changes.  There are no code changes, just a base image update so no need to test on-system.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk, just applies CVE updates to the base image in this dockerfile instead of relying on the base image getting rebuilt.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
