### PR TITLE
added halt-on-error parameter to parallel opts

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -47,7 +47,7 @@ function extract-images() {
 	
     {
 
-    P_OPT="--nonall --retries 5 --delay 5 "
+    P_OPT="--nonall --retries 5 --delay 5 --halt-on-error 2 "
     YQ="docker run --rm -i \"$YQ_IMAGE\""
 
     images="$( bash <<EOF


### PR DESCRIPTION
## Summary and Scope

Improve chart related error handling in extract.sh script by adding "--halt-on-error" parameter to parallel options.
## Issues and Related PRs

* Resolves CASMINST-5176

## Testing

Tested in the build pipeline


## Risks and Mitigations

No known risks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
