### PR TITLE
CASMINST-5816: cf-gitea-import 1.8.0 to 1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+
+- Add cf-gitea-import 1.8.0 (CASMINST-5816)
 - Add cfs-ara 1.0.0 to the manifest (CASMCMS-7690)
 - Release csm-testing v1.15.27, Log test duration in decimal without scientific notation (CASMINST-5793)
 - Release cray-nls 0.4.41 to include functionality for storage rebuild workflow (CASMINST-5745)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -56,6 +56,9 @@ artifactory.algol60.net/csm-docker/stable:
     cf-gitea-update:
       - 1.0.0
 
+    cf-gitea-import:
+      - 1.8.0
+
     cray-capmc:
       - 2.7.0
 


### PR DESCRIPTION
## Summary and Scope

Adding cf-gitea-import 1.8.0 to 1.4 docker index.yaml

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5816](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5816)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Frigg`
 
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

