### PR TITLE
CASMHMS-5468 CAPMC/CAPMC-lite tests for HMTH

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -44,7 +44,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 3.0.6
+    version: 3.0.7
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

This PR consists of the following changes:

- Update CAPMC CT tests to use latest hms-test:4.0.0 image
- Break out CAPMC CT tests into non-disruptive, disruptive, destructive, and build-pipeline-only test buckets
- Adds many new API tests that execute in the runCT environment in the build pipeline (also able to run on live systems but need to be careful doing this for the disruptive and destructive tests)

### Issues and Related PRs

* Resolves [CASMHMS-5468](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5468).

### Testing

- Tests run in the runCT build pipeline environment in GitHub Actions for each branch push and PR.
- Also deployed and ran the non-disruptive tests on Mug and Surtur to verify that they behave as expected.

### Risks and Mitigations

Adding many new API tests that will gate CAPMC changes if breakages occur.