### PR TITLE
CASMCMS-8192: Default the Cray CLI to v1 for BOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed kafka errors in hms-trs-operator (CASMHMS-5525)
 - Added auth.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5817)
 - Added allowed-issuers for istio-ingressgateway-hmn in cray-opa section customizations.yaml (CASMPET-5817)
+- Update craycli to 0.62.0
 - Update craycli to 0.57.0
 - Added api.hmnlb.SYSTEM_DOMAIN annotation for istio-ingressgateway-hmn in customizations.yaml (CASMPET-5795)
 - Updated cray-oauth2-proxy to use the latest image for sec vulnerability (CASMPET-5697)

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.60.0-1.x86_64
+    - craycli-0.62.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.60.0-1.x86_64
+    - craycli-0.62.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.3.34-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch


### PR DESCRIPTION
## Summary and Scope
When no version string is specified for the `cray bos` command, then
default the version to `v1`.

This should merge at the same time as the following PRs:
https://github.com/Cray-HPE/csm-rpms/pull/583
https://github.com/Cray-HPE/csm-rpms/pull/588
https://github.com/Cray-HPE/csm/pull/1224

## Testing
See https://github.com/Cray-HPE/craycli/pull/59.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

