### PR TITLE
CASMINST-5273 - fix for ceph service check osd unit name issue

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.7.0-1.x86_64
     - cray-site-init-1.26.0-1.x86_64
-    - csm-testing-1.15.1-1.noarch
-    - goss-servers-1.15.1-1.noarch
+    - csm-testing-1.15.2-1.noarch
+    - goss-servers-1.15.2-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch


### PR DESCRIPTION
## Summary and Scope
fix ceph-service-check.sh to allow for version specific output

Output from the same command has changed in 16.2.x from the output the script was
written for in 15.2.x. This will allow for the correct format depending on the version.
_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5271

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Drax ceph vers 15.2.15
  * Craystack ceph vers 16.2.x

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

