### PR TITLE
CASMCMS-7690: Add cfs-ara to the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Add cfs-ara 1.0.0 to the manifest (CASMCMS-7690)
 - Release csm-testing v1.16.2, Log test duration in decimal without scientific notation (CASMINST-5793)
 - Release cray-postgres-operator 1.8.2 to pull in latest zalando postres operator
 - Release cray-psp 0.4.2 needed along with cray-postgres-operator change

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -100,6 +100,10 @@ spec:
     source: csm-algol60
     version: 1.9.0
     namespace: services
+  - name: cfs-ara
+    source: csm-algol60
+    version: 1.0.1
+    namespace: services
   - name: gitea
     source: csm-algol60
     version: 2.5.1

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -576,6 +576,8 @@ spec:
             private_key: int_ca.key
             certificate: int_ca.crt
             ca_bundle: root_ca.crt
+      cfs-ara:
+        externalHostname: ara.cmn.{{ network.dns.external }}
       gitea:
         uriPrefix: /vcs
         externalHostname: vcs.cmn.{{ network.dns.external }}


### PR DESCRIPTION
## Summary and Scope

Adds cfs-ara to the manifest.  cfs-operator has already been updated to push data to ARA.

## Issues and Related PRs

* Resolves CASMCMS-7690/CASMTRIAGE-4761

## Testing

### Tested on:

  * Mug/Surtur

### Test description:

Deployed chart, ran CFS sessions and verified that ARA was collecting the data.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

