### PR TITLE
CASMCMS-8398/CASMINST-5874/CASMCMS-8397: CRUS removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Uninstall cray-crus when upgrading to CSM 1.6
+- Remove cray-crus chart (CRUS removed in CSM 1.6)
 - Release csm-testing v1.16.3, CASMINST-5850 and CASMINST-5819
 - Release cray-postgres-operator 1.8.5 minor bug fixes
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -119,10 +119,6 @@ spec:
     version: 1.6.1
     namespace: services
     timeout: 20m0s
-  - name: cray-crus
-    source: csm-algol60
-    version: 1.11.2
-    namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
     version: 1.7.1

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
     - craycli-0.67.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.16.3-1.noarch
+    - csm-testing-1.16.4-1.noarch
     - docs-csm-1.6.4-1.noarch
-    - goss-servers-1.16.3-1.noarch
+    - goss-servers-1.16.4-1.noarch
     - hpe-csm-scripts-0.4.5-1.noarch
     - iuf-cli-1.0.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

* Removes CRUS from the charts manifest
* Update Goss tests to version modified to handle removed CRUS service.
* Update to cmsdev tool which does not include the CRUS service tests.

## Issues and Related PRs

* Part of the [CRUS removal](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396) epic.
* [csm-rpms PR](https://github.com/Cray-HPE/csm-rpms/pull/728)

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
