### PR TITLE
CASMHMS-5897 Add PCS to run_hms_ct_tests.sh script Main

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.2-1.noarch
     - docs-csm-1.6.2-1.noarch
     - goss-servers-1.16.2-1.noarch
-    - hpe-csm-scripts-0.4.3-1.noarch
+    - hpe-csm-scripts-0.4.4-1.noarch
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.14-1.noarch


### PR DESCRIPTION
## Summary and Scope

This change adds PCS to the run_hms_ct_tests.sh script so that PCS tests are executed during the HMS section of the CSM health validation steps.

## Issues and Related PRs

* Resolves CASMHMS-5897 in Main.

## Testing

### Tested on:

* Wasp running CSM 1.4.0-beta.36

### Test description:

Ran the updated run_hms_ct_tests.sh script. Verified that the new PCS tests executed along with all of the other HMS tests and that the results were processed successfully. Also verified that run_hms_ct_tests.sh could execute only the PCS tests if desired.

## Risks and Mitigations

Low risk, impacts HMS testing only.