### PR TITLE
CASMINST-5240: Disable cmsdev testing of BOS CLI without explicitly specifying the version

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
+    - cray-cmstools-crayctldeploy-1.6.1-1.x86_64
     - cray-site-init-1.24.2-1.x86_64
     - csm-testing-1.14.45-1.noarch
     - goss-servers-1.14.45-1.noarch


### PR DESCRIPTION
## Summary and Scope

Fixes cmsdev test false failure. See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/48

## Issues and Related PRs

Fixes: [CASMINST-5240](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5240)
Relates to: [CASMCMS-8087](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8087)
csm-rpms PR: https://github.com/Cray-HPE/csm-rpms/pull/555

## Testing

See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/48

## Risks and Mitigations

Very low risk. Two subtests removed. Nothing added or changed.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
