### PR TITLE
CASMINST-5766: Update csm-testing and goss-servers RPMs

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.6.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.3-1.x86_64
-    - csm-testing-1.14.60-1.noarch
-    - goss-servers-1.14.60-1.noarch
+    - csm-testing-1.14.61-1.noarch
+    - goss-servers-1.14.61-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.35-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update csm-testing goss-servers RPMs to 1.14.61. 

Test updates include:

Update load-balancer ingress path to use for Keycloak interaction, given the master realm admin auth is being requested. This as the CMN LB, specifically the `auth.cmn.*` ingress paths are now supported for master realm administration. 

Use a DNS A record query instead of ping, this to address CAST-31571 as a tangent. 

This should be backward compatible with all releases that included CMN. 

## Issues and Related PRs

* Resolves [CASMINST-5766](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5766)
* Resolves [CAST-31571](https://jira-pro.its.hpecorp.net:8443/browse/CAST-31571)
* Caused by [CASMSEC-371](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-371)
* https://github.com/Cray-HPE/csm-testing/pull/422

## Testing

See csm-testing PR for details on modified test, test. 

A test on an actual CSM base of 1.3.0 GA is still pending. 

## Risks and Mitigations

The changes between 1.14.60 and 1.14.61 are limited to the single test modified noted above. 

