### PR TITLE
CASMINST-5476-1.6 : Upgrade to latest zalando postres operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release cray-postgres-operator 1.8.2 to pull in latest zalando postres operator
+- Release cray-psp 0.4.2 needed along with cray-postgres-operator change
 - Release cray-nls 0.4.41 to include functionality for storage rebuild workflow (CASMINST-5745)
 - Release cray-ims-load-artifacts 2.0.1 to update image used in IUF deliver-product stage (CASM-3718)
 - Updated cfs-operator to collapse all session layers and collect logs with ARA

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -92,7 +92,7 @@ spec:
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60
-    version: 0.4.1
+    version: 0.4.2
     namespace: services
   - name: cray-velero
     source: csm-algol60
@@ -180,7 +180,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.0.0
+    version: 1.8.2
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
Pulls in the latest upstream zalando postgres operator into the cray-postgres-operator chart

## Summary and Scope

Updating cray-postgres-operator to the latest upstream postgres operator v1.8.2
This also pulls in newer locally built images for
* spilo-14:2.1-p7
* logical-backup:v1.8.2
* pgbouncer:master-22

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5476](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5476)
* Change will also be needed in NA
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with `https://github.com/Cray-HPE/cray-psp/pull/8`

## Testing

Validated install os upstream cray-postgres-operator which pull in upstream postgres-operator and psql v14

* Added ClusterRoleBinding to postgres-pod service account (w/o this the postgres statefulsets. initContainers FailedCreate due to — “PodSecurityPolicy: unable to admit pod: [spec.initContainers[0].securityContext.capabilities.add: Invalid value: “NET_RAW”: capability may not be added]“) to fix SyncFailed issues on postgresql resources.
```
$ kubectl get clusterrolebinding cray-postgres-operator-psp -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    meta.helm.sh/release-name: cray-psp
    meta.helm.sh/release-namespace: services
  creationTimestamp: "2023-01-06T21:36:38Z"
  labels:
    app.kubernetes.io/managed-by: Helm
  managedFields:
  - apiVersion: rbac.authorization.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:meta.helm.sh/release-name: {}
          f:meta.helm.sh/release-namespace: {}
        f:labels:
          .: {}
          f:app.kubernetes.io/managed-by: {}
      f:roleRef:
        f:apiGroup: {}
        f:kind: {}
        f:name: {}
      f:subjects: {}
    manager: Go-http-client
    operation: Update
    time: "2023-01-06T21:36:38Z"
  name: cray-postgres-operator-psp
  resourceVersion: "4022"
  uid: 3db53159-bcd1-4290-abf1-5ce917f0d815
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: restricted-transition-net-raw-psp
subjects:
- kind: ServiceAccount
  name: postgres-pod
  namespace: services
- kind: ServiceAccount
  name: postgres-pod
  namespace: spire
- kind: ServiceAccount
  name: postgres-pod
  namespace: argo
- kind: ServiceAccount
  name: postgres-pod
  namespace: sma
```

