### PR TITLE
CASMPET-6193 Bump spire to 2.12.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -183,7 +183,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.11.0
+    version: 2.12.0
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This adds new paths to allow the migration of spire-agent binaries from /usr/bin to /opt/cray/cray-spire.

## Issues and Related PRs

* Resolves [CASMPET-6193](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6193)
* https://github.com/Cray-HPE/cray-spire/pull/56

## Testing

### Tested on:

  * Local development environment

### Test description:

These changes were cherry picked from the master branch.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This needs additional testing on bare metal machines to validate that the changes work with SKERN changes.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
