### PR TITLE
CASMINST-5311/CASMINST-5312/CASMINST-5316: Goss testing improvements

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.14.53-1.noarch
-    - goss-servers-1.14.53-1.noarch
+    - csm-testing-1.14.54-1.noarch
+    - goss-servers-1.14.54-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.14.55-1.noarch
-    - goss-servers-1.14.55-1.noarch
+    - csm-testing-1.14.56-1.noarch
+    - goss-servers-1.14.56-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.14.54-1.noarch
-    - goss-servers-1.14.54-1.noarch
+    - csm-testing-1.14.55-1.noarch
+    - goss-servers-1.14.55-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-5311](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5311)
  - Add clock skew test to storage and worker health check test suites
- Fixes: [CASMINST-5312](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5312)
  - Enable logging of 6 additional Goss tests
- Fixes: [CASMINST-5316](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5316)
  - Fix typo in k8s_kyverno_pods_running.sh

#### Issue Type

- RFE Pull Request

See source PRs for details: 
- https://github.com/Cray-HPE/csm-testing/pull/388
- https://github.com/Cray-HPE/csm-testing/pull/391
- https://github.com/Cray-HPE/csm-testing/pull/392

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

Updated tests and test suites executed successfully on starlord.

### Risks and Mitigations
 
Very low risk -- adding 1 existing test to 2 existing test suites, enabling an existing logging feature in 6 existing tests, and fixing a one character typo in a test script which is only called manually.
