### PR TITLE
CASMPET-5759: Add docker images for cilium

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -151,3 +151,9 @@ artifactory.algol60.net/csm-docker/stable:
     # Argo images
     quay.io/argoproj/argoexec:
       - v3.3.6
+
+    # Cilium images required by platform
+    quay.io/cilium/cilium:
+      - v1.12.2
+    quay.io/cilium/operator-generic:
+      - v1.12.2


### PR DESCRIPTION
## Summary and Scope

This only adds the cilium docker images to prepare for installing cilium during a fresh install or upgrade in the near furture.   The install and upgrade code will still only install weave currently.

## Issues and Related PRs

This is some of the work required for CASMPET-5759.

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Pulled these docker images into nexus with podman on the cilium vshasta v2 cluster.   Successfully installed cilium with these images.

## Risks and Mitigations

None


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

