### PR TITLE
CASMINST-5240: Disable cmsdev testing of BOS CLI without explicitly specifying the version

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
+    - cray-cmstools-crayctldeploy-1.6.1-1.x86_64
     - cray-site-init-1.24.2-1.x86_64
     - csm-testing-1.14.45-1.noarch
     - goss-servers-1.14.45-1.noarch


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/1164