### PR TITLE
CRAYSAT-1526: Add SAT version 3.19 to CSM

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.18.0
+      - 3.19.0
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.18.0"
+sat_version="3.19.0"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

Update the version of the cray-sat container image included in CSM from 3.18.0 to 3.19.0. This version includes important `sat bootprep` functionality implemented in [CRAYSAT-1385](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1385).

(cherry picked from commit cc49c9eea6e42667543ae9cb1c33426fdd361726)

## Issues and Related PRs

* Resolves [CRAYSAT-1526](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1526)
* Pulls in changes from the epic [CRAYSAT-1385](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1385)

## Testing

### Tested on:

* Jenkins

### Test description:

If the Jenkins build succeeds, then that means it could find the new container image.

The container image itself was tested through a test installation of SAT product version 2.4.8 on hermod.

## Risks and Mitigations

Not much risk is introduced here. We are just upgrading the version of the sat container image.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable