### PR TITLE
CASMINST-5650 Bump spire to 2.11.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,7 +179,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.10.1
+    version: 2.11.0
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This adds error checking to the request-ncn-join-token pods. The pods will now error out if it fails 6 times (30 seconds). This should allow them to restart if the istio-proxy sidecar isn't working.

## Issues and Related PRs

* Resolves [CASMINST-5650](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5650) 
* https://github.com/Cray-HPE/cray-spire/pull/51

## Testing

### Tested on:

  * mug
  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y 
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
