### PR TITLE
CASMCMS-8302 - add timeout to allow more time for post-upgrade hooks to complete.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,10 +107,12 @@ spec:
     source: csm-algol60
     version: 1.6.0
     namespace: services
+    timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
     version: 1.7.0
     namespace: services
+    timeout: 20m0s
   - name: cray-console-data
     source: csm-algol60
     version: 1.6.1


### PR DESCRIPTION
## Summary and Scope

This increases the helm timeout value so the console-operator and console-node post-install hooks have more time to complete on large systems where there are a lot of files that need ownership and permissions changes. 

## Issues and Related PRs

* Partly Resolves [CAST-31309](https://jira-pro.its.hpecorp.net:8443/browse/CAST-31309)
* Resolves [CASMCMS-8302](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8302)

## Testing

This is a manifest only change, so it really can't be tested outside of a system upgrade.

## Risks and Mitigations

This should be a low risk change as it only adds an option to the manifest and this option is used in other places successfully for the same purpose. 

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

