### PR TITLE
Changed cray-hms-sls version to 2.1.7

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.6
+    version: 2.1.7
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

SLS changes to do the following:
  * CASMHMS-5696 - Disallow networks with an empty name.
  * CASMHMS-4267 - Added validation to loadstate.
  * CASMHMS-5691 - Added the slignshot11 network type.

## Issues and Related PRs

* Resolves [CASMHMS-5696](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5696)
* Resolves [CASMHMS-4267](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-4267)
* Resolves [CASMHMS-5691](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5691)

## Testing

see: 
  * https://github.com/Cray-HPE/hms-sls/pull/57
  * https://github.com/Cray-HPE/hms-sls/pull/56
  * https://github.com/Cray-HPE/hms-sls/pull/55

### Tested on:

  * mug
  * Local development environment
  
### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

