### PR TITLE
CASMPET-5920: manifest change to update platform-utils version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
 - Update cfs api, operator and trust for pod priority escalation
 - Released goss-servers/csm-testing v1.14.47 for ceph goss test failure output change
 - Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -35,6 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.5-1.noarch
+    - platform-utils-1.4.0-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

manifest change to update platform-utils version
This removes duplicate copy of ceph-service-status.sh from platform-utils. Existing copy of this script is located in csm-testing.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5920](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5920)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

