### PR TITLE
Add separate list of storage nodes for cephExporter endpoints

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -25,6 +25,10 @@ spec:
         - ~FIXME~ e.g., 10.252.1.4
         - ~FIXME~ e.g., 10.252.1.5
         - ~FIXME~ e.g., 10.252.1.6
+      nmn_ncn_storage_mons:
+        - ~FIXME~ e.g., 10.252.1.4
+        - ~FIXME~ e.g., 10.252.1.5
+        - ~FIXME~ e.g., 10.252.1.6
     dns:
       external: ~FIXME~ e.g., eniac.dev.cray.com
       external_s3: ~FIXME~ e.g., s3.eniac.dev.cray.com
@@ -518,7 +522,7 @@ spec:
             # If the system is non airgaped then you can comment out or remove plugins property.
             plugins: ""
         cephExporter:
-          endpoints: '{{ network.netstaticips.nmn_ncn_storage }}'
+          endpoints: '{{ network.netstaticips.nmn_ncn_storage_mons }}'
         cephNodeExporter:
           endpoints: '{{ network.netstaticips.nmn_ncn_storage }}'
           enabled: true


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5428

#### Issue Type

- Bugfix Pull Request

Cephexporter only reports data on the first three storage nodes (running mon/mgr).

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

```
C02YT3JRLVCJ:cray-site-init bklein$ cat foo/foo/customizations.yaml  | grep -A3 nmn_ncn_storage_mons
    nmn_ncn_storage_mons:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
```
 
### Idempotency
 
Good
 
### Risks and Mitigations
 
Low