### PR TITLE
CASMCMS-8210/CASMCMS-8212: cmsdev: Add BOS CLI tests, resolve CVE

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.9.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
     - csm-testing-1.14.57-1.noarch
     - goss-servers-1.14.57-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.9.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
     - csm-testing-1.14.57-1.noarch
     - goss-servers-1.14.57-1.noarch


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8210](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8210)
  - Adds 3 overlooked BOS CLI tests to the cmsdev test tool. See source PR for full details: https://github.com/Cray-HPE/cms-tools/pull/58
- Fixed [CASMCMS-8212](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8212)
  - Updated Golang version and dependent modules to [resolve High severity CVE](https://github.com/Cray-HPE/cms-tools/security/dependabot/1). See source PR for full details: https://github.com/Cray-HPE/cms-tools/pull/60

#### Issue Type

- RFE Pull Request

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

New subtests were run successfully on surtur. See source PR for full details:
https://github.com/Cray-HPE/cms-tools/pull/58

Rebuilt binary with CVE remediations was tested on fanta. See source PR for full details: https://github.com/Cray-HPE/cms-tools/pull/60

### Risks and Mitigations
 
The risk of adding these new subtests is small because they are very basic tests that re-use existing test code.
And the risk of not remediating the CVE seems higher than the update to fix it.