### PR TITLE
CASMCMS-8333: Update CFS to collapse session layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Updated cfs-operator to collapse session layers
 - Released cray-keycloak-users-localize v1.11.3 to fix keycloak localize never ending (CASMTRIAGE-4286)
 - Updated gatekeeper-audit memory limits (CASMTRIAGE-4311)
 - Released platform-utils v1.3.9 to fix issue with fix-spire-on-storage.sh

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,7 +78,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.16.2
+    version: 1.16.3
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates CFS so the only one ansible container is used regardless of the number of layers

## Issues and Related PRs

* Resolves CASMCMS-8333

## Testing

### Tested on:

  * Mug

### Test description:

See the individual ticket PRs for test descriptions

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

