### PR TITLE
CASMPET-6016: Update cray-nexus to use nexus-setup 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-nexus v0.11.1 to update nexus-setup to 0.7.1 (CASMPET-6016)
 - Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)
 - Released platform-utils v1.4.1 to fix issue with etcd_restore_rebuild.sh
 - Released cray-etcd-backup 0.4.3 to add backupPolicy.timeoutInSecond (CASMTRIAGE-4188)

--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.11.0
+    version: 0.11.1
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -81,7 +81,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.38.0-1
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: gatekeeper
     source: csm-algol60
     version: 1.5.2


### PR DESCRIPTION
## Summary and Scope

Updates the version of nexus-setup and the chart version

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6016](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6016)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Almost no risk. The updated image has been used in other installations for a month just not in the cray-nexus chart.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

