### PR TITLE
CASMINST-5268: Resolves issue from CASMPET-5324. Fix manifest versions for csm-testing, goss-servers that were incorrect

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
-    - csm-testing-1.14.47.noarch
-    - goss-servers-1.14.47.noarch
+    - csm-testing-1.14.47-1.noarch
+    - goss-servers-1.14.47-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch


### PR DESCRIPTION
## Summary and Scope

Incorrect csm-testing,goss-servers version was implemented by CASMPET-5324. This fixes the version for csm-testing and goss-servers.


## Issues and Related PRs


* Resolves CASMINST-5268

