### PR TITLE
Bump sealed secrets to 0.4.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -104,7 +104,7 @@ spec:
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60
-    version: 0.3.0
+    version: 0.4.0
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60


### PR DESCRIPTION
Needed for a version that can run in k8s 1.22.

## Summary and Scope

Bumps sealed secrets to 0.4.0 which includes an updated version of upstream sealed secrets that can work in k8s 1.22.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6174
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested by installing the updated sealed secrets on caleb and unsealing existing secrets.

### Tested on:


  * Virtual Shasta - caleb

### Test description:

Manually updated

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? no, caleb wasn't running a full csm stack 
- Were continuous integration tests run? If not, why? no, similarly couldn't test a full install
- Was upgrade tested? If not, why? n/a
- Was downgrade tested? If not, why? n/a
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

No risks I could find. This isn't really a user facing change anyone should care about.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

