### PR TITLE
CASMPET-5966: use cray-postgres-db-backup:0.2.3 image for spire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cray-spire to 2.6.6 to use cray-postgres-db-backup:0.2.3 image (CASMPET-5966)
 - Updated cray-powerdns-manager to 0.6.9 for various record generation fixes (CASMNET-1779)
 - Added all istio images to Nexus precache (CASMPET-5888)
 - Updated cfs-operator to 1.14.18 for CFS fixes around additional inventory

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,5 +179,5 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.6.5
+    version: 2.6.6
     namespace: spire


### PR DESCRIPTION
## Summary and Scope

Use cray-postgres-db-backup:0.2.3 image for spire to fix postgres db restore issue that was caused by incompatible sql version in previous images.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5966](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5966)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Previously verified that postgres restore issue had been resolved by the updated cray-postgres-db-backup:0.2.3 image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

