### PR TITLE
CASMINST-5874: Update Goss tests for CRUS removal

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.16.3-1.noarch
+    - csm-testing-1.16.4-1.noarch
     - docs-csm-1.6.4-1.noarch
-    - goss-servers-1.16.3-1.noarch
+    - goss-servers-1.16.4-1.noarch
     - hpe-csm-scripts-0.4.5-1.noarch
     - iuf-cli-1.0.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Update Goss tests to version modified to handle removed CRUS service.

See [source PR](https://github.com/Cray-HPE/csm-testing/pull/434) for details.

## Issues and Related PRs

* Part of the [CRUS removal](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396) epic.
* [csm-rpms PR](https://github.com/Cray-HPE/csm-rpms/pull/726)

## Testing

None (change is extremely tiny and simple).

## Risks and Mitigations

Without this change, the Goss test in question will fail after CRUS is gone.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
