### PR TITLE
CASMPET-6221: Install - Inject secrets for cray-postgres-operator based logical-backups

### DIFF
--- a/logical_backup_secrets.yaml
+++ b/logical_backup_secrets.yaml
@@ -1,0 +1,8 @@
+spec:
+  kubernetes:
+    services:
+      cray-postgres-operator:
+        postgres-operator:
+          configLogicalBackup:
+            logical_backup_s3_access_key_id:
+            logical_backup_s3_secret_access_key:


### PR DESCRIPTION
## Summary and Scope

The updated postgres operator for CSM 1.6 contains support for logical backups.
In order to configure the logical backup s3 credentials for the install case, the postgres-backup-s3-credentials need to be injected in the customizations.yaml prior to deploying the platform.yaml (cray-postgres-operator).
The postgres-backup-s3-credentials secret should exist at this point - it is created when the storage nodes are bootstrapped and the ceph rgw ansible runs, but a check is also included in case the secret for some reason has not yet been created.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6221](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6221)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in TBD
* Merge with/before/after CASMINST-5476 (updated postgres operator for CSM 1.6)

## Testing

### Tested on:

vshasta 

### Test description:

A test was done to check that the customization.yaml file get updated as expected. Further testing will occur when CSM 1.6 is fresh installed on a metal system.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

