### PR TITLE
CASMCMS-8193: cmsdev test: Update BOS CLI test to reflect default version back to v1

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.7.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.0-1.x86_64
     - csm-testing-1.15.1-1.noarch
     - goss-servers-1.15.1-1.noarch


### PR DESCRIPTION
main backport of https://github.com/Cray-HPE/csm/pull/1223

This should merge at the same time as these PRs:
https://github.com/Cray-HPE/csm-rpms/pull/583
https://github.com/Cray-HPE/csm/pull/1220
https://github.com/Cray-HPE/csm-rpms/pull/588