### PR TITLE
CASMINST-5264 Add CSM pipeline check to prevent capital letters in bu…

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -38,7 +38,9 @@ source "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.
 requires curl docker git perl rsync sed
 
 # Valid SemVer regex, see https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-semver_regex='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+# semver_regex='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+# For 1.3, we also forbid capital letters in release version
+semver_regex='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-z-][0-9a-z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-z-][0-9a-z-]*))*))?(?:\+([0-9a-z-]+(?:\.[0-9a-z-]+)*))?$'
 
 # Release version must be a valid semver
 if [[ -z "$(echo "$RELEASE_VERSION" | perl -ne "print if /$semver_regex/")" ]]; then


### PR DESCRIPTION
## Summary and Scope

Disallow capital letters in release version, as they are failing CSM installation due to incompliancy in Kubernetes resource names.

## Issues and Related PRs

* Resolves [CASMINST-5264](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5264)
* Causes [CASMTRIAGE-3951](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3951)
* Will be superceded by [CASMCMS-8188](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8188) in 1.4

## Testing
### Tested on:

  * Jenkins build

### Test description:

https://jenkins.algol60.net/job/Cray-HPE/job/csm/job/feature%252FCASMINST-5254/1/console

## Risks and Mitigations

Low - build script change only, easy to rollback.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

