### PR TITLE
Bump chart and docker versions to match (CASMINST-5325)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -299,7 +299,7 @@ spec:
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.7
+    version: 0.0.8
     namespace: tapms-operator
   - name: cray-k8s-encryption
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

tapms chart is referring to stale docker image

## Issues and Related PRs

* Resolves [CASMINST-5325](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5325)

## Testing

Updated tapms deployment on fanta, not hanging with latest bits..

### Tested on:

  * `fanta`
 
Now able to create tenant:
```
{
  "childnamespaces": [
    "vcluster-blue-user",
    "vcluster-blue-slurm"
  ],
  "tenantresources": [
    {
      "enforceexclusivehsmgroups": true,
      "hsmgrouplabel": "blue",
      "type": "compute",
      "xnames": [
        "x3000c0s21b1n0",
        "x3000c0s21b2n0"
      ]
    }
  ],
  "uuid": "aa8eb552-2e51-4ca9-8ade-2653a01a6d12"
}

tenants
└── [s] vcluster-blue
    ├── [s] vcluster-blue-slurm
    └── [s] vcluster-blue-user

[s] indicates subnamespaces
```

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
