### PR TITLE
CASMCMS-8076: Update csm services for sp4 base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)
 - Update craycli to 0.63.0 to fix python 3.6 deprecation warning
 - Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
 - Released cray-nls-charts 1.4.0 to add new mount for storage workflows 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -109,7 +109,7 @@ spec:
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.6.0
+    version: 1.7.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
@@ -117,7 +117,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.10.1
+    version: 1.11.0
     namespace: services
   - name: cray-tftp
     source: csm-algol60
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.14.0
+    version: 1.15.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Updates console-node, cray-crus and csm-config to use sp4 base images

## Issues and Related PRs

* Resolves CASMCMS-8076

## Testing

Everything was tested/run on Mug

## Risks and Mitigations

No

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

