### PR TITLE
CASM-2684: Update cfs services for several usability changes/fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cfs-api, cfs-operator, cfs-batcher and cfs-hwsync for fixes to many minor tickets
 - Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)
 - Released platform-utils v1.4.1 to fix issue with etcd_restore_rebuild.sh
 - Released cray-etcd-backup 0.4.3 to add backupPolicy.timeoutInSecond (CASMTRIAGE-4188)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,15 +78,15 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.16.1
+    version: 1.17.0-beta.2
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.11.2
+    version: 1.12.0-beta.1
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.7.34
+    version: 1.8.0-beta.1
     namespace: services
   - name: cfs-trust
     source: csm-algol60
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.8.0
+    version: 1.9.0-beta.1
     namespace: services
   - name: gitea
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the cfs-api, cfs-operator, cfs-batcher and cfs-hwsync-agent to pull in fixes/additions for several tickets in the CFS usability epic. 

## Issues and Related PRs

* Resolves CASMCMS-8243
* Resolves CASMCMS-2121
* Resolves CASMCMS-5919
* Resolves CASMCMS-7114
* Resolves CASMCMS-7278
* Resolves CASMCMS-7457
* Resolves CASMCMS-7548
* Resolves CASMCMS-7639
* Resolves CASMCMS-7714
* Resolves CASMCMS-7719
* Resolves CASMCMS-7803
* Resolves CASMCMS-7802
* Resolves CASMCMS-7850
* Resolves CASMCMS-7886
* Resolves CASMCMS-8195
* Resolves CASMCMS-8208
* Resolves CASMCMS-8211

## Testing

### Tested on:

  * Starlord

### Test description:

All changes were tested installed  and tested.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

