### PR TITLE
CASMHMS-5840 Update FAS actions test to improve handling of unexpected BMC states Main

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -48,7 +48,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.1.5
+    version: 2.1.6
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

This change updates the FAS actions test to better handle unexpected BMC states. Previously the test would fail if there was at least one BMC in HSM with an unexpected state. This case is covered by a separate HSM test, so now the FAS actions test will not fail in this scenario and only requires the minimum of one healthy BMC to run.

This change also updates the FAS CT tests to use the latest hms-test:4.0.0 image and RIE.

### Issues and Related PRs

* Resolves CASMHMS-5840.
* Chart PR: https://github.com/Cray-HPE/hms-firmware-action-charts/pull/18

### Testing

This change was tested by verifying that the FAS tests continue to pass in the runCT build environment using RIE emulated hardware. It was also tested on Frigg by upgrading FAS to the new 2.1.6 version of the chart, running the FAS CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, makes FAS actions test more resilient. The other changes only impact FAS testing in the CT build pipeline.