### PR TITLE
update cray-sysmgmt-health to v0.25.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -206,7 +206,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.21.12
+    version: 0.25.1
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

CASMSTRIAGE-4349: recreated this PR to target stable/1.2 in place of release/1.2
