### PR TITLE
CASMTRIAGE-4744: Fix HSN NIC Discovery in HSM

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 4.0.1
+    version: 4.0.2
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Update the cray-smd chart to 4.0.2 for CASMTRIAGE-4744 to fix HSN NIC discovery.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4744](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4744)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/94

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

