### PR TITLE
CASMTRIAGE-4091 - add configurable timeout to IMS to handle large images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated IMS to provide a larger default image size (CASMCMS-8015)
 - Updated console services to handle Hill nodes.
 - Updated barebones image to use slessp4.
+- Added configurable timeout to IMS service to allow handling large images.
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.6.0
+    version: 3.6.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

There were timeouts configured for connections and read times, but the overall application was timing out when an s3 file operation was taking over 30 seconds. This caused the gunicorn application that is running inside the ims pod to restart, dropping the operation that was in progress.

This change adds the timeout configuration value to the gunicorn application and makes it configurable through the helm charts and ims-config k8s configmap.

There is also a change to the readiness/liveness probes to increase their timing as well. The way they were configured, when an operation took long enough, the liveness probe would fail and the container would be restarted mid-operation. There should be a better solution for this put into place at some point. Currently the http server is single-threaded, so the liveness call will not be responded to until after any current operation completes.

This condition is only seen when the s3 image operations take a long time - in this case it was due to a 2Gb rootfs image.

Code PR:
https://github.com/Cray-HPE/ims/pull/39

Manifest PR to release/1.3:
https://github.com/Cray-HPE/csm/pull/1295

## Issues and Related PRs
* Resolves [CASMTRIAGE-4091](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4091)

## Testing
### Tested on:
  * `Shandy`

### Test description:

I installed the test image through helm upgrade and the sat bootprep commands that uncovered the issue were repeated. After multiple runs I was able to watch the ims logs and verify the gunicorn worker timeout was not being encountered any more. I also manually configured the timeout value in the ims-config configmap, restarted the ims service, and confirmed the new configuration value was used.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a pretty low risk change, but by increasing the liveness/readiness probe failure times it could lengthen the amount of time it takes k8s to restart a failed pod. That should not be a common occurrence.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
