### PR TITLE
CASMINST-5845: Goss Test - use CMN for keycloak admin access, use DNS query vs. ping

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.16.3-1.noarch
+    - csm-testing-1.16.5-1.noarch
     - docs-csm-1.6.4-1.noarch
-    - goss-servers-1.16.3-1.noarch
+    - goss-servers-1.16.5-1.noarch
     - hpe-csm-scripts-0.4.5-1.noarch
     - iuf-cli-1.0.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Goss Test Update for `goss-k8s-resolve-external-dns.yaml`. 

Update load-balancer ingress path to use for Keycloak interaction, given the master realm admin auth is being requested. This as the CMN LB, specifically the auth.cmn.* ingress paths are now supported for master realm administration.

Use a DNS A record query instead of ping, this to address CAST-31571 as a tangent.

This should be backward compatible with all releases that included CMN.

## Issues and Related PRs

* Resolves [CASMINST-5845](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5845)
* Merge After: https://github.com/Cray-HPE/csm/pull/1734
* [sm-testing PR ](https://github.com/Cray-HPE/csm-testing/pull/430)](https://github.com/Cray-HPE/csm-testing/pull/430)

## Testing

### Tested on:

  * wasp running 1.4.0-beta.36, was forward ported from CSM 1.3.1 to 1.4.0, and main

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
