### PR TITLE
CASMMON-190/196 Path change for plugins

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.25.1
+    version: 0.26.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
[CASMMON-190](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-190) - Grafana piechart plugin issues in air-gapped systems
[CASMPET-4897](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-4897) - Grafana is missing the Vonage-status-panel plugin required by the Ceph - Cluster dashboard

Upgrading the pie-chart-panel plugin to the latest by creating a Grafana docker image with the build piechart plugin instead of downloading the piechart plugin while installing the chart. Grafana Upgrade and Dashboard improvements by supporting new visualizations. Setting the new path for plugins to download.

Resolves -
Adds pie chart panel to existing dashboards. Resolves the Grafana Ceph - Cluster dashboard reporting the following error - Panel plugin not found: Vonage-status-panel.

Tested on slice and mug systems. All the charts are working fine and have no issues. The plugins are the latest version and signed.

Screenshots -
image
image
image
image
image