### PR TITLE
CASMHMS-5689 Fix for unset variable in set_ssh_keys.py

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - platform-utils-1.2.10-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64
-    - hpe-csm-scripts-0.2.0-1.noarch
+    - hpe-csm-scripts-0.2.1-1.noarch
     - loftsman-1.2.0-1.x86_64
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch


### PR DESCRIPTION
## Summary and Scope

The set_ssh_keys.py script has a bug in it where it does not properly set a variable and ends up skipping all BMCs other than switch controllers when setting ssh keys. This change reworks an if statement to properly set the variable in all cases.

## Issues and Related PRs

* Resolves [CASMHMS-5689](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5689)

## Testing

### Tested on:

  * `hela`

### Test description:

Code changes were done on hela to fix the problem. The script was then copied to the source.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - N/A
- Was upgrade tested? If not, why? N - Installed via RPM
- Was downgrade tested? If not, why? N - Installed via RPM
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

