### PR TITLE
Changed cray-hms-bss version to 2.1.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.5
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This includes two changes to BSS
* BSS v2.1.5: Include type information when getting the spire token which fixes CASMHMS-5682 "cray-spire bos xname workloads incorrectly named"
* BSS v2.1.4: Convert metal.server boot parameter to a signed, time limited, s3 http url when the boot parameter is set to s3://bucket/path. There will be other changes, to other products, in CSM that will make use of this BSS change. This change is backwards compatible.

## Issues and Related PRs

* Resolves [CASMHMS-5682](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5682)
* Resolves [CASMHMS-5656](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5656)

The fix for CASMHMS-5682 is in BSS 2.1.5 and the fix for CASMHMS-5656 is in BSS 2.1.4

The change for CASMHMS-5656 is backward compatible.

## Testing

  * For CASMHMS-5682 see https://github.com/Cray-HPE/hms-bss/pull/52
  * For CASMHMS-5656 see https://github.com/Cray-HPE/hms-bss/pull/51

### Tested on:

  * mug
  * surtur

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? Yes

## Risks and Mitigations

none


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

