### PR TITLE
CASMPET-6035: add kyverno images to precache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Added kyverno images to Nexus precache (CASMPET-6035)
 - Updated gitea to 2.5.1 for security fixes
 - Release csm-testing v1.14.59, fix check_for_unused_drives.py failing (CASMTRIAGE-4185)
 - Released cray-kyverno 1.3.0 to enable required anti-affinity deployment (CASMPET-6008)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -64,6 +64,9 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.10.6-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1-distroless
+      # Kyverno
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.6.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.6.2
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS


### PR DESCRIPTION
## Summary and Scope

We ran into a case that kyverno failed to pull images from Nexus because Nexus was down; at the meantime, Nexus could not be deleted for a restart because kyverno webhook blocked the Nexus pod deletion to go through.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6035](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6035)
* Change will also be needed in `main`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

