### PR TITLE
CASM-3718: Update ims-load-artifacts Docker image version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release cray-ims-load-artifacts 2.0.1 to update image used in IUF deliver-product stage (CASM-3718)
 - Updated cfs-operator to collapse all session layers and collect logs with ARA
 - Release cray-nls 1.4.25 to update image used in iufBase.template.yaml (CASMINST-5621)
 - Built pre-install-toolkit, kubernetes, storage-ceph without changes

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 1.6.1
+      - 2.0.1
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
## Summary and Scope

Update the ims-load-artifacts Docker image version to pull in the IUF implementation.

## Issues and Related PRs

* Resolves [CASM-3718](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3718)

## Testing

### Tested on:

  * `frigg`

### Test description:

Tested 2.0.0 version of ims-load-artifacts as part of IUF integration testing.

## Risks and Mitigations

N/A


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

