### PR TITLE
CASMTRIAGE-4286: Update keycloak-localize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-keycloak-users-localize v1.11.3 to fix keycloak localize never ending (CASMTRIAGE-4286)
 - Added kyverno images to Nexus precache (CASMPET-6035)
 - Updated gitea to 2.5.1 for security fixes
 - Release csm-testing v1.15.15, fixed BSS test for initrd= boot parameter (CASMTRIAGE-4269)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -250,7 +250,7 @@ spec:
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.2
+    version: 1.11.3
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This is a bugfix that fixes an issue with keycloak localize where it can get into a state of never being able to end and gets stuck in a infinite loop.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-4286](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4286)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low risk fixes bug that was found and should make code work properly

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

