### PR TITLE
CASMPET-6280 ChCat : Add rbac "delete pods" for cray-postgres-operator inject-secret job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Release cray-postgres-operator 1.8.4 minor bug fixes
+- Release cray-postgres-operator 1.8.5 minor bug fixes
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)
 - Update cray-keycloak to 4.0.0 (CASMPET-6079)
 - Add cfs-ara 1.0.0 to the manifest (CASMCMS-7690)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -184,7 +184,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.8.4
+    version: 1.8.5
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Adds "delete pods" to rbac for the cray-postgres-operator-jobs serviceAccount used to inject secrets.
Also removed "hook-succeeded", added TTL of 24hr and removed ">/dev/null >2&1" to provide more info.

## Issues and Related PRs

* Resolves [CASMPET-6280](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6280)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

  * vshasta v2 - dorian
  
### Test description:

* Verified that the job succeeded
```
# kubectl logs cray-postgres-operator-inject-secret-c2tsh -n services
Inject postgres-backup-s3-credentials secret into operatorconfiguration...
operatorconfiguration.acid.zalan.do/cray-postgres-operator patched
operatorconfiguration.acid.zalan.do/cray-postgres-operator patched
Restart the cray-postgres-operator...
pod "cray-postgres-operator-7b456b7449-gr52m" deleted
Delete any logical backup cronjobs so postgres-operator can recreate them on next sync with updated secrets...
Done!
```

* Verified that the cray-postgres-operator pod was successfully restarted by the helm post-upgrade job

```
# kubectl get pods -A | grep postgres-oper
services         cray-postgres-operator-7b456b7449-xbfgr                           2/2     Running     0          85s
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Very low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

