### PR TITLE
Bump cray-site-init version for CASMPET-5428

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
-    - cray-site-init-1.24.2-1.x86_64
+    - cray-site-init-1.25.0-1.x86_64
     - csm-testing-1.14.47.noarch
     - goss-servers-1.14.47.noarch
     - metal-basecamp-1.2.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5428

#### Issue Type

- Bugfix Pull Request

Cephexporter only reports data on the first three storage nodes (running mon/mgr).

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

```
C02YT3JRLVCJ:cray-site-init bklein$ cat foo/foo/customizations.yaml  | grep -A3 nmn_ncn_storage_mons
    nmn_ncn_storage_mons:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
```
 
### Idempotency
 
Good
 
### Risks and Mitigations
 
Low