### PR TITLE
CASMCMS-8300 Backport to 1.3.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -135,7 +135,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.6
+    version: 2.0.7
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.0-beta.7.x86_64
+    - bos-reporter-2.0.7-1.x86_64 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,5 +32,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-    - bos-reporter-2.0.0-beta.7.x86_64
+    - bos-reporter-2.0.7-1.x86_64 
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.0.0-beta.7.x86_64
+    - bos-reporter-2.0.7-1.x86_64 
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,5 +28,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.0-beta.7.x86_64
+    - bos-reporter-2.0.7-1.x86_64 
 


### PR DESCRIPTION
## Summary and Scope

This mod allows BOSv1 and BOSv2 sessiontemplates to skip special appending of information to boot parameters when rootfs_provider and rootfs_provider_passthrough are omitted. This allows Mercury the ability to specify their own root=<values> in the parameters itself without getting in the way of COS specific changes to these fields.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8300](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8300)

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

The affected code was imported into an interactive interpreter and evaluated for appropriate resolution of null string fields.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

