### PR TITLE
CASMNET-1971 - Upgrade PowerDNS to a supported release

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -59,7 +59,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.2.5 # update platform.yaml cray-precache-images with this
+    version: 0.2.7 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.18
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.13
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.7
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15


### PR DESCRIPTION
## Summary and Scope

* Upgrade PowerDNS to 4.6.4 as version 4.4.3 is EOL as of October and no longer receives security fixes.
* Create Prometheus ServiceMonitor definition to allow collection of PowerDNS metrics

## Issues and Related PRs

* Resolves [CASMNET-1971](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1971)
* Resolves [CASMNET-1965](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1965)

## Testing

### Tested on:

  * `surtur`
  * `mug`

### Test description:

Installed build on surtur, the flood of update messages `PowerDNS Security Update Mandatory: Unsupported release (EOL)` is no longer present.

Verified that the ServiceMonitor has been created.
```bash
ncn-m001:~/cspiller # kubectl get servicemonitor -n sysmgmt-health cray-dns-powerdns-exporter
NAME                         AGE
cray-dns-powerdns-exporter   89s
```
Verified metrics are flowing into Prometheus
```bash
ncn-m001:~/cspiller # curl -s http://10.28.9.131:9090/api/v1/query?query=pdns_auth_backend_queries | jq
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "pdns_auth_backend_queries",
          "endpoint": "dns-api",
          "instance": "10.44.0.37:8081",
          "job": "cray-dns-powerdns-api",
          "namespace": "services",
          "pod": "cray-dns-powerdns-7fbb97c95d-7mh24",
          "service": "cray-dns-powerdns-api"
        },
        "value": [
          1670407810.483,
          "718"
        ]
      }
    ]
  }
}
```

## Risks and Mitigations

PowerDNS 4.6.4 is the highest version we can jump to without requiring a database schema migration when we upgrade.

This version is fully supported until October 2023.

[CASMNET-1068](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1068) will introduce a more flexible approach for schema migration allowing the upgrade to PowerDNS 4.7.x to proceed.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


