### PR TITLE
CASMTRAIGE-4338 Bump cray-opa to 1.25.3

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -174,7 +174,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.25.2
+    version: 1.25.3
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Some uan subscription matches were missing preventing uans from booting. This adds the missing policies and sorts the list so that it's easier to parse.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4338](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4338)
* https://github.com/Cray-HPE/cray-opa/pull/68

## Testing

### Tested on:

  * Loki
  * Rocket

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
