### PR TITLE
CASMCLOUD-1214 & CASMINST-5473

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64
-    - manifestgen-1.3.7-1.x86_64
+    - manifestgen-1.3.8-1.x86_64
     - metal-net-scripts-0.0.2-1.noarch
     - platform-utils-1.4.3-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,16 +26,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.63.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - docs-csm-1.4.25-1.noarch
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
-    - hpe-csm-scripts-0.4.1-1.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
-    - ilorest-3.5.1-1.x86_64
     - loftsman-1.2.0-1.x86_64
-    - manifestgen-1.3.8-1.x86_64
-    - metal-net-scripts-0.0.2-1.noarch
     - platform-utils-1.4.3-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,13 +23,19 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
+    - bos-reporter-2.0.0-beta.3.x86_64
     - canu-1.6.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.27.6-1.x86_64
+    - craycli-0.63.0-1.x86_64
     - csm-testing-1.15.21-1.noarch
+    - docs-csm-1.4.25-1.noarch
     - goss-servers-1.15.21-1.noarch
+    - hpe-csm-scripts-0.4.1-1.noarch
+    - ilorest-3.5.1-1.x86_64
+    - manifestgen-1.3.8-1.x86_64
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.11-1.noarch
+    - metal-net-scripts-0.0.2-1.noarch
     - pit-init-1.2.36-1.noarch
     - pit-nexus-1.2.0-1.x86_64
-    - bos-reporter-2.0.0-beta.3.x86_64


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMCLOUD-1214](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1214) & [CASMINST-5473](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5473)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Built against Python3.10 to keep the code current, and built with updated dependencies.

- https://github.com/Cray-HPE/manifestgen/pull/17
- https://github.com/Cray-HPE/manifestgen/pull/18
- https://github.com/Cray-HPE/manifestgen/pull/19
- https://github.com/Cray-HPE/manifestgen/pull/20
- https://github.com/Cray-HPE/manifestgen/pull/22


***NOTE*** This also changes to pull `manifestgen` (and a collection of other packages) from the SP3 repo. I'm doing this in preperation for the SP4 RPMs so I can cleanly show them changing from SP3 to SP4. This also satisfies
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)


`manifestgen` successfully produces a `manifest.yaml` file, and all unit tests pass.

```bash
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen --version
manifestgen 1.3.8
redbull-ncn-m001-pit:/var/www/ephemeral/prep # rpm ^C
redbull-ncn-m001-pit:/var/www/ephemeral/prep # cd ^C
redbull-ncn-m001-pit:/var/www/ephemeral/prep # rm manifest.yaml
(reverse-i-search)`manife': rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/manifestgen/x86_64/^Cnifestgen-1.3.8-1.x86_64.rpm
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen -c site-init/customizations.yaml -i /tmp/platform.yaml -o manifest.yaml
redbull-ncn-m001-pit:/var/www/ephemeral/prep # head !$
head manifest.yaml
apiVersion: manifests/v1beta1
metadata:
  name: platform
spec:
  charts:
  - name: cray-metrics-server
    namespace: kube-system
    source: csm-algol60
    version: 0.4.0
  - name: cray-drydock
```

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
