### PR TITLE
CASMCMS-8333: Update CFS to collapse layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cfs-operator to collapse all session layers and collect logs with ARA
 - Release cray-nls 1.4.25 to update image used in iufBase.template.yaml (CASMINST-5621)
 - Built pre-install-toolkit, kubernetes, storage-ceph without changes
 - Release platform-utils v1.4.3 to edit output from ncnHealthChecks.sh (CASMTRIAGE-4539)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,7 +78,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0-beta.4
+    version: 1.17.0-beta.5
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -73,6 +73,7 @@ spec:
       - sma-kibana.cmn.{{network.dns.external}}
       - csms.cmn.{{ network.dns.external }}
       - argo.cmn.{{ network.dns.external }}
+      - ara.cmn.{{ network.dns.external }}
     customerAccess:
       - capsules.can.{{ network.dns.external }}
     customerHighSpeed:


### PR DESCRIPTION
## Summary and Scope

Updates CFS so the only one ansible container is used regardless of the number of layers
Also includes changes needed for ARA log collection

## Issues and Related PRs

* Resolves CASMCMS-8333
* Partially resolves CASMCMS-7690

## Testing

### Tested on:

  * Mug

### Test description:

See the individual ticket PRs for test descriptions

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

