### PR TITLE
CASMCMS-8375: Remove beta tags from cfs services

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -78,15 +78,15 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0-beta.5
+    version: 1.17.0
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.12.0-beta.2
+    version: 1.12.0
     namespace: services
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.8.0-beta.3
+    version: 1.8.0
     namespace: services
   - name: cfs-trust
     source: csm-algol60
@@ -94,7 +94,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.9.0-beta.1
+    version: 1.9.0
     namespace: services
   - name: gitea
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Removes the beta tags from CFS services prior to release.   This does not include code changes and is a build change only.

## Issues and Related PRs

* Resolves CASMCMS-8375

## Testing

No code changes

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

