### PR TITLE
Fail on missing charts

### DIFF
--- a/build/images/Makefile
+++ b/build/images/Makefile
@@ -7,18 +7,22 @@ export HELM_CACHE_HOME HELM_CONFIG_HOME
 
 SHELL=/usr/bin/env bash -euo pipefail
 
+# Get the process ID of the process running Make
+MAKEPID:= $(shell echo $$PPID)
+
 all: index.txt chartmap
 
 index.txt: $(manifests_images) docker/index.txt
 	cat $^ | sort -u | parallel -j 75% --retries 5 --halt-on-error soon,fail=100% ./inspect.sh | sort -u > $@
 
+# Kill (SIGINT) the make PGID to short-circuit parallel makes (fail fast)
 manifests/%.txt: ../../manifests/%.yaml
 	@mkdir -p $(@D)
-	./extract.sh $< | sort -u > $@
+	./extract.sh $< | sort -u > $@ || kill -INT -$(MAKEPID)
 
 docker/index.txt: ../../docker/index.yaml
 	@mkdir -p $(@D)
-	../../hack/list-images.py $< | sort -u > $@
+	../../hack/list-images.py $< | sort -u > $@ 
 
 .PHONY: chartmap
 
@@ -30,3 +34,4 @@ chartmap: index.txt
 
 clean:
 	$(RM) index.txt $(manifests_images) docker/index.txt chartmap.csv
+

--- a/build/images/Makefile
+++ b/build/images/Makefile
@@ -22,7 +22,7 @@ manifests/%.txt: ../../manifests/%.yaml
 
 docker/index.txt: ../../docker/index.yaml
 	@mkdir -p $(@D)
-	../../hack/list-images.py $< | sort -u > $@ 
+	../../hack/list-images.py $< | sort -u > $@
 
 .PHONY: chartmap
 

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -116,7 +116,7 @@ extract-repos "$manifest" | while read name url; do
     helm repo update --fail-on-repo-update-fail "$name" >&2
 done
 
-parallel $P_OPT docker pull $YQ_IMAGE
+parallel $P_OPT docker pull $YQ_IMAGE >&2
 
 # extract images from chart
 declare -i idx=0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -291,7 +291,7 @@ spec:
     namespace: services
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.3
+    version: 1.4.2
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -291,7 +291,7 @@ spec:
     namespace: services
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.2
+    version: 1.4.3
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Remove complex sub-shell logic in 'extract.sh', script as a small refactor to ~ fix 'not' failing on missing Helm charts.

Also, add logic to the extract phase of the makefile to short-circuit build failures so builds fail faster on missing charts, etc.  

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5355](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5355)

## Testing

Tested forced non-existent chart reference and happy path test via `make -j 8` for images.

### Tested on:

* Ubuntu VM (Local)



