### PR TITLE
CASMCMS-8251: Update gitea chart for CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated gitea to 2.5.1 for security fixes
 - Updated cfs-api, cfs-operator, cfs-batcher and cfs-hwsync for fixes to many minor tickets
 - Released cray-nexus v0.11.1 to update nexus-setup to 0.7.1 (CASMPET-6016)
 - Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -98,7 +98,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.5.0
+    version: 2.5.1
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

Updates the gitea chart to pull in the 1.17.2 version of the gitea image to address CVEs

## Issues and Related PRs

* Resolves CASMCMS-8251

## Testing

### Tested on:

  * Starlord

### Test description:

Pushed and pulled from repos with the new image deployed

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

