### PR TITLE
In HMS services updated k8s deprecated APIs

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,11 +12,11 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 3.0.2
+    version: 4.0.0
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 5.0.2
+    version: 6.0.2
     namespace: services
     values:
       cray-service:
@@ -35,7 +35,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 2.0.5
+    version: 2.1.0
     namespace: services
 
   # Cray DHCP Kea


### PR DESCRIPTION
## Summary and Scope

Updated k8s deprecated APIs
- hms-discovery - changed to use a new version of CronJob
- hms-sls - updated to cray-service chart 9.0.0
- hms-smd - updated to cray-service chart 9.0.0

## Issues and Related PRs

* Resolves [CASMHMS-5878](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5878)
* Resolves [CASMHMS-5880](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5880)
* Resolves [CASMHMS-5881](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5881)

## Testing

### Tested on:

  * Tested some on mug

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

Low. The issues will likely be found in the first upgrade or install.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

