### PR TITLE
CASMHMS-5784 Fix broken HSM CLI call in make_node_groups script Main

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - csm-install-workarounds-1.12.1-1.noarch
     - docs-csm-1.4.19-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.4.0-1.noarch
+    - hpe-csm-scripts-0.4.1-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change fixes a broken HSM CLI call in the make_node_groups script.

### Issues and Related PRs

* Resolves [CASMHMS-5784](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5784).

### Testing

This change was tested by running the updated CLI call and verifying that the errors previously encountered no longer occurred.

Before fix:
```
ncn-m001:~ # cray hsm state components list --type node --role management --subrole master --format json | jq
Usage: cray hsm state components list [OPTIONS]
Try 'cray hsm state components list --help' for help.

Error: Invalid value for '--type': invalid choice: node. (choose from CDU, CabinetCDU, CabinetPDU, CabinetPDUOutlet, CabinetPDUPowerConnector, CabinetPDUController, Cabinet, Chassis, ChassisBMC, CMMRectifier, CMMFpga, CEC, ComputeModule, RouterModule, NodeBMC, NodeEnclosure, NodeEnclosurePowerSupply, HSNBoard, Node, Processor, Drive, StorageGroup, NodeNIC, Memory, NodeAccel, NodeAccelRiser, NodeFpga, HSNAsic, RouterFpga, RouterBMC, HSNLink, HSNConnector, INVALID)
```

After fix:
```
ncn-m001:~ # cray hsm state components list --type Node --role management --subrole master --format json | jq
{
  "Components": [
    {
      "ID": "x3000c0s3b0n0",
      "Type": "Node",
      "State": "Ready",
      "Flag": "OK",
      "Enabled": true,
      "Role": "Management",
      "SubRole": "Master",
      "NID": 100007,
      "NetType": "Sling",
      "Arch": "X86",
      "Class": "River",
      "Locked": true
    },
    <snip>
  ]
}
```

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.