### PR TITLE
CASMHMS-5743 Fix token leaks in HMS test script

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -21,6 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
@@ -29,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.4.4-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.0.38-1.noarch
+    - hpe-csm-scripts-0.0.39-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change updates the hpe-csm-scripts version to v0.0.39 which fixes Keycloak authentication token leaks in the hsm_discovery_status_test.sh script. Previously the test output and logs would contain previously used tokens, now these tokens are redacted.

Example output:

```
ncn-m001:~/schooler # ./hsm_discovery_status_test.sh
Running hsm_discovery_status_test...
(17:29:51) Getting client secret...
(17:29:51) Retrieving authentication token...
(17:29:51) Testing 'curl -s -k -H "Authorization: Bearer <REDACTED>" https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints'...
(17:29:51) Processing response with: 'jq '.RedfishEndpoints[] | { ID: .ID, LastDiscoveryStatus: .DiscoveryInfo.LastDiscoveryStatus}' -c | sort -V | jq -c'...
(17:29:52) Verifying endpoint discovery statuses...
PASS: hsm_discovery_status_test passed!
```

### Issues and Related PRs

* Resolves CASMHMS-5743.

### Testing

This change was tested on Fanta by running the updated version of the script under various pass/fail conditions and verifying that the previously printed tokens were no longer present in the test output.

Was a fresh Install tested? Y
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

Low risk, security improvement.