### PR TITLE
Allow BOS to optionally preserve staged boot artifacts between operations

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.5
+    version: 2.0.0-beta.7
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.62.0-1.x86_64
-    - bos-reporter-2.0.0-beta.5.x86_64
+    - bos-reporter-2.0.0-beta.7.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.5.x86_64
+    - bos-reporter-2.0.0-beta.7.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,5 +32,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-    - bos-reporter-2.0.0-beta.5.x86_64
+    - bos-reporter-2.0.0-beta.7.x86_64
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.0.0-beta.5.x86_64
+    - bos-reporter-2.0.0-beta.7.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,5 +28,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.0-beta.5.x86_64
+    - bos-reporter-2.0.0-beta.7.x86_64
 


### PR DESCRIPTION
## Summary and Scope

This mod updates the BOS Staging behavior to be more in line with the customer requirement to be able to reprovision nodes repeatedly. This mod adds a new API level option to BOSv2 that allows staged session information to be preserved between applystaged options. As a result, WLMs may request the same staged provision action repeatedly, and there is no longer a reason for re-staging thereafter.

## Issues and Related PRs
* Resolves [CASMCMS-8158](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8158)
* Change will also be needed in `main`

## Testing
Tested both on and off on system while booting a COS "staged" node, representing the full lifecycle of the changed operation.

### Tested on:

  * `mug`
  * Local development environment

### Test description:

I created a new BOS v2 session with staging options set; then configured BOSv2 options for staging to preserve staged information. I did a before and after state snap for staged and desired state and verified that apply_staged allowed staged state to equal desired state, and stage state remained.

The staged node completed its reboot and the staged information remained.

I toggled the clear_stage option and verified that the old behavior of cleared stage state also worked. The node once again rebooted cleanly, however the staged information was purged (consistent with old behavior).

## Risks and Mitigations

Very low risk. Customer will likely ask for this to be backported if not included in this release.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] Testing is appropriate and complete, if applicable

