### PR TITLE
plumb credentials to verify rpms, skopeo calls

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -57,28 +57,36 @@ pipeline {
                 stage('Assets') {
                     steps {
                         withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-                            sh "./assets.sh"
+                            sh """
+                                ./assets.sh
+                            """
                         }
                     }
                 }
 
                 stage("Charts and Images") {
                     steps {
-                        sh ". build/.env/bin/activate && make images -j8"
+                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                            sh """
+                                . build/.env/bin/activate && make images -j8
+                            """
+                        }
                     }
                 }
 
                 stage('RPM Index') {
                     steps {
-                        sh """
-                            ./hack/verify-rpm-index.sh \
-                                rpm/cray/csm/sle-15sp2/index.yaml \
-                                rpm/cray/csm/sle-15sp2-compute/index.yaml \
-                                rpm/cray/csm/sle-15sp3/index.yaml \
-                                rpm/cray/csm/sle-15sp3-compute/index.yaml \
-                                rpm/cray/csm/sle-15sp4/index.yaml \
-                                rpm/cray/csm/sle-15sp4-compute/index.yaml
-                        """
+                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                            sh """
+                                ./hack/verify-rpm-index.sh \
+                                    rpm/cray/csm/sle-15sp2/index.yaml \
+                                    rpm/cray/csm/sle-15sp2-compute/index.yaml \
+                                    rpm/cray/csm/sle-15sp3/index.yaml \
+                                    rpm/cray/csm/sle-15sp3-compute/index.yaml \
+                                    rpm/cray/csm/sle-15sp4/index.yaml \
+                                    rpm/cray/csm/sle-15sp4-compute/index.yaml
+                            """
+                        }
                     }
                 }
             }

--- a/assets.sh
+++ b/assets.sh
@@ -85,7 +85,7 @@ function cmd_retry
     exit 1
 }
 
-if [ -z "${ARTIFACTORY_USER}" -o -z "${ARTIFACTORY_TOKEN}"]; then
+if [ -z "${ARTIFACTORY_USER}" -o -z "${ARTIFACTORY_TOKEN}" ]; then
     echo "Missing authentication information for image download. Please set ARTIFACTORY_USER and ARTIFACTORY_TOKEN environment variables."
     exit 1
 fi

--- a/build/images/inspect.sh
+++ b/build/images/inspect.sh
@@ -19,11 +19,17 @@ function skopeo-inspect() {
         --override-arch amd64 \
         inspect \
         --retry-times 5 \
+        --creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" \
         --format "{{.Name}}@{{.Digest}}" \
         "$img"
 }
 
 [[ $# -gt 0 ]] || usage
+
+if [ -z "${ARTIFACTORY_USER}" -o -z "${ARTIFACTORY_TOKEN}" ]; then
+    echo "Missing authentication information for image download. Please set ARTIFACTORY_USER and ARTIFACTORY_TOKEN environment variables."
+    exit 1
+fi
 
 while [[ $# -gt 0 ]]; do
     # Resolve image to canonical form, e.g., alpine -> docker.io/library/alpine

--- a/build/images/sync.sh
+++ b/build/images/sync.sh
@@ -21,6 +21,11 @@ echo >&2 "+ skopeo copy docker://$image dir:$destdir"
 workdir="$(mktemp -d .skopeo-copy-XXXXXXX)"
 trap "rm -fr '$workdir'" EXIT
 
+if [ -z "${ARTIFACTORY_USER}" -o -z "${ARTIFACTORY_TOKEN}" ]; then
+    echo "Missing authentication information for image download. Please set ARTIFACTORY_USER and ARTIFACTORY_TOKEN environment variables."
+    exit 1
+fi
+
 docker run --rm \
     -u "$(id -u):$(id -g)" \
     --mount "type=bind,source=$(realpath "$workdir"),destination=/data" \
@@ -30,6 +35,7 @@ docker run --rm \
     --override-arch amd64 \
     copy \
     --retry-times 5 \
+    --src-creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" \
     "docker://$image" \
     dir:/data \
     >&2 || exit 255

--- a/hack/verify-rpm-index.sh
+++ b/hack/verify-rpm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.11.0"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.3"
 
 set -o errexit
 set -o pipefail
@@ -11,7 +11,19 @@ ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
 
 [[ $# -gt 0 ]] || set -- "${ROOTDIR}/rpm/cray/csm/sle-15sp2/index.yaml" "${ROOTDIR}/rpm/cray/csm/sle-15sp2-compute/index.yaml"
 
+#pass the repo credentials environment variables to the container that runs rpm-sync
+REPO_CREDS_DOCKER_OPTIONS=""
+REPO_CREDS_RPMSYNC_OPTIONS=""
+if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
+    REPOCREDSPATH="/tmp/"
+    REPOCREDSFILENAME="repo_creds.json"
+    jq --null-input   --arg url "https://artifactory.algol60.net/artifactory/" --arg realm "Artifactory Realm" --arg user "$ARTIFACTORY_USER"   --arg password "$ARTIFACTORY_TOKEN"   '{($url): {"realm": $realm, "user": $user, "password": $password}}' > $REPOCREDSPATH$REPOCREDSFILENAME
+    REPO_CREDS_DOCKER_OPTIONS="--mount type=bind,source=${REPOCREDSPATH},destination=/repo_creds_data"
+    REPO_CREDS_RPMSYNC_OPTIONS="-c /repo_creds_data/${REPOCREDSFILENAME}"
+    trap "rm -f '${REPOCREDSPATH}${REPOCREDSFILENAME}'" EXIT
+fi
+
 while [[ $# -gt 0 ]]; do
-    docker run --rm -i "$PACKAGING_TOOLS_IMAGE" rpm-sync --dry-run -v -n 32 - >/dev/null < "$1"
+    docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i "$PACKAGING_TOOLS_IMAGE" rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -v -n 32 - >/dev/null < "$1"
     shift
 done


### PR DESCRIPTION
## Summary and Scope

Changes to allow CSM build scripts to authenticate with Algol60 artifactory

## Issues and Related PRs

* Resolves [CASMINST-5741](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5741)

## Testing

Tested locally and in the Jenkins pipeline

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

