### PR TITLE
CASMTRIAGE-4866: Restore 'namespace' field to cray-console-data chart manifest entry

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
   - name: cfs-ara
     source: csm-algol60
     version: 1.0.1
-    namespace: services  
+    namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
     version: 1.9.0
@@ -108,6 +108,7 @@ spec:
   - name: cray-console-data
     source: csm-algol60
     version: 1.6.2
+    namespace: services
   - name: cray-console-node
     source: csm-algol60
     version: 1.7.1
@@ -134,7 +135,7 @@ spec:
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3
-    namespace: services    
+    namespace: services
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.2
@@ -162,13 +163,14 @@ spec:
     namespace: services
     values:
       keycloakImage:
-        tag: 3.6.1	
+        tag: 3.6.1
 
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
     version: 1.3.1
     namespace: services
+
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60


### PR DESCRIPTION
(cherry picked from commit fe1d7c4424ac469fc989e985fc15b17d4ceda981)

main backport of https://github.com/Cray-HPE/csm/pull/1719