### PR TITLE
casmpet-6033 bump platform-utils to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released platform-utils v1.4.2 to fix issue with fix-spire-on-storage.sh (CASMPET-6033)
 - Updated gitea to 2.5.1 for security fixes
 - Release csm-testing v1.15.15, fixed BSS test for initrd= boot parameter (CASMTRIAGE-4269)
 - Release csm-testing v1.15.14, fix check_for_unused_drives.py failing (CASMTRIAGE-4185)

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -36,6 +36,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - loftsman-1.2.0-1.x86_64
     - manifestgen-1.3.7-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
-    - platform-utils-1.4.1-1.noarch
+    - platform-utils-1.4.2-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This fixes a path issue that prevents spire from being re-joined properly. It also fixes an issue where attempting to delete files that weren't there caused the script to error out.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6033](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6033)
* https://github.com/Cray-HPE/utils/pull/66

## Testing

### Tested on:

  * wasp
  
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
