### PR TITLE
CASMINST-5850:  Bump csm-testing and goss-servers to 1.15.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)
 - Update cray-keycloak to 4.0.0 (CASMPET-6079)
 - Updating cf-gitea-update to 1.0.2 (CASMINST-5814)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,10 +33,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.15.28-1.noarch
+    - csm-testing-1.15.29-1.noarch
     - docs-csm-1.4.53-1.noarch
     - hpe-csm-scripts-0.4.4-1.noarch
-    - goss-servers-1.15.28-1.noarch
+    - goss-servers-1.15.29-1.noarch
     - iuf-cli-1.0.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Release csm-testing 1.15.29.  Make check_static_routes.sh handle undefined RVR networks and also test MTN networks

## Issues and Related PRs

* Resolves [CASMINST-5850](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5850)

## Testing

### Tested on:

  * `baldar` and `surtur`

### Test description:

Ran the test on balder where there are MTN networks and no RVR networks:

```
ncn-m002:~ # /opt/cray/tests/install/ncn/scripts/check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.102.98.1 dev bond0.cmn0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.36.0.0 
10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 linkdown 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.100.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.102.98.0/25 dev bond0.cmn0 proto kernel scope link src 10.102.98.20 
10.102.98.128/25 dev bond0.can0 proto kernel scope link src 10.102.98.134 
10.104.0.0/22 via 10.254.0.1 dev bond0.hmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.5 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.6 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMN_RVR network does not exist in SLS
INFO: NMN_MTN CIDR is 10.100.0.0/22 - route found = true
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMN_RVR network does not exist in SLS
INFO: HMN_MTN CIDR is 10.104.0.0/22 - route found = true
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
PASS
```

Ran on surtur where there are RVR networks and no MTN networks.

```
ncn-m001:~/johren # ./check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.100.254.1 dev lan0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.32.0.1 
10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.100.254.0/24 dev lan0 proto kernel scope link src 10.100.254.78 
10.103.11.0/25 dev bond0.cmn0 proto kernel scope link src 10.103.11.27 
10.103.11.128/26 dev bond0.can0 proto kernel scope link src 10.103.11.141 
10.106.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.107.0.0/22 via 10.254.0.1 dev bond0.hmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.12 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.20 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMN_RVR CIDR is 10.106.0.0/22 - route found = true
INFO: NMN_MTN network does not exist in SLS
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMN_RVR CIDR is 10.107.0.0/22 - route found = true
INFO: HMN_MTN network does not exist in SLS
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
PASS
```

Removed one of the static routes temporarily on surtur and verified that the test fails.
```
ncn-m001:~/johren # ./check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.100.254.1 dev lan0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.32.0.1 
10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.100.254.0/24 dev lan0 proto kernel scope link src 10.100.254.78 
10.103.11.0/25 dev bond0.cmn0 proto kernel scope link src 10.103.11.27 
10.103.11.128/26 dev bond0.can0 proto kernel scope link src 10.103.11.141 
10.106.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.12 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.20 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMN_RVR CIDR is 10.106.0.0/22 - route found = true
INFO: NMN_MTN network does not exist in SLS
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMN_RVR CIDR is 10.107.0.0/22 - route found = false
INFO: HMN_MTN network does not exist in SLS
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
FAIL
```


