### PR TITLE
CASMPET-5970 Bump cray-opa to 1.28.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -171,7 +171,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.28.0
+    version: 1.28.1
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes a build issue due to a missing default tpmProvisioner value.

## Issues and Related PRs

* Resolves [CASMPET-5970](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5970)
* https://github.com/Cray-HPE/cray-opa/pull/62
## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

