### PR TITLE
CRAYSAT-1666: (IUF) Update version of cray-nls

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.45
+    version: 1.4.47
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Version 1.4.47 of cray-nls uses the updated cray-nls container image which includes the latest sat-general template using SAT 3.21.1, the version currently needed by IUF.

## Issues and Related PRs

CRAYSAT-1666

## Testing

Test Description: verified helm chart has been published.

## Risks and Mitigations

This is a low-risk manifest change, the contents of which have already been tested.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

