### PR TITLE
CASMTRIAGE-4750 - fix barebones image recipe for sp4 repos.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,13 +153,13 @@ spec:
             tag: 1.3.1
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.7.0
+            tag: 1.7.1
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
## Summary and Scope

There was a difference in naming between the early systems with hand-loaded sp4 repos and the final csm install so the names need to be updated in the recipes.

Code PR:
https://github.com/Cray-HPE/image-recipes/pull/37

## Issues and Related PRs
* Resolves [CASMTRIAGE-4750](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4750)

## Testing
### Tested on:
  * `Frigg`

### Test description:

The recipe was updated and worked correctly. This is not a service so there really isn't any upgrade/downgrade to test - it is just a new recipe install.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - easy to modify by hand as a workaround on installed systems if needed.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

