### PR TITLE
CASMINST-5243:bump version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.25.0
+    version: 0.25.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope
CASMINST-5243:BREAK/FIX: csm-1.3-beta.41 : install csm service failed

## Issues and Related PRs
[
_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`
](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5243)
## Testing

_List the environments in which these changes were tested._

### Tested on: mug and starloard
installation working fine
 loftsman ship --charts-path . --manifest-path  shs-cust.yaml_snmp_bug
2022-08-17T16:00:44Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2022-08-17T16:00:44Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2022-08-17T16:00:44Z INF Ensuring that the loftsman namespace exists command=ship
2022-08-17T16:00:44Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2022-08-17T16:00:44Z INF Running a release for the provided manifest at shs-cust.yaml_snmp_bug command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-sysmgmt-health v0.25.1-20220817142833+8c1413e
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2022-08-17T16:00:45Z INF Found value overrides for chart, applying:
cephExporter:
  endpoints:
  - 10.252.1.18
  - 10.252.1.19
  - 10.252.1.20
  - 10.252.1.21
  - 10.252.1.22
cephNodeExporter:
  enabled: true
  endpoints:
  - 10.252.1.18
  - 10.252.1.19
  - 10.252.1.20
  - 10.252.1.21
  - 10.252.1.22
imageHost: registry.local
prometheus-operator:
  alertmanager:
    alertmanagerSpec:
      externalAuthority: alertmanager.cmn.mug.dev.cray.com
      externalUrl: https://alertmanager.cmn.mug.dev.cray.com/
  grafana:
    externalAuthority: grafana.cmn.mug.dev.cray.com
  kubeEtcd:
    endpoints:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
  prometheus:
    prometheusSpec:
      externalAuthority: prometheus.cmn.mug.dev.cray.com
      externalUrl: https://prometheus.cmn.mug.dev.cray.com/
      resources:
        limits:
          cpu: "6"
          memory: 30Gi
        requests:
          cpu: "1"
          memory: 15Gi
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.1-20220817142833+8c1413e
2022-08-17T16:00:45Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health cray-sysmgmt-health-0.25.1-20220817142833+8c1413e.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=0.25.1-20220817142833+8c1413e -f /tmp/loftsman-1660752044/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.1-20220817142833+8c1413e
2022-08-17T16:01:44Z INF manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
Release "cray-sysmgmt-health" has been upgraded. Happy Helming!
NAME: cray-sysmgmt-health
LAST DEPLOYED: Wed Aug 17 16:00:47 2022
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 2
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.1-20220817142833+8c1413e
