### PR TITLE
CASMCMS-8300

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -135,7 +135,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.7
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.7-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.7-1.x86_64
     - canu-1.6.27-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.29.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -26,4 +26,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
-
+    - bos-reporter-2.0.7-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,5 +29,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.2.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.7-1.x86_64
 


### PR DESCRIPTION
## Summary and Scope

This is a change to both BOSv1/BOA and BOSv2 that allows sessiontemplates to omit rootfs_provider and rootfs_passthrough fields. This change also updates the associated build RPMs to those corresponding to this particular build.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8300](https://github.com/Cray-HPE/csm/pull/new/CASMCMS-8300)]
* Change will also be needed in `Release 1.3.1` of CSM manifest

### Tested on:
  * Local development environment
  * `Mug`

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