* Postgres operator and clusters are all Running and jobs are Completed
```
$ kubectl get pods -A | grep postgres
argo                cray-nls-postgres-0                                               3/3     Running                      0          5m11s
argo                cray-nls-postgres-1                                               3/3     Running                      0          3m52s
argo                cray-nls-postgres-2                                               3/3     Running                      0          2m7s
services            cray-postgres-operator-65b55b4558-rwcgj                           2/2     Running                      0          5m48s
services            cray-sls-postgres-0                                               3/3     Running                      0          4m15s
services            cray-sls-postgres-1                                               3/3     Running                      0          3m15s
services            cray-sls-postgres-2                                               3/3     Running                      0          108s
services            cray-sls-wait-for-postgres-1-bfbrc                                0/3     Completed                    0          4m16s
services            cray-smd-postgres-0                                               3/3     Running                      0          4m5s
services            cray-smd-postgres-1                                               3/3     Running                      0          3m26s
services            cray-smd-postgres-2                                               3/3     Running                      0          119s
services            cray-smd-wait-for-postgres-1-6n5mc                                0/3     Completed                    0          4m7s
services            gitea-vcs-postgres-0                                              3/3     Running                      0          3m26s
services            gitea-vcs-postgres-1                                              3/3     Running                      0          2m25s
services            gitea-vcs-postgres-2                                              3/3     Running                      0          70s
services            gitea-vcs-wait-for-postgres-1-hwh6r                               0/2     Completed                    0          3m32s
services            keycloak-postgres-0                                               3/3     Running                      0          5m30s
services            keycloak-postgres-1                                               3/3     Running                      0          3m33s
services            keycloak-postgres-2                                               3/3     Running                      0          2m11s
services            keycloak-wait-for-postgres-1-g6lcz                                0/2     Completed                    0          5m32s
spire               spire-postgres-0                                                  3/3     Running                      0          3m7s
spire               spire-postgres-1                                                  3/3     Running                      0          2m22s
spire               spire-postgres-2                                                  3/3     Running                      0          58s
spire               spire-postgres-pooler-6cdd6c9d48-j8q7w                            2/2     Running                      0          26s
spire               spire-postgres-pooler-6cdd6c9d48-tftbj                            2/2     Running                      0          26s
spire               spire-postgres-pooler-6cdd6c9d48-x98kp                            2/2     Running                      0          27s
```

* Postgresql are all Running (The psql VERSION is actually 14 - this will get changed when the services are updated)
```
$ kubectl get postgresql -A
NAMESPACE   NAME                 TEAM        VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE     STATUS
argo        cray-nls-postgres    cray-nls    11        3      1Gi                                     7m55s   Running
services    cray-sls-postgres    cray-sls    11        3      1Gi                                     6m59s   Running
services    cray-smd-postgres    cray-smd    11        3      100Gi    500m          8Gi              6m49s   Running
services    gitea-vcs-postgres   gitea-vcs   11        3      50Gi                                    6m14s   Running
services    keycloak-postgres    keycloak    11        3      10Gi                                    8m14s   Running
spire       spire-postgres       spire       11        3      60Gi     1             4Gi              5m52s   Running
```

* Two examples showing that the version of psql as deployed by the new operator is v14
```
$ kubectl exec cray-smd-postgres-0 -n services -c postgres -- psql --version
psql (PostgreSQL) 14.6 (Ubuntu 14.6-1.pgdg18.04+1)

$ kubectl exec keycloak-postgres-0 -n services -c postgres -- psql --version
psql (PostgreSQL) 14.6 (Ubuntu 14.6-1.pgdg18.04+1)
```

* Two examples showing the postgres clusters are healthy and newer patronictl is working
```
$ kubectl exec cray-sls-postgres-0 -n services -c postgres -- patronictl list
+ Cluster: cray-sls-postgres (7185658365904220233) ----+----+-----------+
| Member              | Host       | Role    | State   | TL | Lag in MB |
+---------------------+------------+---------+---------+----+-----------+
| cray-sls-postgres-0 | 10.38.0.35 | Leader  | running |  1 |           |
| cray-sls-postgres-1 | 10.40.0.70 | Replica | running |  1 |         0 |
| cray-sls-postgres-2 | 10.32.0.75 | Replica | running |  1 |         0 |
+---------------------+------------+---------+---------+----+-----------+

$ kubectl exec spire-postgres-0 -n spire -c postgres -- patronictl list
+ Cluster: spire-postgres (7185658598472941641) ----+----+-----------+
| Member           | Host       | Role    | State   | TL | Lag in MB |
+------------------+------------+---------+---------+----+-----------+
| spire-postgres-0 | 10.38.0.61 | Leader  | running |  1 |           |
| spire-postgres-1 | 10.32.0.71 | Replica | running |  1 |         0 |
| spire-postgres-2 | 10.40.0.80 | Replica | running |  1 |         0 |
+------------------+------------+---------+---------+----+-----------+
```

### Tested on:

  * Virtual Shasta 

### Test description:

Installed new cray-postgres-operator chart along with the updated cray-psp chart

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No known issues for install case.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable