### PR TITLE
CASMCMS-8239: Lengthen BOS deployment timeout to 10 minutes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -135,6 +135,7 @@ spec:
     source: csm-algol60
     version: 2.0.1
     namespace: services
+    timeout: 10m
   - name: csm-ssh-keys
     source: csm-algol60
     version: 1.4.1


### PR DESCRIPTION
## Summary and Scope

When BOS V2 performs an upgrade, it needs to migrate data from the etcd database to a new redis database. It does this 
migration in a post-upgrade Helm hook. The Helm hook needs to wait for the pod containing the etcd database to start up before it can do its migration work. The etcd pod can take a long time to start up and this causes Helm to time out the deployment. Extending the timeout avoids this failure.



## Issues and Related PRs


* Resolves CASMCMS-8239

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Fanta`

### Test description:

I deployed BOS V2 using a manifest that had the same timeout value of 10 minutes. It was successful. I then rolled BOS back to the earlier deployment.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No.
- Were continuous integration tests run? If not, why? No. They don't exist.
- Was upgrade tested? If not, why? Yes.
- Was downgrade tested? If not, why? Yes.
- Were new tests (or test issues/Jiras) created for this change? Nope.

## Risks and Mitigations

Very low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

