### PR TITLE
CASMCMS-8252: Fix cfs-batcher chart to include correct image annotation

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -86,7 +86,7 @@ spec:
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.8.0-beta.1
+    version: 1.8.0-beta.2
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes the cfs-batcher chart so that it's annotation correctly references the beta build image.

## Issues and Related PRs

* Resolves CASMCMS-8252

