### PR TITLE
CASMPET-5779: Update velero jump manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-velero 1.7.1 to 1.7.1-1 (CASMPET-5779)
 - Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 
 - Update craycli to 0.67.0, cray-cfs-api to 1.12.1 (CASMCMS-8380)

--- a/manifests/velero-1.7-upgrade.yaml
+++ b/manifests/velero-1.7-upgrade.yaml
@@ -33,6 +33,6 @@ spec:
   charts:
   - name: cray-velero
     source: csm-algol60
-    version: 1.7.1
+    version: 1.7.1-1
     namespace: velero
     


### PR DESCRIPTION
## Summary and Scope

This updates the cray-velero chart in the jump manifest to 1.7.1-1 which changes where the kubectl docker image is. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5779](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5779)
* Resolves [CASMPET-6237](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6237)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No change so no risk


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

