### PR TITLE
Add slurm-operator namespace role/cert for vault calls

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -183,7 +183,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.3.1
+    version: 1.3.2
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
@@ -199,7 +199,7 @@ spec:
     namespace: ceph-rgw
   - name: cray-certmanager-issuers
     source: csm-algol60
-    version: 0.6.1
+    version: 0.6.2
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fix for slurm-operator writing munge keys to vault from slurm-operator namespace -- add issuer for slurm-operator namespace.

## Issues and Related PRs

* Resolves [CASMPET-5953](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5953)

## Testing

```
ncn-m001-cdd6e862:/home/bklein/demo # kubectl get vault -n vault -o yaml | grep -C6 slurm
          bound_service_account_namespaces:
          - ceph-rgw
          - services
          - istio-system
          - sma
          - tapms-operator
          - slurm-operator
          - spire
          name: pki-common
          policies:
          - pki-common
          ttl: 1h
        - bound_service_account_names:
--
          name: uas
          policies:
          - allow_secrets
          - allow_transit
          ttl: 72h
        - bound_service_account_names:
          - slurm-operator
          bound_service_account_namespaces:
          - slurm-operator
          name: slurm-operator
          policies:
          - allow_secrets
          - allow_transit
          ttl: 72h
        type: kubernetes
      policies:
```

```
ncn-m001-cdd6e862:/home/bklein/demo # kubectl get issuers.cert-manager.io -n slurm-operator -o wide

NAME                         READY   STATUS           AGE
cert-manager-issuer-common   True    Vault verified   34s
```

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
