### PR TITLE
Casmcms 8353

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,62 +72,13 @@ spec:
     namespace: services
 
   # CMS
-  - name: cray-ims
-    source: csm-algol60
-    version: 3.8.2
-    namespace: services
-  - name: cray-cfs-operator
-    source: csm-algol60
-    version: 1.17.0-beta.5
-    namespace: services
-  - name: cray-cfs-api
-    source: csm-algol60
-    version: 1.12.0-beta.2
-    namespace: services
-  - name: cray-cfs-batcher
-    source: csm-algol60
-    version: 1.8.0-beta.2
-    namespace: services
-  - name: cfs-trust
-    source: csm-algol60
-    version: 1.6.1
-    namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
     version: 1.9.0-beta.1
     namespace: services
-  - name: gitea
-    source: csm-algol60
-    version: 2.5.1
-    namespace: services
-    values:
-      keycloakImage:
-        tag: 3.6.1
-  - name: cray-console-operator
-    source: csm-algol60
-    version: 1.6.0
-    namespace: services
-    timeout: 20m0s
-  - name: cray-console-node
-    source: csm-algol60
-    version: 1.7.0
-    namespace: services
-    timeout: 20m0s
-  - name: cray-console-data
+  - name: cfs-trust
     source: csm-algol60
     version: 1.6.1
-    namespace: services
-  - name: cray-crus
-    source: csm-algol60
-    version: 1.11.0
-    namespace: services
-  - name: cray-tftp
-    source: csm-algol60
-    version: 1.8.2
-    namespace: services
-  - name: cray-tftp-pvc
-    source: csm-algol60
-    version: 1.8.2
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -138,9 +89,56 @@ spec:
     version: 2.0.7
     namespace: services
     timeout: 10m
-  - name: csm-ssh-keys
+  - name: cray-cfs-api
     source: csm-algol60
-    version: 1.4.1
+    version: 1.12.0-beta.2
+    namespace: services
+  - name: cray-cfs-batcher
+    source: csm-algol60
+    version: 1.8.0-beta.2
+    namespace: services
+  - name: cray-cfs-operator
+    source: csm-algol60
+    version: 1.17.0-beta.5
+    namespace: services
+  - name: cray-console-data
+    source: csm-algol60
+    version: 1.6.1
+    namespace: services
+  - name: cray-console-node
+    source: csm-algol60
+    version: 1.7.0
+    namespace: services
+    timeout: 20m0s
+  - name: cray-console-operator
+    source: csm-algol60
+    version: 1.6.0
+    namespace: services
+    timeout: 20m0s
+  - name: cray-crus
+    source: csm-algol60
+    version: 1.11.0
+    namespace: services
+  - name: cray-csm-barebones-recipe-install
+    source: csm-algol60
+    version: 1.7.1
+    namespace: services
+    values:
+      cray-import-kiwi-recipe-image:
+        import_image:
+          image:
+            tag: 1.7.1
+  - name: cray-ims
+    source: csm-algol60
+    version: 3.8.2
+    namespace: services    
+  - name: cray-tftp
+    source: csm-algol60
+    version: 1.8.2
+    namespace: services
+  - name: cray-tftp-pvc
+    source: csm-algol60
+    version: 1.8.2
     namespace: services
   - name: csm-config
     source: csm-algol60
@@ -151,15 +149,17 @@ spec:
         catalog:
           image:
             tag: 1.3.1
-  - name: cray-csm-barebones-recipe-install
+  - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.7.1
+    version: 1.4.1
+    namespace: services
+  - name: gitea
+    source: csm-algol60
+    version: 2.5.1
     namespace: services
     values:
-      cray-import-kiwi-recipe-image:
-        import_image:
-          image:
-            tag: 1.7.1
+      keycloakImage:
+        tag: 3.6.1	
 
   # Cray Product Catalog
   - name: cray-product-catalog

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,7 +74,7 @@ spec:
   # CMS
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.9.0-beta.2
+    version: 1.9.0
     namespace: services
   - name: cfs-trust
     source: csm-algol60
@@ -99,7 +99,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0-beta.6
+    version: 1.17.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -74,15 +74,15 @@ spec:
   # CMS
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.9.0-beta.1
+    version: 1.9.0-beta.2
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.1
+    version: 1.6.3
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.11.0
+    version: 1.11.1
     namespace: services
   - name: cray-bos
     source: csm-algol60
@@ -99,25 +99,25 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0-beta.5
+    version: 1.17.0-beta.6
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.6.1
+    version: 1.6.2
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: services
     timeout: 20m0s
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: services
     timeout: 20m0s
   - name: cray-crus
     source: csm-algol60
-    version: 1.11.0
+    version: 1.11.2
     namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
@@ -130,7 +130,7 @@ spec:
             tag: 1.7.1
   - name: cray-ims
     source: csm-algol60
-    version: 3.8.2
+    version: 3.8.3
     namespace: services    
   - name: cray-tftp
     source: csm-algol60
@@ -142,7 +142,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.0
+    version: 1.15.1
     namespace: services
     values:
       cray-import-config:
@@ -151,11 +151,11 @@ spec:
             tag: 1.3.1
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.4.1
+    version: 1.5.1
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.5.1
+    version: 2.5.2
     namespace: services
     values:
       keycloakImage:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,6 +72,10 @@ spec:
     namespace: services
 
   # CMS
+  - name: cfs-ara
+    source: csm-algol60
+    version: 1.0.1
+    namespace: services  
   - name: cfs-hwsync-agent
     source: csm-algol60
     version: 1.9.0
@@ -99,15 +103,11 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0
+    version: 1.17.1
     namespace: services
   - name: cray-console-data
     source: csm-algol60
     version: 1.6.2
-  - name: cfs-ara
-    source: csm-algol60
-    version: 1.0.1
-    namespace: services
   - name: cray-console-node
     source: csm-algol60
     version: 1.7.1


### PR DESCRIPTION
## Summary and Scope

CASMCMS-8353: Artifactory authentication

    I am adding authentication to Artifactory. Mostly, it takes the
    form of adding credentials to the Jenkinsfile.github, so our
    automatic versioning tool cms-meta-tools can authenicate itself.
    For a few additions, it helps pip authenticate straight to Artifactory.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-8353

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * The. build system
### Test description:

Everything builds.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
If it doesn't work, then when Artifactory is under lock down, nothing will build.



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

