### PR TITLE
CASMTRIAGE-4269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release csm-testing v1.15.15, fixed BSS test for initrd= boot parameter (CASMTRIAGE-4269)
 - Release csm-testing v1.15.14, fix check_for_unused_drives.py failing (CASMTRIAGE-4185)
 - Updated cfs-api, cfs-operator, cfs-batcher and cfs-hwsync for fixes to many minor tickets
 - Released cray-nexus v0.11.1 to update nexus-setup to 0.7.1 (CASMPET-6016)

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.27.1-1.x86_64
-    - csm-testing-1.15.14-1.noarch
+    - csm-testing-1.15.15-1.noarch
     - goss-servers-1.15.14-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.11-1.noarch


### PR DESCRIPTION
## Summary and Scope

The BSS boot parameter test (data-validatory.py) was too strict. Instead of testing for **initrd=initrd.img.xz**, we're now just confirming that the **initrd** boot parameter exists.

## Issues and Related PRs

https://github.com/Cray-HPE/csm-testing/pull/407

## Testing

### Tested on:

* rocket

### Test description:

initrd= did not exist on two nodes and the test flagged it.

## Risks and Mitigations

None known.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

