### PR TITLE
CASMINST-5793: csm-testing: Log test duration in decimal without scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Release csm-testing v1.15.27, Log test duration in decimal without scientific notation (CASMINST-5793)
 - Release cray-nls 0.4.41 to include functionality for storage rebuild workflow (CASMINST-5745)
 - Release cray-ims-load-artifacts 2.0.1 to update image used in IUF deliver-product stage (CASM-3718)
 - Updated cfs-operator to collapse all session layers and collect logs with ARA

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.15.26-1.noarch
+    - csm-testing-1.15.27-1.noarch
     - docs-csm-1.4.46-1.noarch
-    - goss-servers-1.15.26-1.noarch
+    - goss-servers-1.15.27-1.noarch
     - hpe-csm-scripts-0.4.3-1.noarch
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

In csm-testing, print_goss_json_results was logging test duration in seconds using scientific notation (this was happening implicitly, by the Python JSON module). This was unable to be consumed by the grok exporter tool being used to collect the Goss test logs. This PR changes things so that scientific notation is not used. It also fixes a few minor bugs in error paths of print_goss_json_results .

## Issues and Related PRs

* Resolves [CASMINST-5793](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5793)
* [1.4 source PR](https://github.com/Cray-HPE/csm-testing/pull/427)
* [main source PR](https://github.com/Cray-HPE/csm-testing/pull/428)
* [main csm manifest PR](https://github.com/Cray-HPE/csm/pull/1634)
* [1.4 csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/697)
* [main csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/698)

## Testing

See [1.4 source PR](https://github.com/Cray-HPE/csm-testing/pull/427) for details.

## Risks and Mitigations

Without this, grok exporter will not be able to properly parse the Goss test logs. The change is invisible to people running the Goss tests, as it only impacts the format of a log file that is not intended for human consumption.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
