### PR TITLE
MTL-1708 SP4 Package updates

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -23,21 +23,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 PIT_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.2/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.2-20221202202441.iso
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.2/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.2-20221202202441.packages
-    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.0.2/cray-pre-install-toolkit-sle15sp3.x86_64-2.0.2-20221202202441.verified
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.1.0/cray-pre-install-toolkit-sle15sp4.x86_64-2.1.0-20221209212153.iso
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.1.0/cray-pre-install-toolkit-sle15sp4.x86_64-2.1.0-20221209212153.packages
+    https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/2.1.0/cray-pre-install-toolkit-sle15sp4.x86_64-2.1.0-20221209212153.verified
 )
 
 KUBERNETES_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.32/kubernetes-0.4.32.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.32/5.3.18-150300.59.87-default-0.4.32.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.32/initrd.img-0.4.32.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.33/kubernetes-0.4.33.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.33/5.14.21-150400.24.33-default-0.4.33.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/0.4.33/initrd.img-0.4.33.xz
 )
 
 STORAGE_CEPH_ASSETS=(
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.32/storage-ceph-0.4.32.squashfs
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.32/5.3.18-150300.59.87-default-0.4.32.kernel
-    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.32/initrd.img-0.4.32.xz
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.33/storage-ceph-0.4.33.squashfs
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.33/5.14.21-150400.24.33-default-0.4.33.kernel
+    https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/0.4.33/initrd.img-0.4.33.xz
 )
 
 HPE_SIGNING_KEY=https://arti.hpc.amslabs.hpecorp.net/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,19 +23,5 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.7-1.x86_64
-    - canu-1.6.27-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
-    - cray-site-init-1.29.0-1.x86_64
-    - craycli-0.65.0-1.x86_64
-    - csm-testing-1.15.23-1.noarch
-    - docs-csm-1.4.33-1.noarch
-    - goss-servers-1.15.23-1.noarch
-    - hpe-csm-scripts-0.4.1-1.noarch
     - ilorest-3.5.1-1.x86_64
-    - manifestgen-1.3.8-1.x86_64
-    - metal-basecamp-1.2.3-1.x86_64
-    - metal-ipxe-2.2.12-1.noarch
-    - metal-net-scripts-0.0.2-1.noarch
-    - pit-init-1.2.36-1.noarch
-    - pit-nexus-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,11 +23,23 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
+    - bos-reporter-2.0.7-1.x86_64
+    - canu-1.6.29-1.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
+    - cfs-debugger-1.2.0-1.x86_64
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - cfs-debugger-1.2.0-1.x86_64
+    - cray-site-init-1.29.1-1.x86_64
+    - craycli-0.65.0-1.x86_64
+    - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.7-1.x86_64
-
+    - csm-testing-1.15.23-1.noarch
+    - docs-csm-1.4.34-1.noarch
+    - goss-servers-1.15.23-1.noarch
+    - hpe-csm-scripts-0.4.2-1.noarch
+    - manifestgen-1.3.9-1.x86_64
+    - metal-basecamp-1.2.4-1.x86_64
+    - metal-ipxe-2.2.13-1.noarch
+    - pit-init-1.2.37-1.noarch
+    - pit-nexus-1.2.1-1.x86_64


### PR DESCRIPTION
Includes new SP4 LiveCD and SP4 NCN images, as well as several Cray packages that now include SP4 metadata.

Notable updates:
- CASMPET-6084 `cephadm` and `ceph-common` version 17.2.3
- `kernel-*` from `5.3.18-150300.59.87.1` to `5.14.21-150400.24.33.2`
- `kernel-firmware` replaced with `kernel-firmware-all`
- `libfmt7` upgraded to `libfmt8`
- `python39` replaced with `python310`, `3.10` is the newest available in SP4 and `3.9` is no longer available; Python3.6 is still the default Python (defined upstream, by SUSE)
- MTL-1810 a `kernel-mft-mlnx-kmp-default` RPM built against the 5.14.21 kernel is now available (and included in the image), enabling usage of `mst` (provided by `mft`) for managing Mellanox hardware
- MTL-2025 Inclusion of `csm-node-identity` in the tarball for COS compute builds; deprecation of `cray-node-identity`
- Go1.19 update (from 1.18) for `csi` and `basecamp`

***NOTE*** This has to merge with https://github.com/Cray-HPE/docs-csm/pull/2921

***NOTE*** If you're viewing this as a draft, that means we're waiting on smoke-testing to finish from @rustydb .
