### PR TITLE
Update multus to v3.9.1 from k8snetworkplumbingwg/multus-cni repo (CASMPET-5821)

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -95,7 +95,7 @@ cmd_retry curl -sSL -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" -o "${KUBERNET
 declare -A KUBERNETES_IMAGES=(
     [KUBERNETES_VERSION]="k8s.gcr.io/kube-apiserver k8s.gcr.io/kube-controller-manager k8s.gcr.io/kube-proxy k8s.gcr.io/kube-scheduler"
     [WEAVE_VERSION]="docker.io/weaveworks/weave-kube docker.io/weaveworks/weave-npc"
-    [MULTUS_VERSION]="docker.io/nfvpe/multus"
+    [MULTUS_VERSION]="ghcr.io/k8snetworkplumbingwg/multus-cni"
     [COREDNS_VERSION]="k8s.gcr.io/coredns"
 )
 error=0

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -82,8 +82,8 @@ artifactory.algol60.net/csm-docker/stable:
       - 11-jre-slim
 
     # Multus required by platform
+    # XXX See also ghcr.io/k8snetworkplumbingwg/multus-cni below
     docker.io/nfvpe/multus:
-      - v3.1
       - v3.7
 
     # XXX Is this missing from cray-sysmgmt-health?
@@ -105,6 +105,10 @@ artifactory.algol60.net/csm-docker/stable:
     # XXX Missing from a SPIRE chart?
     gcr.io/spiffe-io/oidc-discovery-provider:
       - 0.12.2
+
+    # Multus required by platform
+    ghcr.io/k8snetworkplumbingwg/multus-cni:
+      - v3.9.1
 
     # CoreDNS required by platform
     # XXX See also docker.io/coredns/coredns:1.6.2 above

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -53,7 +53,7 @@ spec:
       # Kubernetes
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.1
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:v1.8.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.21.12
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.21.12


### PR DESCRIPTION
### Summary and Scope

This change is a step towards resolving CVEs in multus -- we're switching to the current upstream repo in anticipation of a fix to update the base docker image (https://github.com/k8snetworkplumbingwg/multus-cni/issues/898).

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5821

#### Issue Type

- Bugfix Pull Request

Prep work for finally fixing multus CVEs

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

craystack:

```
ncn-m001:~ # kubectl get po -n kube-system | grep multus
kube-multus-ds-4s25j               1/1     Running   0          84s
kube-multus-ds-d65lk               1/1     Running   0          84s
kube-multus-ds-fs67s               1/1     Running   0          84s
kube-multus-ds-g65tn               1/1     Running   0          84s
kube-multus-ds-nl29k               1/1     Running   0          84s
kube-multus-ds-wn28v               1/1     Running   0          84s
```

```
ncn-m001:~ # kubectl get po -n kube-system kube-multus-ds-8g66n -o yaml | grep '    image:' | uniq
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.1
```

```
ncn-m001:~ # kubectl logs -n kube-system kube-multus-ds-4s25j
2022-08-24T21:44:11+0000 Entering sleep (success)...
```
 
### Idempotency
 
Should be.
 
### Risks and Mitigations
 
Low to Medium?  Partly why getting in CSM 1.4 early...
