### PR TITLE
CASMTRIAGE-4098 - update ims override to the correct access pool.

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -318,7 +318,7 @@ spec:
         keycloak:
           keycloak_admin_client_auth_secret_name: admin-client-auth
         customer_access:
-          access_pool: customer-access
+          access_pool: customer-management
           shasta_domain: '{{ network.dns.external }}'
         api_gw:
           api_gw_service_name: istio-ingressgateway


### PR DESCRIPTION
## Summary and Scope

The override in customizations.yaml was not updated to the correct access-pool for the ims service.  This prevents the networking to be set up correctly.

## Issues and Related PRs
* Resolves [CASMTRIAGE-4098](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4098)

## Testing

No testing - needs to be incorporated into an install.

## Risks and Mitigations

Low risk as this override will not impact anything outside of the ims service and will only resolve the networking for the service.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
