### PR TITLE
CASMHMS-5858 HSM chart to v4.0.1 for HMTH changes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,12 +16,9 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 4.0.0
+    version: 4.0.1
     namespace: services
     values:
-      global:
-        appVersion: 1.58.1
-        testVersion: 1.58.1
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
### Summary and Scope

This change updates the HSM CT tests to use the latest hms-test:4.0.0 image and RIE for HMTH.

### Issues and Related PRs

* Resolves CASMHMS-5858.

### Testing

This change was tested by deploying the updated HSM Helm chart on Mug, running the CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, pulls in new testing infrastructure for HMTH.