### PR TITLE
CASMINST-5823: Fix PCS ETCD image dependency CSM 1.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,7 +72,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.0.0
+    version: 1.1.0
     namespace: services
 
   # CMS

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,7 +72,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.1.0
+    version: 1.0.1
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

Update the PCS chart for CASMINST-5823 to fix PCS ETCD image dependency.

## Issues and Related PRs

* Resolves [CASMINST-5823](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5823)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control-charts/pull/8

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

