### PR TITLE
CASMPET-6008: add required anti-affinity for cray-kyverno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)
 - Released cray-etcd-backup 0.4.3 to add backupPolicy.timeoutInSecond (CASMTRIAGE-4188)
 - Released cray-nls 1.4.1 to fix postgres database restore issue (CASMPET-5960)
 - Released spire 2.10.1 to fix postgres database restore issue (CASMPET-5961)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -135,7 +135,7 @@ spec:
           profile: dryrun
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.2.0
+    version: 1.3.0
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Make anti-affinity required for cray-kyverno chart to spread its deployment to different nodes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6008](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6008)
* Change will also be needed in `release/1.3`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Indian security team did successful sanity tests on mug.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

