### PR TITLE
CASMHMS-5596: Update scsd to support setting TPM in BIOS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -64,7 +64,7 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.1.4
+    version: 2.1.5
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Adds the capability in SCSD to enable or disable TPM in the BIOS for castle servers.

## Issues and Related PRs

* Resolves [CASMHMS-5596](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5596)
* SCSD [PR](https://github.com/Cray-HPE/hms-scsd/pull/53)

## Testing

### Tested on:

  * odin

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

Low risk. It enables a previously unused API on SCSD for castle servers.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

