### PR TITLE
CASMTRIAGE-4288 - IMS - increase timeouts to accommodate larger images.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.6.1
+    version: 3.7.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The ims service is single-threaded, so while it is performing an operation it is not able to respond to liveness/readiness queries. When the image sizes get to 5-13Gb, sometimes the liveness probe will kill the ims container in the middle of an image copy. This increases the timings to allow longer operations until we can get a better solution in place.

Code PR:
https://github.com/Cray-HPE/ims/pull/44

Manifest PR (csm-1.3.0):
https://github.com/Cray-HPE/csm/pull/1397

## Issues and Related PRs
* Resolves [CASMTRIAGE-4288](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4288)
* Resolves [CASMTRIAGE-4268](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4268)
* Resolves [CASMTRIAGE-4091](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4091)

## Testing
### Tested on:
  * `Mug`
  * `Loki`

### Test description:

The settings were changes manually in the deployment on Loki and with these changes can successfully work with 13Gb gpu images. The updated ims-utils image was tested on Mug and shows a large increase in image download performance when setting up an image customize job.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

The only negative impact these helm chart changes will have is it will take k8s longer to recognize when there is a real problem with the pod. This could lead to longer times before k8s automatically restarts pods that have really stopped.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable


