### PR TITLE
CASMCMS-8284: Update bos to fix v2 staged shutdowns

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.4
+    version: 2.0.5
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys


### PR DESCRIPTION
## Summary and Scope

Updates BOS to fix an issue with staging shutdown operations using BOS v2

## Issues and Related PRs

* Resolves CASMCMS-8284

## Testing

### Tested on:

  * Frigg

### Test description:

Staged a shutdown operation and confirmed the staged data was correct and that there were no errors during setup.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

