### PR TITLE
CASMTRIAGE-3835: Update cfs api, operator and trust for pod priority escalation (1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cfs api, operator and trust for pod priority escalation
 - Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix 
 - Released spire 2.10.0 and cray-nls 1.3.8 for security fixes (CASMPET-5873)
 - Added all istio images to Nexus precache (CASMPET-5888)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,11 +78,11 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.16.0
+    version: 1.16.1
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.10.5
+    version: 1.11.1
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60
@@ -90,7 +90,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates cfs-api, operator and trust for pod priority escalation

## Issues and Related PR

* Resolves CASMTRIAGE-3835

## Testing

### Tested on:

  * Mug

### Test description:

Deployed and ran basic tests for updated images/charts

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

