### PR TITLE
Point to cray bss as alternative to setting wipe flag w/out csi (CASMTRIAGE-4095)

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.14.56-1.noarch
-    - goss-servers-1.14.56-1.noarch
+    - csm-testing-1.14.57-1.noarch
+    - goss-servers-1.14.57-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch


### PR DESCRIPTION
## Summary and Scope

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4095 -- point to cray bss command if wipe flag test fails.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4095](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4095)

## Testing

Not a functional change

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
