### PR TITLE
CASMCMS-8251: Updaate gitea chart for CVEs (1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated gitea to 2.5.1 for security fixes
 - Release csm-testing v1.14.59, fix check_for_unused_drives.py failing (CASMTRIAGE-4185)
 - Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)
 - Released platform-utils v1.3.8 to fix issue with etcd_restore_rebuild.sh

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -98,7 +98,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.5.0
+    version: 2.5.1
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

Updates the gitea chart to pull in the 1.17.2 version of the gitea image to address CVEs

## Issues and Related PRs

* Resolves CASMCMS-8251

## Testing

### Tested on:

  * Starlord

### Test description:

Pushed and pulled from repos with the new image deployed

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

