### PR TITLE
CASMTRIAGE-4188 main : LANL DDR5 tycho bos etcd backup has not run for 9 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-etcd-backup 0.4.3 to add backupPolicy.timeoutInSecond (CASMTRIAGE-4188)
 - Released cray-nls 1.4.1 to fix postgres database restore issue (CASMPET-5960)
 - Released spire 2.10.1 to fix postgres database restore issue (CASMPET-5961)
 - Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -271,7 +271,7 @@ spec:
     namespace: operators
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.4.2
+    version: 0.4.3
     namespace: operators
   - name: cray-metallb
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

In LANL tycho enviromment, the bos etcd backups had been timing out for many days.
This environment has 14 workers, 2688 compute nodes in 11 Olympus cabinets.
The default timeout is 1 min, once the timeout was increased, the backups started to succeed in tycho.
The timeout was increased to 10 min for all etcdbackups and a post-upgrade hook was added to allow for the etcdbackup resources to get re-created with the added backupPolicy.timeoutInSecond value.

This is targeted for CSM 1.3.
A troubleshooting doc change will be made for CSM 1.2.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-4188](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4188)
* Change will also be needed in `<insert branch name here>`
* Future work required in N/A
*  Documentation changes required - doc the error and WAR for csm 1.2
* Merge with/before/after `<insert PR URL here>`

## Testing

vshasta
tycho

### Tested on:

  * Virtual Shasta

### Test description:

- install, upgrade (including post-upgrade hook) and rollback
- automated backups, manual backups all completed as expected

```
$ kubectl get etcdbackup -A -o yaml |  grep -B 3 "      timeoutInSecond:"
    backupPolicy:
      backupIntervalInSecond: 60
      maxBackups: 7
      timeoutInSecond: 600
--
    backupPolicy:
      backupIntervalInSecond: 86400
      maxBackups: 7
      timeoutInSecond: 600
--
    backupPolicy:
      backupIntervalInSecond: 86400
      maxBackups: 7
      timeoutInSecond: 600

$ kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- grep -B 3 timeoutInSecond  /usr/local/sbin/create_backup
    forcePathStyle: true
    endpoint: $s3_endpoint
  backupPolicy:
    timeoutInSecond: 600
--
    forcePathStyle: true
    endpoint: $s3_endpoint
  backupPolicy:
    timeoutInSecond: 600
    ```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

