### PR TITLE
CASMHMS-5872 Pull in new version of REDS that does not depend on ETCD

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -31,7 +31,7 @@ spec:
     namespace: services
   - name: cray-hms-reds
     source: csm-algol60
-    version: 2.1.3
+    version: 3.0.0
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in new version of REDS that does not depend on ETCD anymore.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5872](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5872)


## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Mug


### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes 
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? Yes
For testing see: https://github.com/Cray-HPE/hms-reds/pull/35

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

