### PR TITLE
CASMSEC-375: Remove opa-gatekeeper for CSM upgrade support (for Alice)

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -60,6 +60,13 @@ sleep 10
 undeploy cray-ceph-csi-rbd
 undeploy cray-ceph-csi-cephfs
 
+echo "Removing opa gatekeeper charts."
+
+undeploy -n gatekeeper-system gatekeeper-policy-manager
+undeploy -n gatekeeper-system gatekeeper-constraints
+undeploy -n gatekeeper-system gatekeeper-policy-library
+undeploy -n gatekeeper-system gatekeeper
+
 # Deploy services critical for Nexus to run
 echo "Deploying new ceph csi provisioners"
 deploy "${BUILDDIR}/manifests/storage.yaml"


### PR DESCRIPTION
undeploy code added for removing all gatekeeper charts.

Submitting the changes for main branch. Already, submitted the changes to release 1.4 with test logs.

https://github.com/Cray-HPE/csm/pull/1660
https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-375