### PR TITLE
CASMCMS-8144 - update dev.cray.com server addresses to allow continued builds.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -117,7 +117,7 @@ spec:
     namespace: services
   - name: cray-crus
     source: csm-algol60
-    version: 1.10.0
+    version: 1.10.1
     namespace: services
   - name: cray-tftp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This was a change that was merged shortly after the release/1.3 branch was created. The below manifest PR was merged to 'main', but we missed the 'release/1.3' manifest PR.

This updates internal server addresses so when the *.dev.cray.com domain is retired, the nightly builds will continue to succeed.

Manifest PR to main:
https://github.com/Cray-HPE/csm/pull/1238

Code PR:
https://github.com/Cray-HPE/cray-crus/pull/32/files

## Issues and Related PRs

* Resolves [CASMCMS-8144](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8144)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed on system and checked out as much as able with condition of the machine.

## Risks and Mitigations

Low risk - only changes to build server addresses.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

