### PR TITLE
CASMPET-6152:  Update cilium docker images

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -157,6 +157,14 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Cilium images required by platform
     quay.io/cilium/cilium:
-      - v1.12.2
+      - v1.12.4
     quay.io/cilium/operator-generic:
-      - v1.12.2
+      - v1.12.4
+    
+    # Cilium images needed for connectivity testing
+    quay.io/cilium/alpine-curl:
+      - v1.6.0
+    quay.io/cilium/json-mock:
+      - v1.3.3
+    docker.io/coredns/coredns:
+      - 1.10.0


### PR DESCRIPTION
## Summary and Scope

Update these two images in nexus:
quay.io/cilium/cilium:1.12.4
quay.io/cilium/operator-generic:1.12.4

Add these three images to nexus to be able to run the cilium connectivity tests
quay.io/cilium/alpine-curl:v1.6.0
quay.io/cilium/json-mock:v1.3.3
docker.io/coredns/coredns:1.10.0

## Issues and Related PRs

* Resolves [[CASMPET-6152](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6152)]
* Merge with/before/after https://github.com/Cray-HPE/node-images/pull/591

## Testing

### Tested on:

  * Virtual Shasta - cilium cluster

### Test description:

Deployed cilium with multus.  Deployed a subset of platform charts.  Verified that pods got an IP and could reach each other.   Ran connectivity tests.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

