### PR TITLE
CASMTRIAGE-4288: Update cray-sat container image to 3.19.3

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.19.2
+      - 3.19.3
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.19.2"
+sat_version="3.19.3"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
See CHANGELOG.md in sat repo for full description of changes.

## Summary and Scope

Increment the version of SAT included in CSM from 3.19.2 to 3.19.3

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially resolves [CASMTRIAGE-4288](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4288)
* Relates to #1397 and #1398

## Testing


### Tested on:

  * mug

### Test description:

Installed this version of cray-sat container image on mug through installation of SAT product stream version 2.4.13, which includes this same version of the container image.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable