### PR TITLE
CASMHMS-5792: Pull in newer HSM chart that contains a fix for automatic postgres backups

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 2.0.9
+    version: 2.0.10
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Pull in newer HSM chart that contains a fix for automatic postgres backups

## Issues and Related PRs

* Resolves [CASMHMS-5792](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5792)

## Testing

For testing, see: https://github.com/Cray-HPE/hms-smd-charts/pull/30

## Risks and Mitigations

low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

