### PR TITLE
CASMNET-1939 - Unbound forward to PowerDNS does not work in an air-gapped configuration.

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -50,11 +50,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.11 # update platform.yaml cray-precache-images with this
+    version: 0.7.12 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.11
+        appVersion: 0.7.12
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -71,7 +71,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.17
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.11
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.12
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

The current cray-dns-unbound air-gapped configuration breaks forwarding of queries to PowerDNS, the result of this is that the new DNS names such as `api.nmnlb.<system_domain>` stop working.

## Issues and Related PRs

* Resolves [CASMNET-1939](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1939)

## Testing

### Tested on:

  * `groot`
  * `mug`

### Test description:

Chart deployed on groot (airgapped) system and DNS functionality verified.

Chart also deployed on mug in airgapped and non-airgapped mode to ensure DNS behaves as expected.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable