### PR TITLE
CASMINST-5349: csm_ntp.py properly handle unsuccessful responses from BSS

### DIFF
--- a/chrony/csm_ntp.py
+++ b/chrony/csm_ntp.py
@@ -94,15 +94,18 @@ def get_bss_data(token, xname):
     try:
         # rely on BSS data only and ignore the cloud-init cache
         response = requests.get(endpoint, params=data, headers=headers, verify=False, timeout=5)
-        if response.ok:
-            try:
-                return response.json()[0]["cloud-init"]["user-data"]
-            except KeyError:
-                print("BSS did not return the expected key. Please validate your BSS data.")
-                print("See 'operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata' in the CSM release documentation for steps on validating BSS data.")
-                sys.exit(2)
     except:
-        print("BSS query failed. See the error below.")
+        print(f"Error making BSS query to {endpoint}. See the error below:")
+        raise
+    if response.ok:
+        try:
+            return response.json()[0]["cloud-init"]["user-data"]
+        except KeyError:
+            print(f"BSS query to {endpoint} did not return the expected key. Validate the BSS data.")
+            print("See 'operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata' in the CSM release documentation for steps on validating BSS data.")
+            sys.exit(2)
+    else:
+        print(f"BSS query to {endpoint} was not successful. See the error below:")
         response.raise_for_status()
 
 


### PR DESCRIPTION
## Summary and Scope

The csm_ntp.py script has an oversight in how it attempts to handle problems with API calls to BSS. It handles the case where the request function raises an exception, but it does not handle the case where the request gets a response, but that response is not reporting success. This PR modifies the get_bss_data function so that it properly handles both error paths.

Caveats:
- I did not author the original script and don't know much about it. I have tested my changes and am confident that they do what I want, but someone with more context about the script should be sure to review them.
- I don't know if the csm repo is the (only) home of this script. I just saw that it existed here and had the same issue as I saw on surtur. On surtur I could see that the file had not been installed by an RPM, but otherwise I could not determine where it came from. So if this script exists elsewhere, the fix should be made there too. Again, I'm hoping someone who knows more about this than me can weigh in. (Side note -- **why ISN'T this part of an RPM?** It makes it harder to track down by having it just exist as a floating script on the NCNs)

## Issues and Related PRs

[CASMINST-5349](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5349)
1.2 backport: https://github.com/Cray-HPE/csm/pull/1334
main backport: https://github.com/Cray-HPE/csm/pull/1335

## Testing

On surtur, where BSS is currently unhappy and returning 503s, this is how the script behaved before this PR:
```text
Traceback (most recent call last):
  File "/srv/cray/scripts/common/chrony/csm_ntp.py", line 177, in <module>
    allow = bss_data["ntp"]["allow"]
TypeError: 'NoneType' object is not subscriptable
```

After the PR, this is the behavior
```text
BSS query to https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters was not successful. See the error below:
Traceback (most recent call last):
  File "./csm_ntp.py", line 173, in <module>
    bss_data = get_bss_data(token, xname)
  File "./csm_ntp.py", line 109, in get_bss_data
    response.raise_for_status()
  File "/usr/lib/python3.6/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: Service Unavailable for url: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=x3000c0s1b0n0
```

Neither one is pretty, but at least the new one explains what the actual problem is.

## Risks and Mitigations

Quite low risk. The good path is unchanged in the script, only the error path. So we're already only talking about situations where the script is going to fail anyway. This just makes it easier for someone to understand the cause of the failure without having to look at the source code of the script (but if they do want to look at the source code, the new stack trace presents a more accurate reflection of where in the code the true failure happened -- the original stack trace points to a distant part of the code, because it doesn't fail until it tries to access the None object like a dictionary).

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
