### PR TITLE
Casmmon 250

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -30,6 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - loftsman-1.2.0-1.x86_64
+    - pit-observability-1.0.1-1.x86_64
     - platform-utils-1.4.3-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -30,7 +30,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - loftsman-1.2.0-1.x86_64
-    - pit-observability-1.0.1-1.x86_64
     - platform-utils-1.4.3-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -28,3 +28,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - craycli-0.65.0-1.x86_64
     - csm-testing-1.15.23-1.noarch
     - goss-servers-1.15.23-1.noarch
+    - pit-observability-1.0.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,6 +38,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.13-1.noarch
-    - pit-observability-1.0.1-1.x86_64
     - pit-init-1.2.37-1.noarch
     - pit-nexus-1.2.1-1.x86_64
+    - pit-observability-1.0.6-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,5 +38,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.13-1.noarch
+    - pit-observability-1.0.1-1.x86_64
     - pit-init-1.2.37-1.noarch
     - pit-nexus-1.2.1-1.x86_64


### PR DESCRIPTION
CASMMON-250: Failed to start prometheus operator with pit-init

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-250

## Testing

_List the environments in which these changes were tested._

### Tested on:
redbull-pit

### Test description:

#### Containers

redbull-ncn-m001-pit: # podman ps
CONTAINER ID  IMAGE                                                                                   COMMAND               CREATED        STATUS             PORTS       NAMES
28aa25485756  artifactory.algol60.net/csm-docker/stable/docker.io/grafana/grafana:8.5.9                                     14 hours ago   Up 15 minutes ago              grafana
ce678ff652a4  artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest  ./grok_exporter -...  4 minutes ago  Up 2 minutes ago               grok-exporter
a421fc8840a2  artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/prometheus:v2.36.1         --config.file=/et...  4 minutes ago  Up 2 minutes ago               prometheus


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

