### PR TITLE
CASMINST-5875: Remove CRUS during upgrade to CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Uninstall cray-crus when upgrading to CSM 1.6
 - Release csm-testing v1.16.3, CASMINST-5850 and CASMINST-5819
 - Release cray-postgres-operator 1.8.5 minor bug fixes
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021,2023 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 
@@ -51,6 +51,9 @@ function unbound_psp_check() {
     fi
     echo "cray-unbound-coredns-psp check Done"
 }
+
+# CRUS is removed in CSM 1.6, and should be removed during the upgrade, if it exists
+undeploy -n services cray-crus
 
 # Ceph CSI upgrade will require an outage to remove the deployments to move them to namespaces from the default namespace.
 


### PR DESCRIPTION
## Summary and Scope

Modify the upgrade script so that it removes the cray-crus chart, if it is installed.

## Issues and Related PRs

* Part of the [CRUS removal](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396) epic.

## Testing

Manually tested the removal on mug.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
