### PR TITLE
Increase hnc webhook timeouts to avoid retries (CASMINST-4897)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -295,7 +295,7 @@ spec:
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60
-    version: 0.0.3
+    version: 0.0.4
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Increase hnc webhook timeouts to avoid retries

## Issues and Related PRs

* Resolves [CASMINST-4897](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4897)

## Testing

```
ncn-m001-22703c05:/home/bklein # kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration -o yaml | grep timeout
  timeoutSeconds: 30
  timeoutSeconds: 30
  timeoutSeconds: 30
  timeoutSeconds: 30
  timeoutSeconds: 30
```

### Tested on:

  * Virtual Shasta

### Test description:

Updated the chart, saw the new timeouts, ran CRUD operations, no timeouts.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable