### PR TITLE
CASMINST-5441 Use authentication for csm-helm-charts [main]

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -112,7 +112,7 @@ helm env >&2
 # Update helm repos
 extract-repos "$manifest" | while read name url; do
     echo >&2 "+ helm repo add $name $url"
-    helm repo add --force-update "$name" "$url" >&2
+    helm repo add --force-update "$name" "$url" ${ARTIFACTORY_USER+--username ${ARTIFACTORY_USER}} ${ARTIFACTORY_TOKEN+--password ${ARTIFACTORY_TOKEN}} >&2
     helm repo update --fail-on-repo-update-fail "$name" >&2
 done
 


### PR DESCRIPTION
## Summary and Scope

We're going to enable authentication on `csm-helm-charts`. In preparation to this, we'll start configuring credentials for this repo in csm build.

## Issues and Related PRs

* Required by  [CASMINST-5441](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5441)

## Testing
### Tested on:

  * Local development environment
  * Jenkins

### Test description:

* Tested image list generator locally by switching to dev artifactory instance, which does require authentication
* Tested image list generator locally by connecting to main artifactory instance - it does not require authentication yet, but if credentials are provided, they must be correct. Tested all 3 scenarios (no creds, incorrect creds, correct creds).
* Jenkins build produces list of images successfully.

## Risks and Mitigations

Low - easy to rollback.