### PR TITLE
CASMPET-6092: Pull in newer version of cray-hms-hmcollector chart to …

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -60,7 +60,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.9
+    version: 2.15.10
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
Summary and Scope
Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?

Updated cray-hms-hmcollector chart to pickup a change to enable slingshot health event streaming telemetry.

Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?
Backwards compatible bugfix

Issues and Related PRs
List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies.

Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6092
Testing
List the environments in which these changes were tested.

Tested on:
Shandy
Test description:
How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?

Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
Were continuous integration tests run? If not, why?
Was upgrade tested? If not, why?
Was downgrade tested? If not, why?
Were new tests (or test issues/Jiras) created for this change?
For testing see: https://github.com/Cray-HPE/hms-hmcollector-charts/pull/16

Risks and Mitigations
Are there known issues with these changes? Any other special considerations?
No know issues. Low risk.

Pull Request Checklist
 Version number(s) incremented, if applicable
 Copyrights updated
 License file intact
 Target branch correct
 CHANGELOG.md updated
 Testing is appropriate and complete, if applicable
 [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable