### PR TITLE
CASMPET-6079: Update keycloak to version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-keycloak to 4.0.0 (CASMPET-6079)
 - Add cfs-ara 1.0.0 to the manifest (CASMCMS-7690)
 - Release cray-postgres-operator 1.8.3 to pull in post-upgrade and post-install jobs
 - Release csm-testing v1.16.2, Log test duration in decimal without scientific notation (CASMINST-5793)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 3.6.1
+    version: 4.0.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This change updated the cray-keycloak chart to version 4.0.0 which updates the image to version 16.1.1 from image version 9.0.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6079](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6079)
* Documentation changes required in [CASMPET-6232](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6232)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Surtur for upgrade/downgrade
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

The only risk is with downgrade and minor api calls which will be documented. The issue is keycloak does not create a client secret on creation of a client anymore so a post call to the client secret will create it if its not already created. The downgrade risk is the downgrade steps required a restore of the keycloak-postgress database to the previous version.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

