### PR TITLE
CASMHMS-5737: Add PCS to the CSM manifest

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -53,6 +53,9 @@ artifactory.algol60.net/csm-docker/stable:
     hms-trs-worker-http-v1:
       - 1.8.0
 
+    cray-capmc:
+      - 2.7.0
+
     # Utility to help make changes for adding river cabinets
     hardware-topology-assistant:
     - 0.1.0

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -10,3 +10,8 @@
 # specified in all Loftsman manifests under ../manifests and update this file.
 # Therefore there is no need to list charts in this index that are already
 # specified in a Loftsman manifest.
+
+artifactory.algol60.net/csm-helm-charts/stable:
+  charts:
+    cray-hms-capmc:
+      - 3.0.8

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -70,7 +70,7 @@ spec:
     source: csm-algol60
     version: 2.0.4
     namespace: services
-  - name: cray-power-control
+  - name: cray-hms-power-control
     source: csm-algol60
     version: 1.0.0
     namespace: services

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -70,7 +70,7 @@ spec:
     source: csm-algol60
     version: 2.0.4
     namespace: services
-  - name: cray-hms-power-control
+  - name: cray-power-control
     source: csm-algol60
     version: 1.0.0
     namespace: services

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -44,7 +44,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 3.0.7
+    version: 4.0.1
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
@@ -69,6 +69,10 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     version: 2.0.4
+    namespace: services
+  - name: cray-power-control
+    source: csm-algol60
+    version: 1.0.0
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

This adds PCS to the CSM manifest and deploys the CAPMC shim that calls PCS under the covers.

This also pulls the chart and image for full version of CAPMC into the install but doesn't deploy it.

## Issues and Related PRs

* Resolves [CASMHMS-5737](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5737)

## Testing

For testing, see:
PCS - https://github.com/Cray-HPE/hms-power-control/pull/22
CAPMC shim - https://github.com/Cray-HPE/hms-capmc/pull/78

### Tested on:

  * Shandy
  * Local development environment

## Risks and Mitigations

PCS is replacing much of the functionality of CAPMC. Should problems arise from PCS, the CAPMC chart and image is also included in the install for backup.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

