### PR TITLE
CRAYSAT-1661: Bump SAT image version to 3.21.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.20.0
+      - 3.21.1
 
 artifactory.algol60.net/csm-docker/stable:
   images:
@@ -161,7 +161,7 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.12.4
     quay.io/cilium/operator-generic:
       - v1.12.4
-    
+
     # Cilium images needed for connectivity testing
     quay.io/cilium/alpine-curl:
       - v1.6.0

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.20.0"
+sat_version="3.21.1"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope
Bump SAT image version to 3.21.1.

## Issues and Related PRs

* Resolves [CRAYSAT-1661](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1661)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

