### PR TITLE
add set -eo pipefail to inline bash script to force exit on error

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -51,6 +51,8 @@ function extract-images() {
     YQ="docker run --rm -i \"$YQ_IMAGE\""
 
     images="$( bash <<EOF
+set -eo pipefail
+
 parallel $P_OPT \
          helm show chart "${args[@]}" \
 	 | $YQ e -N '.annotations."artifacthub.io/images" | select(.)' - | grep "image:" | awk '{print \$NF;}'

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -47,11 +47,11 @@ function extract-images() {
 	
     {
 
-    P_OPT="--nonall --retries 5 --delay 5 --halt-on-error 2 "
+    P_OPT="--nonall --retries 5 --delay 5 --halt-on-error now,fail=1 "
     YQ="docker run --rm -i \"$YQ_IMAGE\""
 
     images="$( bash <<EOF
-set -eo pipefail
+set -e
 
 parallel $P_OPT \
          helm show chart "${args[@]}" \


### PR DESCRIPTION
## Summary and Scope

Improve chart related error handling in extract.sh script by adding "set -eo pipefail" parameter to parallel options.
## Issues and Related PRs

Resolves casminst-5355

* Resolves CASMINST-5355

## Testing

Tested in the build pipeline


## Risks and Mitigations

No known risks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
