### PR TITLE
CASMINST-5623 Downgrade vault to 1.10.8

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -186,7 +186,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.4.0
+    version: 1.4.1
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

vault 1.12.1 does not work on fresh installs with the latest bank-vaults. We'll need to use 1.10.8 instead. This version is still supported by hashicorp.

## Issues and Related PRs


* Resolves [CASMINST-5623](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5623)
* https://github.com/Cray-HPE/cray-vault/pull/11

## Testing

### Tested on:

  * drax
  * 
### Test description:

Validated vault came up properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? n, already done in previous testing
- Was downgrade tested? If not, why? n, already done in previous testing
- Were new tests (or test issues/Jiras) created for this change? n
## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
