### PR TITLE
Casmsec-374: Chart version increment for gatekeeper code removing

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.14.4
+    version: 2.14.5
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
Bumping up the version for jira "CASMSEC-374: Remove opa-gatekeeper for fresh installs" changes

Reference:
Gatekeeper code removed in https://github.com/Cray-HPE/cray-drydock/pull/31 PR
and updated the chart version in https://github.com/Cray-HPE/cray-drydock/pull/32 PR

