### PR TITLE
CASMCMS-8279: Update BOS for increased v2 default timeouts

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.4
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys


### PR DESCRIPTION
## Summary and Scope

Updates BOS to pull in increased default timeout values.  This is due to testing on shandy where many components were taking longer than expected to boot.

## Issues and Related PRs

* Resolves CASMCMS-8279

## Testing

### Tested on:

  * Shandy

### Test description:

These values were tested on Shandy, and several sessions were run with these values.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

