### PR TITLE
SCICD-578 Update iuf-cli version for release 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update iuf-cli to 1.4.0 (SCICD-578)
 - Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -37,7 +37,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - docs-csm-1.4.54-1.noarch
     - hpe-csm-scripts-0.4.5-1.noarch
     - goss-servers-1.15.29-1.noarch
-    - iuf-cli-1.0.0-1.x86_64
+    - iuf-cli-1.4.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.14-1.noarch


### PR DESCRIPTION
* Updated iuf-cli to 1.4.0 for initial release

## Summary and Scope

Need to update the stable version of the iuf-cli RPM

## Issues and Related PRs

* Resolves [SCICD-578](https://jira-pro.its.hpecorp.net:8443/browse/SCICD-578)

## Testing

jenkins

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ X] License file intact
- [X ] Target branch correct
- [ X] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

