### PR TITLE
CASMSEC-368: Promote cray-opa 1.10.9 to restrict accessible keycloak …

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -162,7 +162,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.10.8
+    version: 1.10.9
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Promote cray-opa 1.10.9 feature to restrict accessible keycloak paths via OPA policy. 

See https://github.com/Cray-HPE/cray-opa/pull/76 for typical PR details.  


