### PR TITLE
Remove cray-etcd-base chart (shouldn't be in manifest anyway)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -176,9 +176,6 @@ spec:
   - name: cray-etcd-operator
     source: csm-algol60
     version: 0.18.1
-  - name: cray-etcd-base
-    source: csm-algol60
-    version: 1.0.0
     namespace: operators
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Added a base chart incorrectly, and without namespace so it broke the install.  Removing altogether as the chart will be picked up by other service charts.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-4755](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4755)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low -- already broken

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

