### PR TITLE
Downgrade etcd operator to functional version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60
-    version: 0.18.1
+    version: 0.17.3
     namespace: operators
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Later changes/builds of the unreleased etcd operator break backup/restore, reverting to working version.  Further engineering effort going into bitnami etcd helm chart.

## Issues and Related PRs

* Resolves [CASMPET-6122](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6122)

## Testing

Tested backup/restore on mug with 0.17.3 and worked.

### Tested on:

  * `mug`

### Test description:

Backed up and restored cray-uas-mgr.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable