### PR TITLE
Include user namespace in wlm secret propagation

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -185,5 +185,5 @@ spec:
   # Tapms service
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.9
+    version: 0.0.10
     namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

In order for tenant specific backups to work using the current wlm backup process, the wlm secret also needs to be propagated to the user namespace (in addition to slurm-operator).

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-4456](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4456)

## Testing

```
1.6669886235564501e+09	INFO	controllers.Tenants	Ensuring secret wlm-s3-credentials exists in user namespace
1.6669886261452048e+09	INFO	controllers.Tenants	Secret wlm-s3-credentials created in user namespace
```

### Tested on:

  * Virtual Shasta

### Test description:

Tested the new operator and saw the secret propagate to user namespace.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
