### PR TITLE
Update craycli to 0.63.0 to fix python 6.3 deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli to 0.63.0 to fix python 3.6 deprecation warning
 - Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
 - Released cray-nls-charts 1.4.0 to add new mount for storage workflows 
 - Update cfs api, operator and trust for pod priority escalation

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.62.0-1.x86_64
+    - craycli-0.63.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.62.0-1.x86_64
+    - craycli-0.63.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.4.3-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch


### PR DESCRIPTION
## Summary and Scope

Update craycli to 0.63.0 to fix python 6.3 deprecation warning

Backward compatible bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCLOUD-1212](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1212)
* Change will also be needed in `release/1.3`

## Testing

### Tested on:

  * `surtur`

### Test description:

Ran the offending command from the ticket, verified that it no longer produces a deprecation warning.  Unit tests and lint run at build on craycli code.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

There are no known risks with this change

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

