### PR TITLE
MTL-1927: new csm-testing rpm with BIOS version updates

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.14.49-1.noarch
-    - goss-servers-1.14.49-1.noarch
+    - csm-testing-1.14.50-1.noarch
+    - goss-servers-1.14.50-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch


### PR DESCRIPTION
## Summary and Scope

release a new version of csm-rpms