### PR TITLE
cray cli 0.66.0

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.65.0-1.x86_64
+    - craycli-0.66.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
-    - craycli-0.65.0-1.x86_64
+    - craycli-0.66.0-1.x86_64
     - csm-testing-1.15.24-1.noarch
     - goss-servers-1.15.24-1.noarch


### PR DESCRIPTION
## Summary and Scope

Removed the SLS option to get credentials in the cray cli. This removes the options to pass public and private keys to sls dumpstate and loadstate.

## Issues and Related PRs

* Resolves [CASMHMS-5771](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5771)

## Testing

### Tested on:

  * mug

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

Low risk. It removes an option that only recently started working the cray cli. Also, it is an option that we don't think customers ever used.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

