### PR TITLE
CASMCMS-8374: Update cfs-operator for fixed session memory limits

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,7 +78,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.16.3
+    version: 1.16.5
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Pulls in the cfs-operator change to fix loading of the configurable memory limits for the containers in cfs sessions.

## Issues and Related PRs

* Resolves CASMCMS-8374

## Testing

### Tested on:

  * Wasp

### Test description:

- Successfully ran sessions with the new operator

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

