### PR TITLE
CASMNET-2001 - Unbound metrics missing from Prometheus

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.13 # update platform.yaml cray-precache-images with this
+    version: 0.7.15 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.13
+        appVersion: 0.7.15
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.18
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.13
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.15
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.7
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

During investigation of a customer issue it was observed that Prometheus metrics for Unbound DNS are missing.

The unbound-telemetry process included in the image was not working correctly.

The unbound-telemetry exporter is EOL and the GitHub repo was archived in November with a recommendation to use the letsencrypt unbound exporter instead. 

The unbound-telemetry exporter also contains a security vulnerability (CVE-2020-26235) which will not be patched now the project has been archived.

As the letsencrypt exporter exists in the Alpine Linux edge package repo this PR removes unbound-telemetry and adds the new exporter.

A followup ticket to CASMMON will be required to overhaul the dashboard due to changes in the available metrics.

## Issues and Related PRs

* Resolves [CASMNET-2001](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2001)
* [CASMMON-254](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-254) has been opened to address the required dashboard changes.

## Testing

### Tested on:

  * `surtur`
  * Local development environment

### Test description:

Installed release on surtur and verified targets are now up
```
ncn-m001:~/cspiller/CASMNET-2001 # curl -sk http://10.19.244.228:9090/api/v1/targets?state=active | jq -c '.data.activeTargets[] | select(.health=="up") | select(.discoveredLabels.job|contains("unbound")) | {"job": .discoveredLabels.job, "health":.health}'
{"job":"sysmgmt-health/cray-dns-unbound-dns-unbound-exporter/0","health":"up"}
{"job":"sysmgmt-health/cray-dns-unbound-dns-unbound-exporter/0","health":"up"}
{"job":"sysmgmt-health/cray-dns-unbound-dns-unbound-exporter/0","health":"up"}
```
Verified the metrics are available from Prometheus
```
ncn-m001:~/cspiller/CASMNET-2001 # curl -sk -XPOST http://10.19.244.228:9090/api/v1/query --data-urlencode 'query=unbound_queries_total{pod="cray-dns-unbound-b9d4b68bd-vkth2"}' | jq .
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "unbound_queries_total",
          "endpoint": "exporter",
          "instance": "10.38.0.61:9167",
          "job": "cray-dns-unbound-dns-unbound-exporter",
          "namespace": "services",
          "pod": "cray-dns-unbound-b9d4b68bd-vkth2",
          "service": "cray-dns-unbound-dns-unbound-exporter",
          "thread": "0"
        },
        "value": [
          1673539115.013,
          "125342"
        ]
      },
      {
        "metric": {
          "__name__": "unbound_queries_total",
          "endpoint": "exporter",
          "instance": "10.38.0.61:9167",
          "job": "cray-dns-unbound-dns-unbound-exporter",
          "namespace": "services",
          "pod": "cray-dns-unbound-b9d4b68bd-vkth2",
          "service": "cray-dns-unbound-dns-unbound-exporter",
          "thread": "1"
        },
        "value": [
          1673539115.013,
          "149053"
        ]
      }
    ]
  }
}
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

