### PR TITLE
CRAYSAT-1559: Update cray-sat container image to 3.19.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.19.1
+      - 3.19.2
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.19.1"
+sat_version="3.19.2"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

This updates the version of the cray-sat container image from 3.19.1 to 3.19.2 to include the fix for [CRAYSAT-1552](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1552).

See [sat CHANGELOG.md](https://github.com/Cray-HPE/sat/blob/release/3.19/CHANGELOG.md) for a full description of the changes.

(cherry picked from commit 861956ae9932f7292300df4eb4c66f8636d1470f)

## Issues and Related PRs

* Part of [CRAYSAT-1559](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1559)
* Resolves [CRAYSAT-1552](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1552)

## Testing

### Tested on:

  * surtur

### Test description:

Installed this version of cray-sat container image on surtur through installation of SAT product stream version 2.4.11, which includes this same version of the container image.

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
