### PR TITLE
CASMCMS-8397: Remove CRUS tests from cmsdev tool

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
     - craycli-0.67.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Update to cmsdev tool which does not include the CRUS service tests.

## Issues and Related PRs

* Part of the [CRUS removal](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396) epic.
* [csm-rpms PR](https://github.com/Cray-HPE/csm-rpms/pull/727)

## Testing

Test on mug to verify that all other test content remained unchanged.

## Risks and Mitigations

Without this change, cmsdev will fail during CSM health checks due to CRUS not being there.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

