### PR TITLE
MTL-2036 & CASMPET-6124: NCN assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Built pre-install-toolkit, kubernetes, storage-ceph without changes
 - Release platform-utils v1.4.3 to edit output from ncnHealthChecks.sh (CASMTRIAGE-4539)
 - Released cray-nls v1.4.8 to add configmap for iuf-install-workflow-files (CASMINST-5530)
 - Released cray-keycloak-users-localize v1.11.3 to fix keycloak localize never ending (CASMTRIAGE-4286)

--- a/assets.sh
+++ b/assets.sh
@@ -29,15 +29,15 @@ PIT_ASSETS=(
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.28/kubernetes-0.4.28.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.28/5.3.18-150300.59.87-default-0.4.28.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.28/initrd.img-0.4.28.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.29/kubernetes-0.4.29.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.29/5.3.18-150300.59.87-default-0.4.29.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.29/initrd.img-0.4.29.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.28/storage-ceph-0.4.28.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.28/5.3.18-150300.59.87-default-0.4.28.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.28/initrd.img-0.4.28.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.29/storage-ceph-0.4.29.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.29/5.3.18-150300.59.87-default-0.4.29.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.29/initrd.img-0.4.29.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc


### PR DESCRIPTION
## Summary and Scope

We were missing changes from recent PR's because the node-images pipeline wasn't building / promoting images correctly. That will be resolved in an upcoming PR to node-images. The images in 0.4.29 were built from HEAD of main without any changes, we just needed to built all of pre-install-toolkit, kubernetes, storage-ceph.

## Issues and Related PRs
Related to: https://jira-pro.its.hpecorp.net:8443/browse/MTL-2036

## Testing


### Tested on:

  * redbull
  
### Test description:

Images were booted on redbull. Jeanne O. and Brad K. too a look to confirm that their desired changes were in place.

## Risks and Mitigations
No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

