### PR TITLE
CASMINST-5366 Bump hpe-csm-scripts version to pickup newer verify_hsm_discovery.py script CSM 1.3

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.3.70-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.3.0-1.noarch
+    - hpe-csm-scripts-0.4.0-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This adds a reference to validate_csm_health.md to the output of verify_hsm_discovery.py.

## Issues and Related PRs

* Resolves [CASMINST-5366](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5366)

## Testing

For testing, see https://github.com/Cray-HPE/hpe-csm-scripts/pull/27

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

