### PR TITLE
Add slurm-operator namespace to sonar-jobs-watcher

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.14.3
+    version: 2.14.4
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Include slurm-operator namespace in jobs cleanup.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4501](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4501)

## Testing

(tyr)
```
Checking containers in pod mycluster-slurm-config-t4rqj
Found pod mycluster-slurm-config-t4rqj with restartPolicy 'Never' and container 'istio-proxy' with status '2022-11-02T16:39:46Z'
Found pod mycluster-slurm-config-t4rqj with restartPolicy 'Never' and container 'slurm-config' with status 'Completed'
All containers of job pod mycluster-slurm-config-t4rqj has completed. Killing istio-proxy (0a6d955ea5779a324dfa07042bf5418736a5dfae601379e6beac1b26a33fbcf8) to allow job to complete
0a6d955ea5779a324dfa07042bf5418736a5dfae601379e6beac1b26a33fbcf8
```

```
C02YT3JRLVCJ:cray-drydock bklein$ helm template . | grep -A10 command
        command:
        - "/bin/sonar-jobs-watcher.sh"
        - "services"
        - "nexus"
        - "spire"
        - "vault"
        - "slurm-operator"
```

### Tested on:

  * `tyr`

### Test description:

Manually edited the daemonset, and sonar-jobs-watcher cleaned up the istio-proxy container.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
