### PR TITLE
Move tapms chart deploy later in the install

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -297,10 +297,6 @@ spec:
     source: csm-algol60
     version: 0.0.4
     namespace: hnc-system
-  - name: cray-tapms-operator
-    source: csm-algol60
-    version: 0.0.8
-    namespace: tapms-operator
   - name: cray-k8s-encryption
     source: csm-algol60
     version: 0.0.4

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -178,3 +178,9 @@ spec:
     source: csm-algol60
     version: 2.10.1
     namespace: spire
+
+  # Tapms service
+  - name: cray-tapms-operator
+    source: csm-algol60
+    version: 0.0.8
+    namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Adding some distance between the hnc and tapms charts.  Wasn't able to reproduce the issue but it looked like hnc was still doing some config when tapms was installed.  It makes sense to move tapms after the hms stuff anyway, since it makes hsm calls anyway..

## Issues and Related PRs

* Resolves [CASMTRIAGE-4209](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4209)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

