### PR TITLE
CASMPET-6086 CSM 1.2.2 : BREAK/FIX: Cray-nls needs to pick up the cray base chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Released cray-nls to 1.2.7 to fix postgres database restore issue (CASMPET-5936)
 - Updated cray-oauth2-proxies to 0.2.1 to address security vulnerabilities (CASMPET-6071)
 - Released cray-keycloak to 3.3.2 to fix postgres database restore issue (CASMPET-5936)
 - Updated cray-spire to 2.6.6 to use cray-postgres-db-backup:0.2.3 image (CASMPET-5966)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -280,3 +280,7 @@ spec:
     source: csm-algol60
     version: 0.2.1
     namespace: services
+  - name: cray-nls
+    source: csm-algol60
+    version: 1.2.7
+    namespace: argo


### PR DESCRIPTION
## Summary and Scope

BREAK/FIX: Cray-nls needs to pick up the cray base chart version 8.1.5 to fix postgres restore incompatibility issue in CSM 1.2.2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6086](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6086)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:
```
$ wget https://artifactory.algol60.net/artifactory/csm-helm-charts/stable/cray-nls/cray-nls-1.2.7.tgz
$ tar xvf cray-nls-1.2.7.tgz
$ grep -A 2 cray-ser cray-nls/charts/cray-service/Chart.yaml
name: cray-service
version: 8.1.5
```
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Very low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

