### PR TITLE
CASMHMS-5776: Pull in newer cray-hms-hmcollector chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -60,7 +60,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.7
+    version: 2.15.8
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in newer  cray-hms-hmcollector chart. Switched over to use ping from the iputils package instead of from busybox to work around an issue where busybox ping does not have permission when running as non-root user. This was causing River telemetry to not be polled.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5776](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5776)

## Testing

_List the environments in which these changes were tested._

### Tested on:
* Tyr
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No.

For more detailed testing see: https://github.com/Cray-HPE/hms-hmcollector/pull/44

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

