### PR TITLE
CAMSEC-376: Get upstream K8s policies running via kyverno in audit mo…

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -90,6 +90,10 @@ spec:
     source: csm-algol60
     version: 1.2.0
     namespace: kyverno
+  - name: cray-kyverno-policies-upstream
+    source: csm-algol60
+    version: 1.0.0
+    namespace: kyverno
   - name: cray-psp
     source: csm-algol60
     version: 0.4.1


### PR DESCRIPTION
## Summary and Scope

manifest changes for kyverno upstream policies.

## Testing

```
ncn-m001:/tmp/pradeep/jan20/prereq_test # helm list -n kyverno
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                APP VERSION
cray-kyverno    kyverno         6               2022-09-23 07:25:22.13837338 +0000 UTC  deployed        cray-kyverno-1.2.0   v1.6.2
kyverno-policy  kyverno         2               2022-09-15 18:13:55.296523586 +0000 UTC deployed        kyverno-policy-1.2.0 v1.6.0
ncn-m001:/tmp/pradeep/jan20/prereq_test # wget https://artifactory.algol60.net/artifactory/csm-helm-charts/stable/cray-kyverno-policies-upstream/cray-kyverno-policies-upstream-1.0.0.tgz
--2023-01-20 15:21:06--  https://artifactory.algol60.net/artifactory/csm-helm-charts/stable/cray-kyverno-policies-upstream/cray-kyverno-policies-upstream-1.0.0.tgz
Resolving artifactory.algol60.net (artifactory.algol60.net)... 34.120.105.219
Connecting to artifactory.algol60.net (artifactory.algol60.net)|34.120.105.219|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9704 (9.5K) [application/x-gzip]
Saving to: ‘cray-kyverno-policies-upstream-1.0.0.tgz’

cray-kyverno-policies-upstream- 100%[=====================================================>]   9.48K  --.-KB/s    in 0.001s

2023-01-20 15:21:07 (17.4 MB/s) - ‘cray-kyverno-policies-upstream-1.0.0.tgz’ saved [9704/9704]

ncn-m001:/tmp/pradeep/jan20/prereq_test # ls -ltr
total 12
-rw-r--r-- 1 root root 9704 Jan 20 13:10 cray-kyverno-policies-upstream-1.0.0.tgz
ncn-m001:/tmp/pradeep/jan20/prereq_test # kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
ncn-m001:/tmp/pradeep/jan20/prereq_test # ls -lr
total 92
-rw-r--r-- 1 root root 79456 Jan 20 15:21 customizations.yaml
-rw-r--r-- 1 root root  9704 Jan 20 13:10 cray-kyverno-policies-upstream-1.0.0.tgz
ncn-m001:/tmp/pradeep/jan20/prereq_test # cp ../kyverno.yaml .
ncn-m001:/tmp/pradeep/jan20/prereq_test # cat kyverno.yaml
apiVersion: manifests/v1beta1

metadata:

name: cray-kyverno-policies-upstream

spec:

charts:

- name: cray-kyverno-policies-upstream

   namespace: kyverno

   source: csm

   version: 1.0.0

ncn-m001:/tmp/pradeep/jan20/prereq_test # loftsman ship --charts-path . --manifest-path kyverno.yaml                          2023-01-20T15:22:14Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-01-20T15:22:15Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-01-20T15:22:15Z INF Ensuring that the loftsman namespace exists command=ship
2023-01-20T15:22:15Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2023-01-20T15:22:15Z INF Running a release for the provided manifest at kyverno.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-kyverno-policies-upstream v1.0.0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-01-20T15:22:15Z INF Running helm install/upgrade with arguments: upgrade --install cray-kyverno-policies-upstream cray-kyverno-policies-upstream-1.0.0.tgz --namespace kyverno --create-namespace --set global.chart.name=cray-kyverno-policies-upstream --set global.chart.version=1.0.0 chart=cray-kyverno-policies-upstream command=ship namespace=kyverno version=1.0.0
2023-01-20T15:22:16Z INF Release "cray-kyverno-policies-upstream" does not exist. Installing it now.
NAME: cray-kyverno-policies-upstream
LAST DEPLOYED: Fri Jan 20 15:22:15 2023
NAMESPACE: kyverno
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing cray-kyverno-policies-upstream 1.0.0 😀

We have installed the collection of policies that implement the various levels of Kubernetes Pod Security Standards.

Visit https://kyverno.io/policies/ to find more sample policies.
chart=cray-kyverno-policies-upstream command=ship namespace=kyverno version=1.0.0
2023-01-20T15:22:16Z INF Ship status: success. Recording status, manifest to configmap loftsman-cray-kyverno-policies-upstream in namespace loftsman command=ship
2023-01-20T15:22:16Z INF Recording log data to configmap loftsman-cray-kyverno-policies-upstream-ship-log in namespace loftsman command=ship
ncn-m001:/tmp/pradeep/jan20/prereq_test # helm list -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                 APP VERSION
cray-kyverno                    kyverno         6               2022-09-23 07:25:22.13837338 +0000 UTC  deployed        cray-kyverno-1.2.0                    v1.6.2
cray-kyverno-policies-upstream  kyverno         1               2023-01-20 15:22:15.749052457 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0  v1.6.2
kyverno-policy                  kyverno         2               2022-09-15 18:13:55.296523586 +0000 UTC deployed        kyverno-policy-1.2.0                  v1.6.0
ncn-m001:/tmp/pradeep/jan20/prereq_test # kubectl get clusterpolicy
NAME                             BACKGROUND   ACTION   READY
disallow-capabilities            true         audit
disallow-host-namespaces         true         audit    true
disallow-host-path               true         audit
disallow-host-ports              true         audit    true
disallow-host-process            true         audit    true
disallow-privileged-containers   true         audit    true
disallow-proc-mount              true         audit    true
disallow-selinux                 true         audit
restrict-apparmor-profiles       true         audit    true
restrict-seccomp                 true         audit    true
restrict-sysctls                 true         audit
ncn-m001:/tmp/pradeep/jan20/prereq_test # kubectl get polr -A
NAMESPACE           NAME                        PASS   FAIL   WARN   ERROR   SKIP   AGE
argo                polr-ns-argo                11     0      0      0       0      123d
cdelatte            polr-ns-cdelatte            0      0      0      0       0      66d
ceph-cephfs         polr-ns-ceph-cephfs         4      0      0      0       0      126d
ceph-rbd            polr-ns-ceph-rbd            4      0      0      0       0      126d
cert-manager-init   polr-ns-cert-manager-init   0      0      0      0       0      126d
cert-manager        polr-ns-cert-manager        3      0      0      0       0      126d
default             polr-ns-default             1      0      0      0       0      118d
gatekeeper-system   polr-ns-gatekeeper-system   5      0      0      0       0      126d
hnc-system          polr-ns-hnc-system          1      0      0      0       0      126d
ims                 polr-ns-ims                 10     0      0      0       0      114d
istio-operator      polr-ns-istio-operator      1      0      0      0       0      121d
istio-system        polr-ns-istio-system        6      0      0      0       0      126d
kyverno             polr-ns-kyverno             1      0      0      0       0      121d
metallb-system      polr-ns-metallb-system      5      0      0      0       0      126d
nexus               polr-ns-nexus               4      0      0      0       0      126d
opa                 polr-ns-opa                 4      0      0      0       0      126d
operators           polr-ns-operators           7      0      0      0       0      126d
pki-operator        polr-ns-pki-operator        1      0      0      0       0      121d
services            polr-ns-services            483    3      0      0       0      126d
sma                 polr-ns-sma                 92     0      0      0       0      121d
spire               polr-ns-spire               28     0      0      0       0      126d
sysmgmt-health      polr-ns-sysmgmt-health      34     0      0      0       0      126d
tapms-operator      polr-ns-tapms-operator      1      0      0      0       0      121d
user                polr-ns-user                1      0      0      0       0      126d
vault               polr-ns-vault               5      0      0      0       0      126d
velero              polr-ns-velero              4      0      0      0       0      126d
ncn-m001:/tmp/pradeep/jan20/prereq_test # helm delete cray-kyverno-policies-upstream -n kyverno                               release "cray-kyverno-policies-upstream" uninstalled
ncn-m001:/tmp/pradeep/jan20/prereq_test # helm list -n kyverno
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                APP VERSION
cray-kyverno    kyverno         6               2022-09-23 07:25:22.13837338 +0000 UTC  deployed        cray-kyverno-1.2.0   v1.6.2
kyverno-policy  kyverno         2               2022-09-15 18:13:55.296523586 +0000 UTC deployed        kyverno-policy-1.2.0 v1.6.0
ncn-m001:/tmp/pradeep/jan20/prereq_test #
```

### Tested on:

MUG

### Test description:

Installed on mug using loftsman and verified for baseline policies.