### PR TITLE
CASMINST-5239: Fix occasional failure in goss_check_static_routes test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix 
 - Released spire 2.10.0 and cray-nls 1.3.8 for security fixes (CASMPET-5873)
 - Added all istio images to Nexus precache (CASMPET-5888)
 - Released cfs-operator 1.16.0 to fix issues with additional inventory

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
-    - csm-testing-1.14.45-1.noarch
-    - goss-servers-1.14.45-1.noarch
+    - csm-testing-1.14.46-1.noarch
+    - goss-servers-1.14.46-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch


### PR DESCRIPTION
## Summary and Scope

See https://github.com/Cray-HPE/csm-testing/pull/366 for details.

## Issues and Related PRs

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5239

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable