### PR TITLE
CASMTRIAGE-4770: Prometheus alerts expression fix for POD CPU usage

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.4
+    version: 0.26.5
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
Prometheus alerts expression fix for POD CPU usage.

## Issues and Related PRs -
Resolves [CASMTRIAGE-4770](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4770)

### Tested on:
  * `mug`

### Test description:
Changes tested and successfully verified.
![image](https://user-images.githubusercontent.com/110656037/210975098-f6674cc7-0ad8-4898-9f3d-ae54dffbc8e6.png)
![image](https://user-images.githubusercontent.com/110656037/211043271-81e5f0c8-6862-4e96-bf1b-bcabf38240bb.png)

## Pull Request Checklist
- [x] Version number(s) incremented, if applicable
- [x] Testing is appropriate and complete, if applicable