### PR TITLE
CASMINST-5399: Fix cfs-api image annotation

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -82,7 +82,7 @@ spec:
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.12.0-beta.1
+    version: 1.12.0-beta.2
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the cfs-api chart to pull in a chart that has the correct image annotation

## Issues and Related PRs

* Resolves CASMINST-5399

## Testing

The build logs confirm that the correct annotation was generated

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

