### PR TITLE
CASMHMS-5626: Remove HSM v1 APIs

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 4.0.2
+    version: 5.0.0
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

This updates the cray-smd chart to v5.0.0 for removing the v1 APIs from HSM

## Issues and Related PRs

* Resolves [CASMHMS-5626](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5626)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/96

## Risks and Mitigations

Low. Everything using HSM directly has been migrated to use the v2 APIs

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

