### PR TITLE
CASMINST-5213: Run local tests in parallel with remote endpoint tests

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.6.0-beta.1.x86_64
     - cray-site-init-1.24.2-1.x86_64
-    - csm-testing-1.14.47-1.noarch
-    - goss-servers-1.14.47-1.noarch
+    - csm-testing-1.15.1-1.noarch
+    - goss-servers-1.15.1-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.7-1.noarch
     - pit-init-1.2.33-1.noarch


### PR DESCRIPTION
## Summary and Scope

Currently the Goss scripts run any local tests first, then run the remote tests in parallel. This includes the local tests in the parallel portion. See the source PR for more details:
https://github.com/Cray-HPE/csm-testing/pull/370

## Testing

Currently the Goss scripts run any local tests first, then run the remote tests in parallel. This includes the local tests in the parallel portion. See the source PR for more details:
https://github.com/Cray-HPE/csm-testing/pull/370

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
