### PR TITLE
CASMPET-6127: CVE-2020-10770 mitigation change

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -162,7 +162,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.10.6
+    version: 1.10.7
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -162,7 +162,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.10.7
+    version: 1.10.8
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bumping up the version as part of  CVE-2020-10770 mitigation changes

## Testing

Details are in the below PR,
https://github.com/Cray-HPE/cray-opa/pull/71
