### PR TITLE
CASMPET-5961-main : BREAK/FIX: Spire needs to pick up the cray base chart version 8.2.3 to fix postgres restore incompatibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released spire 2.10.1 to fix postgres database restore issue (CASMPET-5961)
 - Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)
 - Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)
 - Update craycli to 0.63.0 to fix python 3.6 deprecation warning

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,5 +176,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.10.0
+    version: 2.10.1
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Rebuilds spire to pickup base chart cray-service:8.2.3
Bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5961](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5961)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

```
$ kubectl get cronjob spire-postgresql-db-backup -n spire -o yaml | grep cray-service
    helm.sh/base-chart: cray-service-8.2.3

$ kubectl get cronjob spire-postgresql-db-backup -n spire -o yaml | grep backup | grep image
            image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3

$ kubectl logs spire-postgresql-db-backup-27718110-xq8vg -n spire
2022-09-13 16:30:25,170 - INFO    - root - Exec'ing ['pg_dumpall', '-c', '-h', 'spire-postgres-1']
2022-09-13 16:30:25,171 - INFO    - root - Sending pg_dump file to storage. bucket='postgres-backup', key='spire-postgres-2022-09-13T16:30:25.psql'
2022-09-13 16:30:26,003 - INFO    - root - progress: upload_fileobj sent 195882 bytes.
2022-09-13 16:30:26,004 - INFO    - root - Completed sending pg_dump file to storage.
2022-09-13 16:30:26,004 - INFO    - root - Fetching spire/spire.spire-postgres.credentials secrets
2022-09-13 16:30:26,017 - INFO    - root - Fetching spire/service-account.spire-postgres.credentials secrets
2022-09-13 16:30:26,023 - INFO    - root - Fetching spire/postgres.spire-postgres.credentials secrets
2022-09-13 16:30:26,028 - INFO    - root - Fetching spire/standby.spire-postgres.credentials secrets
2022-09-13 16:30:26,053 - INFO    - root - Completed sending creds file to storage. key='spire-postgres-2022-09-13T16:30:25.manifest'
2022-09-13 16:30:26,053 - INFO    - root - Listing objects in 'postgres-backup' with prefix 'spire-postgres-'
2022-09-13 16:30:26,103 - INFO    - root - Keys for db 'spire-postgres': ['spire-postgres-2022-09-13T16:30:25.manifest', 'spire-postgres-2022-09-13T16:30:25.psql']

ncn-w001-4712e011:~ # python list.py
spire-postgres-2022-09-13T16:40:16.manifest
spire-postgres-2022-09-13T16:40:16.psql

Verified restore from backup -- https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/kubernetes/Restore_Postgres.md#restore-postgres-for-spire (after downloading - renamed spire-postgres-2022-09-13T16:40:16.psql to exclude (":") in the name)
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

