### PR TITLE
CASMPET-5936: fix postgres database restore issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)
 - Update craycli to 0.63.0 to clean up python 3.6 deprecation warning
 - Update cfs api, operator and trust for pod priority escalation
 - Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix 

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -243,7 +243,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.6.0
+    version: 3.6.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updated cray-keycloak to 3.6.1 to fix postgres sql version incompatibility issue causing restore to fail.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Change will also be needed in `main`
* Future work required by [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Verified that cray-keycloak chart can restore the backed up image successfully with the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

