### PR TITLE
CASMMON-256, CASM-3815 & CASM-3816  Create timing dashboard, grok-exporter config and IUF timing execution time changes.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.11
+    version: 0.26.12
     namespace: sysmgmt-health
     values:
       prometheus-operator:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.7
+    version: 0.26.11
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope
_Timing dashboard for monitoring to record timing data for each stage in the install/upgrade of Shasta products._

_Changes in grok exporter configuration as goss tests logs format is changed. We do not want to use scientific notation as the calculation is wrong on Grafana. Hence, when logging test duration is changed to seconds._

_Calculation of execution time for IUF product and IUF stage using the difference of maximum and minimum of operation end and operation start respectively instead of sum in IUF timing dashboard._

_Change is a backward-compatible bugfix._

## Issues and Related PRs
Resolves 
[CASMMON-256](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-256)
[CASM-3815](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3815)
[CASM-3816](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3816)

## Testing
### Tested on:
  * `frigg`
  * Local development environment
  * Virtual Shasta

### Test description:
Tested and success verified.

![image](https://user-images.githubusercontent.com/110656037/215101870-8c268550-d481-4087-942b-4387ae266acf.png)
![image](https://user-images.githubusercontent.com/110656037/215101950-27acbf76-274e-4b65-bdc5-d1ea9dd354a0.png)


## Pull Request Checklist
- [x] Version number(s) incremented, if applicable
- [x] Testing is appropriate and complete, if applicable