### PR TITLE
CASMCMS-8270: Update bos to fix v2 session status reporting

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.1
+    version: 2.0.2
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys


### PR DESCRIPTION
## Summary and Scope

Fixes BOS v2 session extended status reporting for cases with many component failures.

## Issues and Related PRs

* Resolves CASMCMS-8270

## Testing

### Tested on:

  * Changes were tested locally

### Test description:

Created a test case to mimic the multiple failures seen on Shandy

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

