### PR TITLE
CASMHMS-5776: Pull in cray-hms-hmcollector for polling river telemetry fix.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -64,6 +64,9 @@ spec:
   - name: cray-hms-hmcollector
     source: csm-algol60
     version: 2.15.4
+    values:
+      global:
+          appVersion: 2.22.0
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in newer cray-hms-hmcollector container image. Switched over to use ping from the iputils package instead of from busybox to work around an issue where busybox ping does not have permission when running as non-root user. This was causing River telemetry to not be polled.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5776](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5776)


## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Bradi - CSM 1.2 system

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? 
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Tes
- Were new tests (or test issues/Jiras) created for this change? No

Verified the collector-poll pod is polling for river environmental telemetry
```
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s6b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s20b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s11b3/redfish/v1/Chassis/Self/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s5b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s11b2/redfish/v1/Chassis/Self/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s13b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s2b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s11b1/redfish/v1/Chassis/Self/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s7b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s8b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s9b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s11b4/redfish/v1/Chassis/Self/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s3b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s4b0/redfish/v1/Chassis/1/Power
2022/10/11 20:04:26 [DEBUG] GET http://cray-smd/hsm/v2/Inventory/RedfishEndpoints
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s5b0/redfish/v1/Chassis/1/Thermal
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s20b0/redfish/v1/Chassis/1/Thermal
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s13b0/redfish/v1/Chassis/1/Thermal
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s3b0/redfish/v1/Chassis/1/Thermal
2022/10/11 20:04:26 [DEBUG] GET https://x3000c0s7b0/redfish/v1/Chassis/1/Thermal
```

Verified river polled environment telemetry was flowing into the PMDB:
```
pmdb=> pmdb=> distinct(location) from pmdb.river_view where timestamp > now() - interval '30 second';
   location
--------------
 x3000c0s2b0
 x3000c0s11b4
 x3000c0s3b0
 x3000c0s4b0
 x3000c0s8b0
 x3000c0s11b3
 x3000c0s7b0
 x3000c0s9b0
 x3000c0s11b1
 x3000c0s13b0
 x3000c0s11b2
 x3000c0s5b0
 x3000c0s6b0
 x3000c0s20b0
(14 rows)
```


I powered on and off a compute node, and verified the redfish events were sent to the SMA kafka instance and PMDB:
```
pmdb=> select * from pmdb.dmtf_redfish_events order by "EventTimestamp" desc limit 10;
   Context    | Actions | EventGroupId |                EventId                |     EventTimestamp     |    EventType    | MemberId |                                   Message                                    |          MessageArgs           |           MessageId            |                   Oem                    |                     OriginOfCondition                      | Severity
--------------+---------+--------------+---------------------------------------+------------------------+-----------------+----------+------------------------------------------------------------------------------+--------------------------------+--------------------------------+------------------------------------------+------------------------------------------------------------+----------
 x3000c0s11b1 |         |              | /redfish/v1/Systems/Self - 1665518709 | 2022-10-11 20:05:09+00 |                 |          | The power state of resource /redfish/v1/Systems/Self has changed to type Off | {/redfish/v1/Systems/Self,Off} | EventLog.1.0.PowerStatusChange |                                          | {"@odata.id": "/redfish/v1/Systems"}                       | OK
 x3000c0s11b1 |         |              | /redfish/v1/Systems/Self - 1665518200 | 2022-10-11 19:56:40+00 |                 |          | The power state of resource /redfish/v1/Systems/Self has changed to type On  | {/redfish/v1/Systems/Self,On}  | EventLog.1.0.PowerStatusChange |                                          | {"@odata.id": "/redfish/v1/Systems"}                       | OK
 ```

 Verified power on/off events were sent and made it to the shared services kafka:
 ```
 ncn-m001:~ # kubectl exec -it -n services cray-shared-kafka-kafka-0 -- bash
bash-4.4$  cd /opt/kafka/bin
bash-4.4$ ./kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic cray-dmtf-resource-event --from-beginning
{"@odata.context":"/redfish/v1/$metadata#Event.Event","@odata.type":"#Event.v1_4_0.Event","Id":"264","Name":"Event Array","Context":"x3000c0s11b1","Events":[{"EventId":"/redfish/v1/Systems/Self - 1665518200","EventTimestamp":"2022-10-11T19:56:40+00:00","Severity":"OK","Message":"The power state of resource /redfish/v1/Systems/Self has changed to type On","MessageId":"EventLog.1.0.PowerStatusChange","MessageArgs":["/redfish/v1/Systems/Self","On"],"Context":"x3000c0s11b1","OriginOfCondition":{"@odata.id":"/redfish/v1/Systems"}}],"Events@odata.count":1}
{"@odata.context":"/redfish/v1/$metadata#Event.Event","@odata.type":"#Event.v1_4_0.Event","Id":"91","Name":"Event Array","Context":"x3000c0s11b999","Events":[{"EventId":"91","EventTimestamp":"2020-12-04T16:56:40+00:00","Severity":"OK","Message":"Presence Detected - Assert","MessageId":"AmiIpmiOem.1.0.GeneralEventData","Context":"x3000c0s11b999","OriginOfCondition":{"@odata.id":"/redfish/v1/Chassis/Self"}}],"Events@odata.count":1}
```


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

