### PR TITLE
CASMHMS-5824: Pull in newer cary-hms-hmcollector chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -60,7 +60,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.10
+    version: 2.15.11
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in v2.23.0 version of the collector. Added a message key to kafka messages to ensure events are sent to the same Kafka partition. The message key is the BMC Xname concatenated with the Redfish Event Message ID. For example x3000c0s11b4.EventLog.1.0.PowerStatusChange. This is needed for the the telemetry-metics-filter to work properly.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5824

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Bradi
  * Mug

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? N/A 
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk, needed for the telemetry-metrics-filter to properly work.

For testing see: https://github.com/Cray-HPE/hms-hmcollector/pull/45

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

