### PR TITLE
CASMCMS-8203: Stop failing git commands from crashing cmsdev

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
     - cray-site-init-1.26.2-1.x86_64
     - csm-testing-1.15.7-1.noarch
     - goss-servers-1.15.7-1.noarch


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8203](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8203)
- Relates to: [CASMTRIAGE-4074](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4074)

#### Issue Type

- Bugfix Pull Request

The cmsdev test crashes in a couple of error paths when it dereferences null pointers. The fix is very simple.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

Tested on starlord, where the problem was discovered. See source PR for details: https://github.com/Cray-HPE/cms-tools/pull/57

### Risks and Mitigations
 
Very low risk to include. Fix is extremely simple.
