### PR TITLE
CASMINST-3902: Add hardware-topology-assistant to docker.index

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -53,6 +53,10 @@ artifactory.algol60.net/csm-docker/stable:
     hms-trs-worker-http-v1:
       - 1.8.0
 
+    # Utility to help make changes for adding river cabinets
+    hardware-topology-assistant:
+    - 0.1.0
+
     # Rebuilt third-party images below
 
     # Required by ceph


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Add hardware-topology-assistant to docker.index. This is a docker image that will help facilitate adding of river cabinets to a system.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible. New docker image.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-3902


## Testing

_List the environments in which these changes were tested._

### Tested on:

* Mug
* Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A


For testing see: https://github.com/Cray-HPE/hardware-topology-assistant/pull/1
* Local testing using mock data taken from Hela to add a river cabinet.
* Perfomed no-op testing on Mug.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk, new tool used in the procedure to add river cabinets.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

