### PR TITLE
Master - CASMPET-6097: Adjust NCN "Memory/Cpu Usage Warning" Too High down from 85% to 80%.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.5
+    version: 0.26.6
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
### Summary and Scope
Master - CASMPET-6097: Adjust NCN "Memory/Cpu Usage Warning" Too High down from 85% to 80%.

Merge pull request #90 from Cray-HPE/CASMPET-6097

### Issues and Related PRs
CASMPET-6097



