### PR TITLE
Ensure hnc webhook is responsive before completing chart deployment

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -302,7 +302,7 @@ spec:
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60
-    version: 0.0.4
+    version: 0.0.5
     namespace: hnc-system
   - name: cray-k8s-encryption
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

In addition to making sure the hnc deployment is rolled out, also ensure the validating webhook is responsive.

## Issues and Related PRs

* Resolves [CASMPET-6098](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6098)

## Testing

```
kubectl logs -n hnc-system wait-for-hnc-manager-pods-8mkkf
sleeping 10 seconds to ensure the deployment rollout has begun...
Waiting for deployment "hnc-controller-manager" rollout to finish: 0 of 1 updated replicas are available...
deployment "hnc-controller-manager" successfully rolled out
sleeping 10 seconds allowing the webhook time to start...
Webhook is now responding...
```

### Tested on:

  * Virtual Shasta

### Test description:

Multiple chart installes

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
