### PR TITLE
CASMINST-5352: Fix broken link in unused_drives_on_storage_nodes test description

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.14.57-1.noarch
-    - goss-servers-1.14.57-1.noarch
+    - csm-testing-1.14.58-1.noarch
+    - goss-servers-1.14.58-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.35-1.noarch


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-5352](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5352)
- Relates to: [CASMTRIAGE-4198](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4198)

#### Related PRs:

- csm
  - https://github.com/Cray-HPE/csm/pull/1339
- csm-rpms
  - https://github.com/Cray-HPE/csm-rpms/pull/614
  - https://github.com/Cray-HPE/csm-rpms/pull/615
- csm-testing
  - https://github.com/Cray-HPE/csm-testing/pull/398
  - https://github.com/Cray-HPE/csm-testing/pull/399
- docs-csm
  - https://github.com/Cray-HPE/docs-csm/pull/2498
  - https://github.com/Cray-HPE/docs-csm/pull/2499

#### Issue Type

- Bugfix Pull Request
- Docs Pull Request

The description of this test (seen when it fails) includes a link to a page which no longer exists in the csm-1.3 documentation. This updates the test description text to correct that, as well as to include instructions on how to manually run the test, if desired.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [X] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
Very low risk. Change is only to description text of the test.