### PR TITLE
CASM-3758, CASM-3710: (IUF) Add images needed by IUF to CSM

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -169,3 +169,9 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.3.3
     docker.io/coredns/coredns:
       - 1.10.0
+
+    # Images needed by IUF
+    cray-product-catalog-update:
+      - 1.8.2
+    cray-nexus-setup:
+      - 0.9.0


### PR DESCRIPTION
The following images need to be present in Nexus for IUF to be functional.

## Summary and Scope

This commit adds two new container images to the CSM manifest.

## Issues and Related PRs

* Resolves CASM-3710 and CASM-3758

## Testing

### Test description:

Tested by building CSM.

## Risks and Mitigations

This should be relatively low risk as it is adding new images but not changing versions of any existing images.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable