### PR TITLE
CASMINST-5677: Generate Goss log file suitable for consumption by grok-exporter

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.29.0-1.x86_64
     - craycli-0.65.0-1.x86_64
-    - csm-testing-1.15.22-1.noarch
+    - csm-testing-1.15.23-1.noarch
     - docs-csm-1.4.33-1.noarch
-    - goss-servers-1.15.22-1.noarch
+    - goss-servers-1.15.23-1.noarch
     - hpe-csm-scripts-0.4.1-1.noarch
     - ilorest-3.5.1-1.x86_64
     - manifestgen-1.3.8-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Modifies the `print_goss_json_results.py` tool so that in addition to what it normally does, it also generates a log file suitable for consumption by grok-exporter. 

## Issues and Related PRs

* See [the source PR](https://github.com/Cray-HPE/csm-testing/pull/420) for more details
* Resolves [CASMINST-5677](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5677)
* This is to enable part of IUATCT [CASM-3373](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3373). 
* [csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/666)

## Testing

Tested on frigg to ensure that the new log file is correctly generated, and the existing functionality continues to work as before.

## Risks and Mitigations

Minor risk, because the changes were very limited in scope.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
