### PR TITLE
CASMPET-5936: fix postgres database restore issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak to 3.3.2 to fix postgres database restore issue (CASMPET-5936)
 - Updated cray-powerdns-manager to 0.6.9 for various record generation fixes (CASMNET-1779)
 - Added all istio images to Nexus precache (CASMPET-5888)
 - Updated cfs-operator to 1.14.18 for CFS fixes around additional inventory

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -234,7 +234,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.3.1
+    version: 3.3.2
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updated cray-keycloak to 3.3.2  to fix postgres sql version incompatibility issue causing restore to fail.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Change will also be needed in `release/1.3`
* Future work required by [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Verified that cray-keycloak chart can restore the backed up image successfully with the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

