### PR TITLE
CASMPET-5024 Bump cray-opa to 1.28.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -171,7 +171,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.25.0
+    version: 1.28.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

- Splits OPA policies up by type instead of by gateway
- Adds ability for customers to add their own policies without modifying the charts
- Adds TPM Provisioner access

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._


* Resolves [CASMPET-5898](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5898)
* Resolves [CASMPET-5673](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5673) 
* Resolves [CASMPET-5024](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5024)
* https://github.com/Cray-HPE/cray-opa/pull/59
* https://github.com/Cray-HPE/cray-opa/pull/60
* https://github.com/Cray-HPE/cray-opa/pull/61

## Testing

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This policy needs additional testing on a CSM 1.4 bare metal system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

