### PR TITLE
CASMTRIAGE-4744: Fix HSN NIC Discovery in HSM CSM 1.3

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,8 +20,8 @@ spec:
     namespace: services
     values:
       global:
-        appVersion: 1.58.1
-        testVersion: 1.58.1
+        appVersion: 1.58.2
+        testVersion: 1.58.2
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

Update the cray-smd image override to 1.58.2 for CASMTRIAGE-4744 to fix HSN NIC discovery.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4744](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4744)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/94

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

