### PR TITLE
CASMINST-5866: Bumping cf-gitea-import to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)
 - Update cray-keycloak to 4.0.0 (CASMPET-6079)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -57,7 +57,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.0.2
 
     cf-gitea-import:
-      - 1.8.0
+      - 1.8.1
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Bumping container to 1.8.1 to account for IUF logging.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Backwards compatible.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5866)
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `frigg`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

