### PR TITLE
CASMINST-5838: Use CMN for Keycloak access, use DNS query vs. ping for test

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.15.27-1.noarch
+    - csm-testing-1.15.28-1.noarch
     - docs-csm-1.4.50-1.noarch
-    - goss-servers-1.15.27-1.noarch
+    - goss-servers-1.15.28-1.noarch
     - hpe-csm-scripts-0.4.3-1.noarch
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Update `goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml` in csm-testing to use CMN for keycloak admin access, use DNS query vs. ping for test. 

Verified RPMs were published into proper artifactory location.

See https://github.com/Cray-HPE/csm-testing/pull/429 for details. 



