### PR TITLE
CASMTRIAGE-4452: Update cfs-operator to remove high pod priority

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,7 +78,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0-beta.2
+    version: 1.17.0-beta.3
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates cfs-operator to remove the high pod priority on CFS sessions.

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-4452

## Testing

### Tested on:

  * Shandy

### Test description:

- Ran a full system reboot and configure

## Risks and Mitigations

This will require followup to analyze the memory usage of CFS sessions.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

