### PR TITLE
Bump cray-k8s-encryption to 0.0.4

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -303,5 +303,5 @@ spec:
     namespace: tapms-operator
   - name: cray-k8s-encryption
     source: csm-algol60
-    version: 0.0.3
+    version: 0.0.4
     namespace: kube-system


### PR DESCRIPTION
## Summary and Scope

Update manifest to pull in 0.0.4 of the cray-k8s-encryption chart.

Bugfix to ensure placement only on masters.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-5968
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Validated on starlord and mug that we get placement only on master/control plane nodes.

### Tested on:

  * starlord/mug
  * Virtual Shasta

### Test description:

On a system with the node label having a different value than what I tested with, manually edited the changes into place to ensure we still only get placement on master nodes. While worker nodes also technically are fine they'll just never work due to missing volume mount.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? n/a
- Were continuous integration tests run? If not, why? This just ensures the daemonset is running.
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No risks known

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x ] Target branch correct
- [ ] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
