### PR TITLE
CASMHMS-5791: Pull in newer SLS chart that contains a fix for automatic postgres backups.

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
 Pull in newer SLS chart that contains a fix for automatic postgres backups.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
 backwards compatible bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5791](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5791)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? 
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? N/A

For testing see: https://github.com/Cray-HPE/hms-sls-charts/pull/20

Performed upgrade and downgrade testing between the latest CSM 1.2 version of SLS and the chart from this PR.
Manually triggered an automatic backup of the SLS database, and was able to successfully restore the SLS database from it.  

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

