### PR TITLE
CASMTRIAGE-4311 main: gatekeeper-audit manager container is oom-killed frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated gatekeeper-audit memory limits (CASMTRIAGE-4311)
 - Added kyverno images to Nexus precache (CASMPET-6035)
 - Updated gitea to 2.5.1 for security fixes
 - Release csm-testing v1.15.15, fixed BSS test for initrd= boot parameter (CASMTRIAGE-4269)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -87,7 +87,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: gatekeeper
     source: csm-algol60
-    version: 1.5.2
+    version: 1.5.3
     namespace: gatekeeper-system
     timeout: 20m
     values:


### PR DESCRIPTION
## Summary and Scope

Verified on many systems that the gatekeeper-audit pod (manager container) was being OOM killed frequently.

This is a backward compatible bug fix to increase the memory limit from 512Mi to 1Gi.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [[CASMTRIAGE-4311](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4311)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Verified the pod is no longer restarting and kubectl events no longer reports OOMs for the manager container process.

### Tested on:

Tested in shandy (1.3.0-rc.1) , hermod (1.2.0-rc.2) and tyr (1.3.0-alpha.30)

### Test description:
* No restarts in 23m
```
# kubectl get pods -A | grep gatekeeper-audit
gatekeeper-system   gatekeeper-audit-794c974777-4cd84                                 1/1     Running            0          23m
```
* No new OOM kills in 23m
```
ncn-m001:~ # kubectl get events -A | grep OOM | grep manager
default             50m         Warning   OOMKilling               node/ncn-w003                                                     Memory cgroup out of memory: Killed process 656851 (manager) total-vm:1245884kB, anon-rss:506464kB, file-rss:29040kB, shmem-rss:0kB
default             36m         Warning   OOMKilling               node/ncn-w003                                                     Memory cgroup out of memory: Killed process 1222058 (manager) total-vm:1244284kB, anon-rss:507220kB, file-rss:28656kB, shmem-rss:0kB
default             26m         Warning   OOMKilling               node/ncn-w003                                                     Memory cgroup out of memory: Killed process 1523961 (manager) total-vm:1244860kB, anon-rss:508240kB, file-rss:28464kB, shmem-rss:0kB
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

