### PR TITLE
CASMCMS-8192: Default the Cray CLI to v1 for BOS

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.61.0-1.x86_64
+    - craycli-0.62.0-1.x86_64
     - bos-reporter-2.0.0-beta.5.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.61.0-1.x86_64
+    - craycli-0.62.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.3.38-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/1220

This should merge at the same time as these other PRs:
https://github.com/Cray-HPE/csm-rpms/pull/589
https://github.com/Cray-HPE/csm/pull/1223
https://github.com/Cray-HPE/csm-rpms/pull/582