### PR TITLE
CASM-2374 - add option to IMS to enable secure DKMS usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated console services to handle Hill nodes.
 - Updated barebones image to use slessp4.
 - Added configurable timeout to IMS service to allow handling large images.
+- Added an option to enable DKMS to IMS service.
 
 
 ## [0.9.0] - 2021-03-17

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.7.1
+    version: 3.8.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Added a feature flag for the user to enable secure DKMS usage inside IMS create and customize jobs. The feature requires that Kata is installed and configured on the worker nodes of the system.

## Issues and Related PRs
* Resolves [CASM-2374](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2374)

## Testing
### Tested on:
  * `Mug`

### Test description:

The version was installed via helm upgrade, then the DKMS flag was enabled, and jobs run to insure that dkms is working correctly and as expected in the jobs that were created. Next the flag was disabled, and I verified that the enhanced security needed to run dkms was no longer allowed in the new jobs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not covered
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a fairly large change, but pretty well tested to verify no new security vulnerabilities are added, and the current functioning of IMS is not impacted.

Other teams still need to verify that this works as they expect so there may be additional tweaking needed that we don't currently know about, but getting it installed as part of the normal csm package will help with that testing.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

