### PR TITLE
Update pause version for nexus test

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.15.6-1.noarch
-    - goss-servers-1.15.6-1.noarch
+    - csm-testing-1.15.7-1.noarch
+    - goss-servers-1.15.7-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.34-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update nexus test to pull correct pause image.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4057](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4057)

## Testing

Tested fix on fanta:

```
ncn-m001:~ # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-nexus-can-pull.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml v

Total Duration: 0.153s
Count: 1, Failed: 0, Skipped: 0
```

### Tested on:

  * `fanta`

### Test description:

Tested on fanta

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable