### PR TITLE
CASMINST-5509: Backport CASMTRIAGE-3756 - fix import of barebones image

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -156,13 +156,13 @@ spec:
             tag: 1.3.1
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.4.9
+    version: 1.4.11
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.4.9
+            tag: 1.4.11
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
## Summary and Scope

This is a backport of the [1.3 PR](https://github.com/Cray-HPE/csm/pull/1086) for [CASMTRIAGE-3756](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3756), because the fix is needed for 1.2.2 as well.

## Issues and Related PRs

Source PRs:
* https://github.com/Cray-HPE/ims-load-artifacts/pull/28
* https://github.com/Cray-HPE/image-recipes/pull/33

Resolves [CASMINST-5509](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5509).

## Testing

I tested the fix on fanta and it resolved the problem.

## Risks and Mitigations

Low risk, and barebones builds during install will fail without this fix.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
