### PR TITLE
CASMCMS-8347 - update istio api version for k8s 1.22 deprecation.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.8.0
+    version: 3.8.2
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update the k8s api interface used for the istio service. This will bring us up to date with the most recent version and keep us from having depreciation problems as k8s is upgraded.

## Issues and Related PRs
* Resolves [CASMCMS-8347](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8347)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I upgraded the image being used on surtur and verified that jobs started correctly and the istio connections are created successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as it upgrades the interface version but there are no differences in this particular use case.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
