### PR TITLE
Remove previous (not used) multus docker image reference (CASMPET-6051)

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -87,7 +87,6 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Multus required by platform
     docker.io/nfvpe/multus:
-      - v3.1
       - v3.7
 
     # XXX Is this missing from cray-sysmgmt-health?


### PR DESCRIPTION
## Summary and Scope

Remove unused multus v3.1 docker image from tarball in CSM 1.3

## Issues and Related PRs

* Resolves [CASMPET-6051](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6051)

## Testing

Will verify the image is no longer in the tarball.

### Tested on:

Not yet

### Test description:

Not yet

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

