### PR TITLE
CASMPET-6238: Remove the cilium/json-mock container image for now

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -173,8 +173,9 @@ artifactory.algol60.net/csm-docker/stable:
     # Cilium images needed for connectivity testing
     quay.io/cilium/alpine-curl:
       - v1.6.0
-    quay.io/cilium/json-mock:
-      - v1.3.3
+    # Not pulling in json-mock until there is update to address some CVEs
+    # quay.io/cilium/json-mock:
+    #    - v1.3.3
     docker.io/coredns/coredns:
       - 1.10.0
 


### PR DESCRIPTION
## Summary and Scope

There are critical and high CVEs currently in the cilium/json-mock:v1.3.3 image.  That is the most recent tag for that image currently.   This image is only needed for running the connectivity test.   Since we are not turning on cilium support in 1.4, it is not needed.   Removing it from the build and we will watch for fixes for those CVEs.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6238](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6238)

## Testing

Testing not needed for this removal.  This image is not being used currently because cilium is not enabled in 1.4.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

