### PR TITLE
CASMCMS-8385: Update cfs-operator for memory limit fix (1.4)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -82,7 +82,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.0
+    version: 1.17.1
     namespace: services
   - name: cray-cfs-api
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Pulls in an updated cfs-operator that increases the memory limit and improves recovery after the pod goes down.

## Issues and Related PRs

* Resolves CASMCMS-8384
* Resolves CASMCMS-8385

## Testing
### Tested on:

  * Mug

### Test description:

Tested stressing the cfs-operator by scaling it down, creating a backlog of events and then scaling it back up.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

