### PR TITLE
CASMCMS-8193: cmsdev test: Update BOS CLI test to reflect default version back to v1

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.7.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.0-1.x86_64
     - csm-testing-1.14.47-1.noarch
     - goss-servers-1.14.47-1.noarch


### PR DESCRIPTION
## Summary and Scope

Updates the cmsdev test to reflect the change of the BOS default CLI version to v1.

This should merge at the same time as these PRs:
https://github.com/Cray-HPE/csm-rpms/pull/582
https://github.com/Cray-HPE/csm/pull/1225
https://github.com/Cray-HPE/csm-rpms/pull/589

## Issues and Related PRs

This should merge when the manifest PRs for [CASMCMS-8192](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8192) merge. Otherwise the tests and the CLI will be mismatched.

csm-rpms: https://github.com/Cray-HPE/csm-rpms/pull/582

## Testing

See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/53

## Risks and Mitigations

If the CLI change goes in without this, there will be test failures.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
