### PR TITLE
CASMCMS-8163: Adjust healthz payload to be v1/v2 agnostic

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.4
+    version: 2.0.0-beta.5
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.61.0-1.x86_64
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.0-beta.5.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.0-beta.5.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,5 +32,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.0-beta.5.x86_64
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.0-beta.5.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,5 +28,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.0-beta.5.x86_64
 


### PR DESCRIPTION
## Summary and Scope

This mod corrects the behavior documented in CASMCMS-8163 with respect to making the used schema backwards compatible with the v1 healthz openapi generated structure.

## Issues and Related PRs

* Resolves [CASMCMS-8163](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8163)
* Change will also be needed in `main`

## Testing
### Tested on:

  * `groot`

### Test description:

Applied the change to groot and verified that the health endpoints for v1 and v2 were appropriately populating.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

