### PR TITLE
CASMMON-254 Rework sysmgmt-health Unbound Grafana dashboard to support new exporter

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.7
+    version: 0.26.10
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
Summary and Scope
During investigation of a customer issue it was observed that the Prometheus metrics for Unbound DNS are missing.

The unbound-telemetry exporter is not working correctly and is now EOL and contains a security vulnerability which will not be patched now the project has been archived.

cray-dns-unbound now incorporates the letsencrypt unbound_exporter however the dashboard needs reworking to support it as some metrics are no longer available via this new exporter.

Issues and Related PRs
CASMMON-254 Rework sysmgmt-health Unbound Grafana dashboard to support new exporter

Testing
Tested on surtur

![image](https://user-images.githubusercontent.com/22464568/213169920-dc4ea21b-49d7-438f-810b-8b6db89d68d9.png)
