### PR TITLE
CASMPET-6145:  Bump cray-site-init to 1.28.0

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - bos-reporter-2.0.0-beta.3.x86_64
     - canu-1.6.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
-    - cray-site-init-1.27.6-1.x86_64
+    - cray-site-init-1.28.0-1.x86_64
     - craycli-0.63.0-1.x86_64
     - csm-testing-1.15.22-1.noarch
     - docs-csm-1.4.25-1.noarch


### PR DESCRIPTION
## Summary and Scope

Add cilium-operator-replicas, k8s-primary-cni, and kube-proxy-replacement to CSI.