### PR TITLE
CASMTRIAGE-4307: Re-add missing cfs-state-reporter RPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated CSM rpm manifest to include missing cfs-state-reporter RPMs
 - Updated gitea to 2.5.1 for security fixes
 - Release csm-testing v1.15.15, fixed BSS test for initrd= boot parameter (CASMTRIAGE-4269)
 - Release csm-testing v1.15.14, fix check_for_unused_drives.py failing (CASMTRIAGE-4185)

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -27,4 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.63.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
+    - cfs-state-reporter-1.9.0-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - bos-reporter-2.0.0-beta.3.x86_64
+    - cfs-state-reporter-1.9.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -33,3 +33,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
+    - cfs-state-reporter-1.9.0-1.x86_64
+

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -26,4 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
+    - cfs-state-reporter-1.9.0-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -23,7 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
     - cfs-state-reporter-1.9.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,5 +29,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
     - bos-reporter-2.0.0-beta.3.x86_64
-    - cfs-state-reporter-1.9.0-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -30,3 +30,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-roles-1.5.0-1.noarch
     - bos-reporter-2.0.0-beta.3.x86_64
     - cfs-state-reporter-1.9.0-1.x86_64
+

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,4 +29,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
     - bos-reporter-2.0.0-beta.3.x86_64
-    - cfs-state-reporter-1.9.0.x86_64
+    - cfs-state-reporter-1.9.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,4 +29,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
     - bos-reporter-2.0.0-beta.3.x86_64
-
+    - cfs-state-reporter-1.9.0.x86_64


### PR DESCRIPTION
## Summary and Scope

This long standing RPM must have been accidentally stripped from our RPM manifest; it is required to be installed on a number of different downstream managed products. When it is not provided, associated configuration tasks that aim to install it into respective images ends up failing. We do not know by which process they were accidentally removed.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4307](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4307)
* Change will also be needed in other CSM manifest releases where it has been removed (TBD).


