### PR TITLE
CASMINST-5866: Backport 1.4 Bumping cf-gitea-import to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Uninstall cray-crus when upgrading to CSM 1.6
 - Release csm-testing v1.16.3, CASMINST-5850 and CASMINST-5819
 - Release cray-postgres-operator 1.8.5 minor bug fixes

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -51,6 +51,9 @@ artifactory.algol60.net/csm-docker/stable:
     hms-shcd-parser:
       - 1.8.0
 
+    cf-gitea-import:
+      - 1.8.1
+
     cray-capmc:
       - 2.7.0
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Backport PR from release/1.4 to main

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5866)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

