### PR TITLE
CASMMON-190/196 Path change for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update craycli to 0.63.0 to fix python 3.6 deprecation warning
 - Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
 - Released cray-nls-charts 1.4.0 to add new mount for storage workflows 
 - Update cfs api, operator and trust for pod priority escalation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)
 - Update craycli to 0.63.0 to fix python 3.6 deprecation warning
 - Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
 - Released cray-nls-charts 1.4.0 to add new mount for storage workflows 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-nls-charts 1.4.0 to add new mount for storage workflows 
 - Update cfs api, operator and trust for pod priority escalation
 - Released goss-servers/csm-testing v1.14.47 for ceph goss test failure output change
 - Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated IMS to provide a larger default image size (CASMCMS-8015)
 - Updated console services to handle Hill nodes.
 - Updated barebones image to use slessp4.
+- Added configurable timeout to IMS service to allow handling large images.
 
 
 ## [0.9.0] - 2021-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-nls 1.4.1 to fix postgres database restore issue (CASMPET-5960)
 - Released spire 2.10.1 to fix postgres database restore issue (CASMPET-5961)
 - Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)
 - Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
 - Released cray-nls-charts 1.4.0 to add new mount for storage workflows 
 - Update cfs api, operator and trust for pod priority escalation
 - Released goss-servers/csm-testing v1.14.47 for ceph goss test failure output change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-etcd-backup 0.4.3 to add backupPolicy.timeoutInSecond (CASMTRIAGE-4188)
 - Released cray-nls 1.4.1 to fix postgres database restore issue (CASMPET-5960)
 - Released spire 2.10.1 to fix postgres database restore issue (CASMPET-5961)
 - Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released spire 2.10.1 to fix postgres database restore issue (CASMPET-5961)
 - Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)
 - Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)
 - Update craycli to 0.63.0 to fix python 3.6 deprecation warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)
 - Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)
 - Update craycli to 0.63.0 to fix python 3.6 deprecation warning
 - Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -97,6 +97,9 @@ pipeline {
                 stage('Init') {
                     steps{
                         script {
+                            // verify head of correlated to DOCS-CSM branch has been tagged (built)
+                            // need to explicitly provide name of correlated to DOCS-CSM branch
+                            sh "./verify-docs-csm-tag.sh main"
                             env.RELEASE_VERSION = sh(script: './version.sh', returnStdout: true).trim()
                             slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting, see #${env.SLACK_CHANNEL_ALERTS} for details")
                             slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting")

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -75,7 +75,9 @@ pipeline {
                                 rpm/cray/csm/sle-15sp2/index.yaml \
                                 rpm/cray/csm/sle-15sp2-compute/index.yaml \
                                 rpm/cray/csm/sle-15sp3/index.yaml \
-                                rpm/cray/csm/sle-15sp3-compute/index.yaml
+                                rpm/cray/csm/sle-15sp3-compute/index.yaml \
+                                rpm/cray/csm/sle-15sp4/index.yaml \
+                                rpm/cray/csm/sle-15sp4-compute/index.yaml
                         """
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ building a release distribution. CSM release distributions are automatically
 uploaded to one of the following Artifactory repositories by the CI pipeline:
 
 * _Stable_ major-minor-patch releases --
-  [shasta-distribution-stable-local](https://arti.dev.cray.com:443/artifactory/shasta-distribution-stable-local/)
+  [shasta-distribution-stable-local](https://arti.hpc.amslabs.hpecorp.net:443/artifactory/shasta-distribution-stable-local/)
 * _Unstable_ pre-releases --
-  [shasta-distribution-unstable-local](https://arti.dev.cray.com:443/artifactory/shasta-distribution-unstable-local/)
+  [shasta-distribution-unstable-local](https://arti.hpc.amslabs.hpecorp.net:443/artifactory/shasta-distribution-unstable-local/)
 
 
 ## Contributing

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220824200039.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220824200039.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220824200039.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220826204837.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220826204837.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220826204837.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.2/kubernetes-0.4.2.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.2/5.3.18-150300.59.43-default-0.4.2.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.2/initrd.img-0.4.2.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.4/kubernetes-0.4.4.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.4/5.3.18-150300.59.87-default-0.4.4.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.4/initrd.img-0.4.4.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.2/storage-ceph-0.4.2.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.2/5.3.18-150300.59.43-default-0.4.2.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.2/initrd.img-0.4.2.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/storage-ceph-0.4.4.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/5.3.18-150300.59.87-default-0.4.4.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/initrd.img-0.4.4.xz
 )
 
 HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.9/kubernetes-0.4.9.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.9/5.3.18-150300.59.87-default-0.4.9.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.9/initrd.img-0.4.9.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.10/kubernetes-0.4.10.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.10/5.3.18-150300.59.87-default-0.4.10.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.10/initrd.img-0.4.10.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.9/storage-ceph-0.4.9.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.9/5.3.18-150300.59.87-default-0.4.9.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.9/initrd.img-0.4.9.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.10/storage-ceph-0.4.10.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.10/5.3.18-150300.59.87-default-0.4.10.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.10/initrd.img-0.4.10.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,9 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220920210912.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220920210912.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220920210912.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220921195844.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220921195844.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220921195844.verified
 )
 
 KUBERNETES_ASSETS=(

--- a/assets.sh
+++ b/assets.sh
@@ -40,7 +40,7 @@ STORAGE_CEPH_ASSETS=(
     https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/initrd.img-0.4.4.xz
 )
 
-HPE_SIGNING_KEY=https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
+HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc
 
 set -exo pipefail
 

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220826204837.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220826204837.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.0/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.0-20220826204837.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220901210009.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220901210009.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220901210009.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.4/kubernetes-0.4.4.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.4/5.3.18-150300.59.87-default-0.4.4.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.4/initrd.img-0.4.4.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.7/kubernetes-0.4.7.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.7/5.3.18-150300.59.87-default-0.4.7.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.7/initrd.img-0.4.7.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/storage-ceph-0.4.4.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/5.3.18-150300.59.87-default-0.4.4.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.4/initrd.img-0.4.4.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.7/storage-ceph-0.4.7.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.7/5.3.18-150300.59.87-default-0.4.7.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.7/initrd.img-0.4.7.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220901210009.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220901210009.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220901210009.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220907202523.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.7/kubernetes-0.4.7.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.7/5.3.18-150300.59.87-default-0.4.7.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.7/initrd.img-0.4.7.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.8/kubernetes-0.4.8.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.8/5.3.18-150300.59.87-default-0.4.8.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.8/initrd.img-0.4.8.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.7/storage-ceph-0.4.7.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.7/5.3.18-150300.59.87-default-0.4.7.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.7/initrd.img-0.4.7.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.8/storage-ceph-0.4.8.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.8/5.3.18-150300.59.87-default-0.4.8.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.8/initrd.img-0.4.8.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220912184904.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220920210912.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220920210912.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.1/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.1-20220920210912.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.10/kubernetes-0.4.10.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.10/5.3.18-150300.59.87-default-0.4.10.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.10/initrd.img-0.4.10.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.11/kubernetes-0.4.11.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.11/5.3.18-150300.59.87-default-0.4.11.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.11/initrd.img-0.4.11.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.10/storage-ceph-0.4.10.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.10/5.3.18-150300.59.87-default-0.4.10.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.10/initrd.img-0.4.10.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.11/storage-ceph-0.4.11.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.11/5.3.18-150300.59.87-default-0.4.11.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.11/initrd.img-0.4.11.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.8/kubernetes-0.4.8.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.8/5.3.18-150300.59.87-default-0.4.8.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.8/initrd.img-0.4.8.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.9/kubernetes-0.4.9.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.9/5.3.18-150300.59.87-default-0.4.9.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.9/initrd.img-0.4.9.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.8/storage-ceph-0.4.8.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.8/5.3.18-150300.59.87-default-0.4.8.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.8/initrd.img-0.4.8.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.9/storage-ceph-0.4.9.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.9/5.3.18-150300.59.87-default-0.4.9.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.9/initrd.img-0.4.9.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/build/README.md
+++ b/build/README.md
@@ -42,13 +42,13 @@ version):
    For example, the comment for CSM 0.9.0 would be:
 
    > Release distribution at
-   > https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm/csm-0.9.0.tar.gz
+   > https://arti.hpc.amslabs.hpecorp.net/artifactory/shasta-distribution-stable-local/csm/csm-0.9.0.tar.gz
 
 10. Announce the availability of the release in the #casm-release-management
     Slack channel. E.g.,
 
     > CSM v0.9.0 at
-    > https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm/csm-0.9.0.tar.gz
+    > https://arti.hpc.amslabs.hpecorp.net/artifactory/shasta-distribution-stable-local/csm/csm-0.9.0.tar.gz
 
 
 ## Creating a Release Distribution Patch
@@ -114,7 +114,7 @@ _destination_ (`$dst_version`) versions to be extracted in the same directory.
      version
 
    ```bash
-   $ curl -sSLki -X PUT -H "X-JFrog-Art-Api: ${apikey}" -H "X-Checksum-Sha1: $(sha1sum "${patchfile}.gz" | awk '{print $1}')" "https://arti.dev.cray.com/artifactory/${repo}/csm/${patchfile}.gz" -T "${patchfile}.gz"
+   $ curl -sSLki -X PUT -H "X-JFrog-Art-Api: ${apikey}" -H "X-Checksum-Sha1: $(sha1sum "${patchfile}.gz" | awk '{print $1}')" "https://arti.hpc.amslabs.hpecorp.net/artifactory/${repo}/csm/${patchfile}.gz" -T "${patchfile}.gz"
    ```
 
 
@@ -187,7 +187,7 @@ desired compressed patch (`${patchfile}.gz`) have been downloaded.
 [CASMREL issues]: https://connect.us.cray.com/jira/projects/CASMREL/issues/
 [Jenkins job]: https://cje2.dev.cray.com/teams-casmpet-team/job/casmpet-team/job/csm/
 [Jenkins build]: https://cje2.dev.cray.com/teams-casmpet-team/blue/organizations/casmpet-team/csm/activity
-[shasta-distribution-unstable-local]: https://arti.dev.cray.com/artifactory/shasta-distribution-unstable-local/csm/
-[shasta-distribution-stable-local]: https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm/
-[Artifactory]: https://arti.dev.cray.com/
-[profile page]: https://arti.dev.cray.com/ui/admin/artifactory/user_profile
+[shasta-distribution-unstable-local]: https://arti.hpc.amslabs.hpecorp.net/artifactory/shasta-distribution-unstable-local/csm/
+[shasta-distribution-stable-local]: https://arti.hpc.amslabs.hpecorp.net/artifactory/shasta-distribution-stable-local/csm/
+[Artifactory]: https://arti.hpc.amslabs.hpecorp.net/
+[profile page]: https://arti.hpc.amslabs.hpecorp.net/ui/admin/artifactory/user_profile

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -47,10 +47,12 @@ function extract-images() {
 	
     {
 
-    P_OPT="--nonall --retries 5 --delay 5 --halt-on-error 2 "
+    P_OPT="--nonall --retries 5 --delay 5 --halt-on-error now,fail=1 "
     YQ="docker run --rm -i \"$YQ_IMAGE\""
 
     images="$( bash <<EOF
+set -e
+
 parallel $P_OPT \
          helm show chart "${args[@]}" \
 	 | $YQ e -N '.annotations."artifacthub.io/images" | select(.)' - | grep "image:" | awk '{print \$NF;}'

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -47,7 +47,7 @@ function extract-images() {
 	
     {
 
-    P_OPT="--nonall --retries 5 --delay 5 "
+    P_OPT="--nonall --retries 5 --delay 5 --halt-on-error 2 "
     YQ="docker run --rm -i \"$YQ_IMAGE\""
 
     images="$( bash <<EOF

--- a/build/images/resolve.py
+++ b/build/images/resolve.py
@@ -11,7 +11,7 @@ INVALID_DOMAINS = set([
 
 NON_MIRRORED_DOMAINS = set([
     'artifactory.algol60.net',
-    'arti.dev.cray.com',
+    'arti.hpc.amslabs.hpecorp.net',
 ])
 
 parser = argparse.ArgumentParser(description="Resolves image repositories to canonical forms")

--- a/chrony/csm_ntp.py
+++ b/chrony/csm_ntp.py
@@ -94,15 +94,18 @@ def get_bss_data(token, xname):
     try:
         # rely on BSS data only and ignore the cloud-init cache
         response = requests.get(endpoint, params=data, headers=headers, verify=False, timeout=5)
-        if response.ok:
-            try:
-                return response.json()[0]["cloud-init"]["user-data"]
-            except KeyError:
-                print("BSS did not return the expected key. Please validate your BSS data.")
-                print("See 'operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata' in the CSM release documentation for steps on validating BSS data.")
-                sys.exit(2)
     except:
-        print("BSS query failed. See the error below.")
+        print(f"Error making BSS query to {endpoint}. See the error below:")
+        raise
+    if response.ok:
+        try:
+            return response.json()[0]["cloud-init"]["user-data"]
+        except KeyError:
+            print(f"BSS query to {endpoint} did not return the expected key. Validate the BSS data.")
+            print("See 'operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata' in the CSM release documentation for steps on validating BSS data.")
+            sys.exit(2)
+    else:
+        print(f"BSS query to {endpoint} was not successful. See the error below:")
         response.raise_for_status()
 
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.19.1
+      - 3.19.2
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.19.0
+      - 3.19.1
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -53,6 +53,10 @@ artifactory.algol60.net/csm-docker/stable:
     hms-trs-worker-http-v1:
       - 1.8.0
 
+    # Utility to help make changes for adding river cabinets
+    hardware-topology-assistant:
+    - 0.1.0
+
     # Rebuilt third-party images below
 
     # Required by ceph

--- a/hack/gen-helm-index.sh
+++ b/hack/gen-helm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.11.0"
 
 set -o errexit
 set -o pipefail
@@ -19,7 +19,7 @@ fi
 set -o xtrace
 
 # Generate index
-docker run --rm -v "$(realpath "$ROOTDIR"):/data" "$PACKAGING_TOOLS_IMAGE" sh -c "helm-index --default-repo 'https://arti.dev.cray.com/artifactory/csm-helm-stable-local/' ${options} manifests/*.yaml" > "${workdir}/helm-index.yaml"
+docker run --rm -v "$(realpath "$ROOTDIR"):/data" "$PACKAGING_TOOLS_IMAGE" sh -c "helm-index --default-repo 'https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-helm-stable-local/' ${options} manifests/*.yaml" > "${workdir}/helm-index.yaml"
 
 # Save to helm/index.yaml
 [[ -d "${ROOTDIR}/helm" ]] || mkdir -p "${ROOTDIR}/helm"

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -45,17 +45,17 @@ fi
 docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.3 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
 -d  https://download.opensuse.org/repositories/filesystems:/ceph/openSUSE_Leap_15.3/                                        opensuse_leap/15.3 \
 -d  https://artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph/openSUSE_Leap_15.3/                       mirror/opensuse_leap/15.3 \
--d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
--d  https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
--d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \
--d  https://arti.dev.cray.com/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP2/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP2/x86_64/current \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpm-stable-local/release/                                                     cray/csm/sle-15sp3/x86_64 \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP3/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP3/x86_64/current \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP2/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP2/x86_64/current \
 -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                              cray/csm/sle-15sp3 \
 -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                              cray/csm/sle-15sp3 \
--d  https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                               cray/cos-2.3/sle15_sp3_ncn \
--d  https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_ncn/                               cray/cos-2.1/sle15_sp2_ncn \
--d  https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                               cray/cos-2.2/sle15_sp3_ncn \
--d  https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                                cray/cos-2.2/sle15_sp3_cn \
--d  https://arti.dev.cray.com/artifactory/slingshot-host-software-rpm-stable-local/release/cos-2.2/sle15_sp2_ncn/           cray/cos-2.2/sle15_sp2_ncn \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                               cray/cos-2.3/sle15_sp3_ncn \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_ncn/                               cray/cos-2.1/sle15_sp2_ncn \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                               cray/cos-2.2/sle15_sp3_ncn \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                                cray/cos-2.2/sle15_sp3_cn \
+-d  https://arti.hpc.amslabs.hpecorp.net/artifactory/slingshot-host-software-rpm-stable-local/release/cos-2.2/sle15_sp2_ncn/           cray/cos-2.2/sle15_sp2_ncn \
     -d  http://slemaster.us.cray.com/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/                  suse/SLE-Module-Basesystem/15-SP2/x86_64/product \
     -d  http://slemaster.us.cray.com/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product_debug/            suse/SLE-Module-Basesystem/15-SP2/x86_64/product_debug \
     -d  http://slemaster.us.cray.com/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/                    suse/SLE-Module-Basesystem/15-SP2/x86_64/update \

--- a/hack/list-squashfs-rpms.sh
+++ b/hack/list-squashfs-rpms.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-SQUASHFS_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/squashfs-tools:0.1.0"
+SQUASHFS_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/squashfs-tools:0.1.0"
 
 function rpm-list() {
     while [[ $# -gt 0 ]]; do

--- a/hack/verify-rpm-index.sh
+++ b/hack/verify-rpm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.dev.cray.com/internal-docker-stable-local/packaging-tools:0.11.0"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.11.0"
 
 set -o errexit
 set -o pipefail

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.19.0"
+sat_version="3.19.1"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.19.1"
+sat_version="3.19.2"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -69,6 +69,8 @@ nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2"         "csm-${RELEASE_VERS
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2-compute" "csm-${RELEASE_VERSION}-sle-15sp2-compute"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERSION}-sle-15sp3"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3-compute" "csm-${RELEASE_VERSION}-sle-15sp3-compute"
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4"         "csm-${RELEASE_VERSION}-sle-15sp4"
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute" "csm-${RELEASE_VERSION}-sle-15sp4-compute"
 
 clean-install-deps
 

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -50,11 +50,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.10 # update platform.yaml cray-precache-images with this
+    version: 0.7.11 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.10
+        appVersion: 0.7.11
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -19,6 +19,9 @@ spec:
     version: 2.1.9
     namespace: services
     values:
+      global:
+        appVersion: 1.58.1
+        testVersion: 1.58.1
       cray-service:
         sqlCluster:
           resources:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.1.9
+    version: 4.0.0
     namespace: services
     values:
       global:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.7
+    version: 3.0.1
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -44,7 +44,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.15 # update platform.yaml cray-precache-images with this
+    version: 0.10.16 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.1.6
+    version: 2.1.7
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -171,7 +171,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.28.0
+    version: 1.28.1
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -303,5 +303,5 @@ spec:
     namespace: tapms-operator
   - name: cray-k8s-encryption
     source: csm-algol60
-    version: 0.0.3
+    version: 0.0.4
     namespace: kube-system

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.14.2
+    version: 2.14.3
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -299,7 +299,7 @@ spec:
     namespace: hnc-system
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.7
+    version: 0.0.8
     namespace: tapms-operator
   - name: cray-k8s-encryption
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.25.1
+    version: 0.26.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -183,7 +183,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.3.1
+    version: 1.3.2
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
@@ -199,7 +199,7 @@ spec:
     namespace: ceph-rgw
   - name: cray-certmanager-issuers
     source: csm-algol60
-    version: 0.6.1
+    version: 0.6.2
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -297,10 +297,6 @@ spec:
     source: csm-algol60
     version: 0.0.4
     namespace: hnc-system
-  - name: cray-tapms-operator
-    source: csm-algol60
-    version: 0.0.8
-    namespace: tapms-operator
   - name: cray-k8s-encryption
     source: csm-algol60
     version: 0.0.4

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -171,7 +171,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.25.0
+    version: 1.28.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -243,7 +243,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.6.0
+    version: 3.6.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.5
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.10
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.11
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.5
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.16
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.11
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -271,7 +271,7 @@ spec:
     namespace: operators
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.4.2
+    version: 0.4.3
     namespace: operators
   - name: cray-metallb
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -29,7 +29,7 @@ spec:
     charts:
     - name: csm
       type: repo
-      location: https://arti.dev.cray.com/artifactory/csm-helm-stable-local/
+      location: https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-helm-stable-local/
     - name: csm-algol60
       type: repo
       location: https://artifactory.algol60.net/artifactory/csm-helm-charts/

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -291,7 +291,7 @@ spec:
     namespace: services
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.0
+    version: 1.4.1
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -291,7 +291,7 @@ spec:
     namespace: services
   - name: cray-nls
     source: csm-algol60
-    version: 1.3.8
+    version: 1.4.0
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -82,7 +82,7 @@ spec:
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.11.1
+    version: 1.11.2
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.3
+    version: 2.0.0-beta.6
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.0-beta.6
+    version: 2.0.0
     namespace: services
   - name: csm-ssh-keys
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -178,3 +178,9 @@ spec:
     source: csm-algol60
     version: 2.10.1
     namespace: spire
+
+  # Tapms service
+  - name: cray-tapms-operator
+    source: csm-algol60
+    version: 0.0.8
+    namespace: tapms-operator

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -109,7 +109,7 @@ spec:
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.6.0
+    version: 1.7.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
@@ -117,7 +117,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.10.1
+    version: 1.11.0
     namespace: services
   - name: cray-tftp
     source: csm-algol60
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.14.0
+    version: 1.15.0
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,5 +176,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.10.0
+    version: 2.10.1
     namespace: spire

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -117,7 +117,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.10.0
+    version: 1.10.1
     namespace: services
   - name: cray-tftp
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -166,11 +166,11 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.21.0
+    version: 1.22.0
     namespace: services
   - name: update-uas
     source: csm-algol60
-    version: 1.7.4
+    version: 1.8.0
     namespace: services
 
   # Spire service

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.13.0
+    version: 1.14.0
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,7 +141,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.12.0
+    version: 1.13.0
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.6.0
+    version: 3.6.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60

--- a/manifests/velero-1.7-upgrade.yaml
+++ b/manifests/velero-1.7-upgrade.yaml
@@ -29,7 +29,7 @@ spec:
     charts:
     - name: csm
       type: repo
-      location: https://arti.dev.cray.com/artifactory/csm-helm-stable-local/
+      location: https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-helm-stable-local/
     - name: csm-algol60
       type: repo
       location: https://artifactory.algol60.net/artifactory/csm-helm-charts/

--- a/nexus-repositories.yaml
+++ b/nexus-repositories.yaml
@@ -73,3 +73,33 @@ type: group
 group:
   memberNames:
   - csm-0.0.0-sle-15sp3-compute
+
+---
+name: csm-0.0.0-sle-15sp4
+format: raw
+storage:
+  blobStoreName: csm
+---
+name: csm-sle-15sp4
+format: raw
+storage:
+  blobStoreName: csm
+type: group
+group:
+  memberNames:
+  - csm-0.0.0-sle-15sp4
+
+---
+name: csm-0.0.0-sle-15sp4-compute
+format: raw
+storage:
+  blobStoreName: csm
+---
+name: csm-sle-15sp4-compute
+format: raw
+storage:
+  blobStoreName: csm
+type: group
+group:
+  memberNames:
+  - csm-0.0.0-sle-15sp4-compute

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.62.0-1.x86_64
+    - craycli-0.63.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -21,6 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
@@ -29,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.4.4-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.0.38-1.noarch
+    - hpe-csm-scripts-0.0.39-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -28,7 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.63.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - docs-csm-1.4.4-1.noarch
+    - docs-csm-1.4.5-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-scripts-0.0.39-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.62.0-1.x86_64
+    - craycli-0.63.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.4.3-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.62.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - docs-csm-1.3.34-1.noarch
+    - docs-csm-1.4.3-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-scripts-0.0.38-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -35,6 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.3.5-1.noarch
+    - platform-utils-1.4.0-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.63.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - docs-csm-1.4.3-1.noarch
+    - docs-csm-1.4.4-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-scripts-0.0.38-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -21,7 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
@@ -30,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.4.4-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.0.39-1.noarch
+    - hpe-csm-scripts-0.0.38-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.2-1.x86_64
     - csm-testing-1.15.11-1.noarch
     - goss-servers-1.15.11-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -30,6 +30,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - goss-servers-1.15.11-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
-    - pit-init-1.2.34-1.noarch
+    - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
     - cray-site-init-1.26.2-1.x86_64
-    - csm-testing-1.15.7-1.noarch
-    - goss-servers-1.15.7-1.noarch
+    - csm-testing-1.15.10-1.noarch
+    - goss-servers-1.15.10-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.15.6-1.noarch
-    - goss-servers-1.15.6-1.noarch
+    - csm-testing-1.15.7-1.noarch
+    - goss-servers-1.15.7-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
-    - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
     - cray-site-init-1.26.2-1.x86_64
     - csm-testing-1.15.7-1.noarch
     - goss-servers-1.15.7-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-testing-1.15.4-1.noarch
     - goss-servers-1.15.4-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
-    - metal-ipxe-2.2.9-1.noarch
+    - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.34-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.15.4-1.noarch
-    - goss-servers-1.15.4-1.noarch
+    - csm-testing-1.15.6-1.noarch
+    - goss-servers-1.15.6-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - csm-testing-1.15.13-1.noarch
     - goss-servers-1.15.13-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
-    - metal-ipxe-2.2.10-1.noarch
+    - metal-ipxe-2.2.11-1.noarch
     - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.1-1.x86_64
     - cray-site-init-1.26.2-1.x86_64
-    - csm-testing-1.15.10-1.noarch
-    - goss-servers-1.15.10-1.noarch
+    - csm-testing-1.15.11-1.noarch
+    - goss-servers-1.15.11-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.2-1.x86_64
-    - csm-testing-1.15.11-1.noarch
-    - goss-servers-1.15.11-1.noarch
+    - csm-testing-1.15.13-1.noarch
+    - goss-servers-1.15.13-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.10-1.noarch
     - pit-init-1.2.35-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.15.2-1.noarch
-    - goss-servers-1.15.2-1.noarch
+    - csm-testing-1.15.3-1.noarch
+    - goss-servers-1.15.3-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
     - cray-site-init-1.26.1-1.x86_64
-    - csm-testing-1.15.3-1.noarch
-    - goss-servers-1.15.3-1.noarch
+    - csm-testing-1.15.4-1.noarch
+    - goss-servers-1.15.4-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.34-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.8.0-1.x86_64
-    - cray-site-init-1.26.1-1.x86_64
+    - cray-site-init-1.26.2-1.x86_64
     - csm-testing-1.15.7-1.noarch
     - goss-servers-1.15.7-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
@@ -33,4 +33,3 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - pit-init-1.2.34-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
-

--- a/validate.sh
+++ b/validate.sh
@@ -3,7 +3,7 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 declare -A HELM_REPOS
-HELM_REPOS[csm]="https://arti.dev.cray.com/artifactory/csm-helm-stable-local/"
+HELM_REPOS[csm]="https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-helm-stable-local/"
 HELM_REPOS[csm-algol60]="https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 DEFAULT_HELM_REPO="csm"
 
@@ -199,7 +199,7 @@ function get_images() {
 
     # # Images found in configmap data attributes
     IMAGES+=( $(echo "$yaml" | yq r -d '*' - 'data(.==dtr.dev.cray.com/*)') )
-    IMAGES+=( $(echo "$yaml" | yq r -d '*' - 'data(.==arti.dev.cray.com/*)') )
+    IMAGES+=( $(echo "$yaml" | yq r -d '*' - 'data(.==arti.hpc.amslabs.hpecorp.net/*)') )
     IMAGES+=( $(echo "$yaml" | yq r -d '*' - 'data(.==artifactory.algol60.net/*') )
     IMAGES+=( $(echo "$yaml" | yq r -d '*' - 'data.images_to_cache' | grep dtr.dev.cray.com) )
 

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -318,7 +318,7 @@ spec:
         keycloak:
           keycloak_admin_client_auth_secret_name: admin-client-auth
         customer_access:
-          access_pool: customer-access
+          access_pool: customer-management
           shasta_domain: '{{ network.dns.external }}'
         api_gw:
           api_gw_service_name: istio-ingressgateway

--- a/verify-docs-csm-tag.sh
+++ b/verify-docs-csm-tag.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+if [ $# -ge 1 ] && [ -n "$1" ]
+then
+      DOCS_CSM_BRANCH=$1
+      echo "checking ${DOCS_CSM_BRANCH} branch in docs-csm repo to verify head is tagged"
+else
+      echo "ERROR: branch to verify in docs-csm repo not specified in arguments"
+      exit 1
+fi
+      
+git clone --no-checkout --depth 1 --branch ${DOCS_CSM_BRANCH} https://github.com/Cray-HPE/docs-csm.git
+if [ -d "docs-csm" ]
+then
+      cd docs-csm
+      HEAD_TAG=$(git tag --points-at HEAD)
+      if [ -z "$HEAD_TAG" ]
+      then
+            echo "ERROR: head of doc-csm ${DOCS_CSM_BRANCH} is not tagged, please investigate"
+            cd ..
+            rm -rf docs-csm
+            exit 1
+      else
+            echo "head of doc-csm ${DOCS_CSM_BRANCH} is tagged as ${HEAD_TAG}" 
+            cd ..
+            rm -rf docs-csm
+      fi
+else
+      echo "ERROR: Unable to clone ${DOCS_CSM_BRANCH} branch of docs-csm repo, unable to verify head tag"
+      exit 1 
+fi
+
+
+


### PR DESCRIPTION
[CASMMON-190](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-190) - Grafana piechart plugin issues in air-gapped systems
[CASMPET-4897](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-4897) - Grafana is missing the Vonage-status-panel plugin required by the Ceph - Cluster dashboard

Upgrading the pie-chart-panel plugin to the latest by creating a Grafana docker image with the build piechart plugin instead of downloading the piechart plugin while installing the chart. Grafana Upgrade and Dashboard improvements by supporting new visualizations. Setting the new path for plugins to download.

Resolves -
Adds pie chart panel to existing dashboards. Resolves the Grafana Ceph - Cluster dashboard reporting the following error - Panel plugin not found: Vonage-status-panel.

Tested on slice and mug systems. All the charts are working fine and have no issues. The plugins are the latest version and signed.

Screenshots -
image
image
image
image
image