### PR TITLE
CASMCMS-8398: Remove CRUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Uninstall cray-crus when upgrading to CSM 1.6
+- Remove cray-crus chart (CRUS removed in CSM 1.6)
 - Release csm-testing v1.16.3, CASMINST-5850 and CASMINST-5819
 - Release cray-postgres-operator 1.8.5 minor bug fixes
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -119,10 +119,6 @@ spec:
     version: 1.6.1
     namespace: services
     timeout: 20m0s
-  - name: cray-crus
-    source: csm-algol60
-    version: 1.11.2
-    namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
     version: 1.7.1


### PR DESCRIPTION
## Summary and Scope

This PR removes CRUS from the charts manifest, since CRUS is being removed in CSM 1.6.

## Issues and Related PRs

* Part of the [CRUS removal](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396) epic.

## Testing

None. Not feasible to test outside of doing an install.

## Risks and Mitigations

Low risk -- on installs, it just means we won't install that chart, which is what we want.

For upgrades, there will be other tickets to handle making sure it gets removed when upgrading to 1.6.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
