### PR TITLE
CASMTRIAGE-4866: Restore 'namespace' field to cray-console-data chart manifest entry

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -80,7 +80,7 @@ spec:
   - name: cfs-ara
     source: csm-algol60
     version: 1.0.1
-    namespace: services  
+    namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
     version: 1.9.0
@@ -113,6 +113,7 @@ spec:
   - name: cray-console-data
     source: csm-algol60
     version: 1.6.2
+    namespace: services
   - name: cray-console-node
     source: csm-algol60
     version: 1.7.1
@@ -139,7 +140,7 @@ spec:
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3
-    namespace: services    
+    namespace: services
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.2
@@ -167,13 +168,14 @@ spec:
     namespace: services
     values:
       keycloakImage:
-        tag: 3.6.1	
+        tag: 3.6.1
 
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
     version: 1.3.1
     namespace: services
+
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

When the sysmgmt.yaml manifests were edited in [CASMCMS-8353](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8353), the `namespace` field was accidentally removed from the `cray-console-data` entry. This PR restores it (and also fixes a few other small formatting issues that may or may not have caused problem for CSM installs, but definitely broke Python YAML's ability to load the file).

## Issues and Related PRs

* Resolves [CASMTRIAGE-4866](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4866) and [CASMINST-5871](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5871)
* Caused accidentally by [CASMCMS-8353](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8353)
* [main backport PR](https://github.com/Cray-HPE/csm/pull/1720) -- I verified that this is needed for main but not needed for release/1.3

## Testing

No testing myself, but @erl-hpe did note that adding the `namespace` field to the manifest allowed his vshasta install to proceed, indicating that this should fix the problem being reported.

## Risks and Mitigations

Very low risk, especially since the manifest is currently broken anyway.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
