### PR TITLE
CASMCMS-8209: Add csm-sle15sp4 repo in NCN personalization

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.13.0
+    version: 1.14.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Update the CSM CFS layer so that it configures the CSM SLES15 SP4 RPM repository.

## Issues and Related PRs

- Source PR: https://github.com/Cray-HPE/csm-config/pull/78
- Resolves [CASMCMS-8209](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8209)
- Combined with [CASMINST-5314](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5314), resolves [CASMTRIAGE-4094](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4094)

## Testing

Tested the fix (in WAR format) on surtur.

## Risks and Mitigations

Low risk. Just adding one stanza to the yaml file to define the repository, following the same pattern as is used for the other SP versions.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
