### PR TITLE
CASMSEC-375: Remove opa-gatekeeper for CSM upgrade support (for Alice…

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -60,6 +60,13 @@ sleep 10
 undeploy cray-ceph-csi-rbd
 undeploy cray-ceph-csi-cephfs
 
+echo "Removing opa gatekeeper charts."
+
+undeploy -n gatekeeper-system gatekeeper-policy-manager
+undeploy -n gatekeeper-system gatekeeper-constraints
+undeploy -n gatekeeper-system gatekeeper-policy-library
+undeploy -n gatekeeper-system gatekeeper
+
 # Deploy services critical for Nexus to run
 echo "Deploying new ceph csi provisioners"
 deploy "${BUILDDIR}/manifests/storage.yaml"


### PR DESCRIPTION
## Summary and Scope

Remove opa-gatekeeper for CSM upgrade support (for Alice) by Jan 31 2023

## Issues and Related PRs

https://github.com/Cray-HPE/csm/pull/1614/files
https://github.com/Cray-HPE/cray-drydock/pull/31/files
https://github.com/Cray-HPE/cray-drydock/pull/32/files

## Testing

```
ncn-m001:/tmp/pradeep # helm list -n gatekeeper-system
NAME                            NAMESPACE               REVISION        UPDATED                                 STATUS       CHART                            APP VERSION
gatekeeper                      gatekeeper-system       1               2023-01-20 07:39:32.849377453 +0000 UTC deployed     gatekeeper-1.5.3                 v3.1.1
gatekeeper-constraints          gatekeeper-system       1               2023-01-20 07:41:16.204372356 +0000 UTC deployed     gatekeeper-constraints-0.5.0     1.16.0
gatekeeper-policy-library       gatekeeper-system       1               2023-01-20 07:40:25.719088453 +0000 UTC deployed     gatekeeper-policy-library-0.5.0  1.16.0
gatekeeper-policy-manager       gatekeeper-system       1               2023-01-20 07:41:27.021058894 +0000 UTC deployed     gatekeeper-policy-manager-1.3.0  0.4.0

ncn-m001:/tmp/pradeep # cat undeploy.sh
#!/usr/bin/env bash

# Copyright 2021 Hewlett Packard Enterprise Development LP


# Undeploy the chart if it exists on the system.
# Use this if a chart has been removed from a manifest and needs
# to be removed from the system as part of an upgrade.
function undeploy() {
    # If the chart is missing (rc==1) just return success.
    helm status "$@" || return 0
    # Remove the chart.
    helm uninstall "$@"
}

undeploy -n gatekeeper-system gatekeeper-policy-manager
undeploy -n gatekeeper-system gatekeeper-constraints
undeploy -n gatekeeper-system gatekeeper-policy-library
undeploy -n gatekeeper-system gatekeeper
ncn-m001:/tmp/pradeep #

ncn-m001:/tmp/pradeep # ./undeploy.sh
NAME: gatekeeper-policy-manager
LAST DEPLOYED: Fri Jan 20 07:41:27 2023
NAMESPACE: gatekeeper-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Gatekeeper Policy Manager can be accessed from a Web Browser as below:
1. URL : https://opa-gpm.<external DNS of the system>
   Ex. https://opa-gpm.vshasta.io/
2. Forward communication on Port 8080 and access GPM from browser using that port
release "gatekeeper-policy-manager" uninstalled
NAME: gatekeeper-constraints
LAST DEPLOYED: Fri Jan 20 07:41:16 2023
NAMESPACE: gatekeeper-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
release "gatekeeper-constraints" uninstalled
NAME: gatekeeper-policy-library
LAST DEPLOYED: Fri Jan 20 07:40:25 2023
NAMESPACE: gatekeeper-system
STATUS: deployed
REVISION: 1
release "gatekeeper-policy-library" uninstalled
NAME: gatekeeper
LAST DEPLOYED: Fri Jan 20 07:39:32 2023
NAMESPACE: gatekeeper-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
W0120 07:42:16.733164  651076 warnings.go:70] admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
release "gatekeeper" uninstalled

ncn-m001:/tmp/pradeep # helm list -n gatekeeper-system
NAME    NAMESPACE       REVISION        UPDATED STATUS  CHART   APP VERSION
ncn-m001:/tmp/pradeep #
```

### Tested on:

drax

###Test description

Above code snippet is tested and integrated into the file "upgrade.sh" with logs.