### PR TITLE
MTL-1952 MTL-1953 Fixes for `pit-init`

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -30,6 +30,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - goss-servers-1.15.11-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
-    - pit-init-1.2.34-1.noarch
+    - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64


### PR DESCRIPTION
Fixes usage for `csi-setup-lan0.sh`. Also fixes the `PITDATA` variable in `pit-init.sh` for systems running in memory (e.g. for recovery where no partition can be provided).

- https://github.com/Cray-HPE/pit-init/pull/53
- https://github.com/Cray-HPE/pit-init/pull/52
