### PR TITLE
Changed cray-hms-sls version to 3.0.0

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.6
+    version: 3.0.0
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Changed the cray-service chart version to 8.2.3 for SLS. With this change the following changes are brought in.

* CASMHMS-5696 - Disallow Networks with empty names
* CASMHMS-4267 - Changed loadstate to validate
* CASMHMS-5691: Added the slingshot11 network type
* CASMINST-3902: Expanded the SLS client to perform dumpstate and PUT to networks.

## Issues and Related PRs

* Resolves [CASMHMS-5753](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5753)
* Resolves [CASMHMS-5696](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5696)
* Resolves [CASMHMS-4267](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-4267)
* Resolves [CASMHMS-5691](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5691)
* Resolves [CASMINST-3902](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3902)

## Testing

See the PRs:
* https://github.com/Cray-HPE/hms-sls-charts/pull/18
* https://github.com/Cray-HPE/hms-sls/pull/57
* https://github.com/Cray-HPE/hms-sls/pull/56
* https://github.com/Cray-HPE/hms-sls/pull/55
* https://github.com/Cray-HPE/hms-sls/pull/54

## Risks and Mitigations

Some risk was mitigated by testing the changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

