### PR TITLE
CASMCMS-8272 - fix broken nightly build due to linting error.

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 1.6.0
+      - 1.6.1
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
## Summary and Scope

A linting error from an updated base image pylinter was causing the nightly builds to fail. I made a slight code change that fixes the linting error. There is no practical change to the underlying code, but it needed an updated ims-load-artifacts image to resolve.

The barebones recipe image automatically picks up the new ims-load-artifacts image (with no change to its version), but the manifests need to update to the ims-load-artifacts:1.6.1 version that is getting picked up.

Code PR:
https://github.com/Cray-HPE/ims-load-artifacts/pull/25

## Issues and Related PRs
* Resolves [CASMCMS-8272](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8272)
* Change will also be needed in `release/1.2` and `main`

## Risks and Mitigations

Very low risk - just a change to make the linter happy.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

