### PR TITLE
CASMTRIAGE-4452: Update cfs-operator to remove the high priority on pods

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,7 +78,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.16.1
+    version: 1.16.2
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the cfs-operator image to remove the high priority from cfs session pods

## Issues and Related PRs

* Resolves CASMTRIAGE-4452

## Testing

### Tested on:

  * Shandy

### Test description:

Ran a full system reboot

## Risks and Mitigations

This may impact very small systems like where the original triage ticket to increase the priority was from.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

