### PR TITLE
CASMPET-5081 Update spire to 3.1.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,7 +179,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: spire
 
   # Tapms service

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,7 +179,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.11.0
+    version: 3.1.0
     namespace: spire
 
   # Tapms service

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -43,3 +43,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.2.38-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.1-1.x86_64
+https://artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle15_sp4_ncn:
+  rpms:
+    - spire-agent-1.4.0-2.5_20230117111813__gc07bb77.x86_64


### PR DESCRIPTION
## Summary and Scope

This updates spire to 1.4.0 as a required pre-req for TPM support. It also adds the /opt/cray/cray-spire paths required for SKERN-7109.

## Issues and Related PRs

* Resolves [CASMPET-5081](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5081)
* Resolves [CASMPET-6193](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6193)
* Required by [SKERN-7109](https://jira-pro.its.hpecorp.net:8443/browse/SKERN-7109)
## Testing

### Tested on:

  * Local development environment
  * Loki
  * Odin

### Test description:

Validated that new paths were created and that spire 1.4 worked properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y, requires reinstall of spire-server
- Was downgrade tested? If not, why? Y, requires reinstall of spire-server
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

