### PR TITLE
Removed trs operator

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -50,8 +50,6 @@ artifactory.algol60.net/csm-docker/stable:
     # XXX facilitate install/upgrade?
     hms-shcd-parser:
       - 1.8.0
-    hms-trs-worker-http-v1:
-      - 1.8.0
 
     # Utility to help make changes for adding river cabinets
     hardware-topology-assistant:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -34,10 +34,6 @@ spec:
 
   # HMS
   # Install any operators first, wait for them to come up before continuing.
-  - name: cray-hms-trs-operator
-    source: csm-algol60
-    version: 2.0.3
-    namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
     version: 2.1.6

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -99,6 +99,9 @@ fi
 # cray-conman needs to be removed if it exists.
 undeploy -n services cray-conman
 
+# In CSM 1.6.0 the trs operator is obsolete and thus is removed here.
+undeploy -n operators cray-hms-trs-operator
+
 # Deploy remaining system management applications
 deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 


### PR DESCRIPTION
## Summary and Scope

We are removing the hms-trs-operator and trs-worker. The trs-operator feature is not used by anything. Also, trs operator uses deprecated k8s APIs, which is another reason to remove it.

## Issues and Related PRs

* Resolves [CASMHMS-5854](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5854)

## Testing

### Tested on:

- mug 

### Test description:

Removed the trs-operator and verified that some hms projects that use trs still work.

## Risks and Mitigations

The risk is that this will break the next install or upgrade. If there are errors they should be caught in the first install and upgrade tests, and will not make it onto a customer system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

