### PR TITLE
CASMINST-5661: manifest version bumps for iuf and cray-nls

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -58,7 +58,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.1.0
 
     iuf:
-    - v0.0.5
+    - v0.0.6
 
     # Rebuilt third-party images below
 

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -295,7 +295,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.32
+    version: 1.4.36
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

manifest version bumps for iuf and cray-nls