### PR TITLE
CASMINST-5664 Prometheus error with web hook for node exporter fix

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.1
+    version: 0.26.4
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope
Adding hook-delete-policy to delete the failed patch-nodeexporter-alerts job if it failed during installation.
This change is backward-compatible bugfix.

Resolves [issue id](issue link)
https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5664
https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5589

### Tested on:
  * `slice`
  * Local development environment

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Target branch correct