### PR TITLE
CASMINST-5400 Bump cray-opa to 1.29.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -171,7 +171,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.28.1
+    version: 1.29.0
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

When the opa policies were broken up by use the system-pxe and system-compute policies were not moved over. This creates a new policy group, keycloak-system, that's used on the main ingress.

## Issues and Related PRs


* Resolves [CASMINST-5400](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5400)
* https://github.com/Cray-HPE/cray-opa/pull/63

## Testing

### Tested on:

  * fanta
  * Local development environment

### Test description:

Validated that system-pxe keycloak access worked after applying and that it allowed nodes to continue booting.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
