### PR TITLE
CASMTRIAGE-4185 release csm-testing v1.15.14, fix check_for_unused_drives.py failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release csm-testing v1.15.14, fix check_for_unused_drives.py failing (CASMTRIAGE-4185)
 - Updated cfs-api, cfs-operator, cfs-batcher and cfs-hwsync for fixes to many minor tickets
 - Released cray-nexus v0.11.1 to update nexus-setup to 0.7.1 (CASMPET-6016)
 - Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.13-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.27.1-1.x86_64
-    - csm-testing-1.15.13-1.noarch
-    - goss-servers-1.15.13-1.noarch
+    - csm-testing-1.15.14-1.noarch
+    - goss-servers-1.15.14-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.11-1.noarch
     - pit-init-1.2.35-1.noarch


### PR DESCRIPTION
## Summary and Scope

release csm-testing v1.15.14, fix check_for_unused_drives.py failing

## Issues and Related PRs


* Resolves [CASMTRIAGE-4185](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4185)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Tested on redbull
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

