### PR TITLE
CASMPET-5918 release platform-utils v1.3.6

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -35,6 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.5-1.noarch
+    - platform-utils-1.3.6-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Release updated version of platform utils.
This update creates a symbolic link for utils/ceph-service-status.sh to point to updated version of script in opt/cray/tests/install/ncn/scripts/ceph-service-status.sh

