### PR TITLE
CASMPET-6126 Switch jwks endpoint back to ingress gateway

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -174,7 +174,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.25.3
+    version: 1.25.4
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

While testing a different issue on frigg I noticed that the spire-jwks endpoint is still internal on CSM 1.3. This is supposed to use the istio ingress gateway due to a caching issue causing port exhaustion. This fixes that problem.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves  [CASMPET-6126](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6126)
* https://github.com/Cray-HPE/cray-opa/pull/70

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * frigg
  * Local development environment

### Test description:

Validated ingress gateway worked and that the endpoint was set to the ingress gateway.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
