### PR TITLE
Update OPA Chart to 1.25.7 with keycloak restrictions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -171,7 +171,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.25.6
+    version: 1.25.7
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update OPA Chart to 1.25.7 with keycloak restrictions

See for details: https://github.com/Cray-HPE/cray-opa/pull/77