### PR TITLE
Casmsec-374: Chart version increment for gatekeeper code removing

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.14.4
+    version: 2.14.5
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
Bumping up the version for jira "CASMSEC-374: Remove opa-gatekeeper for fresh installs" changes

Reference:
Gatekeeper code removed in Cray-HPE/cray-drydock#31 PR and updated the chart version in Cray-HPE/cray-drydock#32 PR Submitted to release/1.4 in https://github.com/Cray-HPE/csm/pull/1614 PR