### PR TITLE
CRAYSAT-1550: Update cray-sat container image to 3.19.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.19.0
+      - 3.19.1
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.19.0"
+sat_version="3.19.1"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
See CHANGELOG.md in sat repo for full description of changes.

## Summary and Scope

This updates the version of the cray-sat container image from 3.19.0 to 3.19.1 to include several release-critical bugfixes.

See [sat CHANGELOG.md](https://github.com/Cray-HPE/sat/blob/release/3.19/CHANGELOG.md) for a full description of the changes.

## Issues and Related PRs

* Resolves [CRAYSAT-1550](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1550)

## Testing

### Tested on:

  * loki

### Test description:

Installed this version of cray-sat container image on loki through installation of SAT product stream version 2.4.10, which includes this same version of the container image.

## Risks and Mitigations

None.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

