### PR TITLE
CASMPET-6151 Update vault and vault-operator

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -182,11 +182,11 @@ spec:
     namespace: operators
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.1.1
+    version: 1.2.0
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.3.2
+    version: 1.4.0
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60


### PR DESCRIPTION

## Summary and Scope

- Update vault to 1.12.1
- Update vault-operator to 1.16.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6151 ](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6151)
* https://github.com/Cray-HPE/cray-vault/pull/10

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Adeed test data into vault. Validated that data was accessible after both upgrading and downgrading vault and the vault-operator

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

When vault is downgraded the `--pre-flight-checks` needs to be manually removed from command line options in the cray-vault-configurer deployment. If this isn't removed then the pod will crash due to this not being a valid option in bank-vaults 1.8.0.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
