### PR TITLE
CASMTRIAGE-4857 Bump spire to 2.21.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -187,7 +187,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.12.0
+    version: 2.12.1
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

The latest version of the spire-agent RPM locks down the /var/lib/spire/conf directory, breaking the request-ncn-join-token pod. This fixes the issue, allowing NCNs to be joined to spire.


## Issues and Related PRs

* Resolves [CASMTRIAGE-4857](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4857)
* https://github.com/Cray-HPE/cray-spire/pull/57

## Testing

### Tested on:

  * fanta

### Test description:

validated new chart fixed the issue and that NCNs were properly joined to spire.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
