### PR TITLE
Casminst 5243

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.25.0
+    version: 0.25.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.60.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - docs-csm-1.3.32-1.noarch
+    - docs-csm-1.3.34-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-scripts-0.0.38-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch


### PR DESCRIPTION
Summary and Scope
CASMINST-5243:BREAK/FIX: csm-1.3-beta.41 : install csm service failed

Issues and Related PRs
[
List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies.

Resolves [issue id](issue link)
Change will also be needed in <insert branch name here>
Future work required by [issue id](issue link)
Documentation changes required in [issue id](issue link)
Merge with/before/after <insert PR URL here>
](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5243)
Testing
List the environments in which these changes were tested.

Tested on: mug and starloard
installation working fine
loftsman ship --charts-path . --manifest-path shs-cust.yaml_snmp_bug
2022-08-17T16:00:44Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2022-08-17T16:00:44Z INF Initializing helm client object command=ship
|
|
|
|\ Shipping your Helm workloads with Loftsman
--||/


2022-08-17T16:00:44Z INF Ensuring that the loftsman namespace exists command=ship
2022-08-17T16:00:44Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2022-08-17T16:00:44Z INF Running a release for the provided manifest at shs-cust.yaml_snmp_bug command=ship

Releasing cray-sysmgmt-health v0.25.1-20220817142833+8c1413e


2022-08-17T16:00:45Z INF Found value overrides for chart, applying:
cephExporter:
  endpoints:
  - 10.252.1.18
  - 10.252.1.19
  - 10.252.1.20
  - 10.252.1.21
  - 10.252.1.22
cephNodeExporter:
  enabled: true
  endpoints:
  - 10.252.1.18
  - 10.252.1.19
  - 10.252.1.20
  - 10.252.1.21
  - 10.252.1.22
imageHost: registry.local
prometheus-operator:
  alertmanager:
    alertmanagerSpec:
      externalAuthority: alertmanager.cmn.mug.dev.cray.com
      externalUrl: https://alertmanager.cmn.mug.dev.cray.com/
  grafana:
    externalAuthority: grafana.cmn.mug.dev.cray.com
  kubeEtcd:
    endpoints:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
  prometheus:
    prometheusSpec:
      externalAuthority: prometheus.cmn.mug.dev.cray.com
      externalUrl: https://prometheus.cmn.mug.dev.cray.com/
      resources:
        limits:
          cpu: "6"
          memory: 30Gi
        requests:
          cpu: "1"
          memory: 15Gi
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.1-20220817142833+8c1413e
2022-08-17T16:00:45Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health cray-sysmgmt-health-0.25.1-20220817142833+8c1413e.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=0.25.1-20220817142833+8c1413e -f /tmp/loftsman-1660752044/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.1-20220817142833+8c1413e
2022-08-17T16:01:44Z INF manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
Release "cray-sysmgmt-health" has been upgraded. Happy Helming!
NAME: cray-sysmgmt-health
LAST DEPLOYED: Wed Aug 17 16:00:47 2022
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 2
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.1-20220817142833+8c1413e