### PR TITLE
CASMPET-6228 ChCat : Update cray-keycloak to support cray-postgres-operator:1.8x changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-keycloak to 4.1.0 to use the upgraded postgres operator logical backup (CASMPET-6228)
 - Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Uninstall cray-crus when upgrading to CSM 1.6
 - Remove cray-crus chart (CRUS removed in CSM 1.6)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 4.0.0
+    version: 4.1.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Modify cray-keycloak :
* Enable the postgres-operator based logical backups to backup the cray-keycloak postgres cluster
* Remove the postgresql-backup CR that was used previously (home-grown postgresql backup solution)
* Add a post-upgrade helm hook job to remove the old cronjob that was created as part of the previous home-grown postgresql backup solution.

Without this change, the cray-keycloak postgresql backups would fails with the latest upgrade of the cray-postgres-operator - since it assumed psql v12 and with the upgraded postgres operator, psql v14 is used.

## Issues and Related PRs

* Resolves [CASMPET-6228](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6228)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * vshasta v2 - dorian
  
### Test description:
Upgrade cray-keycloak from 4.0.0

* Keycloak postgresql CR is Running
```
# kubectl get postgresql -A | grep keycloak
services    keycloak-postgres                   keycloak                   14        3      10Gi                                    11d    Running
```

* Keycloak postgresql CR looks good
```
# kubectl get postgresql keycloak-postgres -n services -o yaml
apiVersion: acid.zalan.do/v1
kind: postgresql
metadata:
  annotations:
    meta.helm.sh/release-name: cray-keycloak
    meta.helm.sh/release-namespace: services
  creationTimestamp: "2023-01-16T17:01:48Z"
  generation: 25
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: keycloak-postgres
  name: keycloak-postgres
  namespace: services
  resourceVersion: "15171876"
  uid: cfc784f7-81d6-4354-acfe-9cb9ec694b9d
spec:
  databases:
    service_db: service_account
  enableLogicalBackup: true
  logicalBackupSchedule: 10 2 * * *
  numberOfInstances: 3
  podPriorityClassName: csm-high-priority-service
  postgresql:
    version: "14"
  teamId: keycloak
  tls:
    secretName: keycloak-postgres-tls
  users:
    service_account: []
  volume:
    size: 10Gi
status:
  PostgresClusterStatus: Running
```

* Post-upgrade hook removed the old home-grown keycloak-postgresql-db-backup cronjob
```# kubectl get cronjobs -A | grep postgresql-db-backup
argo          cray-nls-postgresql-db-backup      10 23 * * *    False     0        16m             11d
services      cray-sls-postgresql-db-backup      10 23 * * *    False     0        16m             11d
services      cray-smd-postgresql-db-backup      10 0 * * *     False     0        23h             11d
services      gitea-vcs-postgresql-db-backup     10 1 * * *     False     0        22h             11d
spire         spire-postgresql-db-backup         10 3 * * *     False     0        20h             11d
pit:/tmp #
```

* Postgres operator creates the logical backup cronjob for the enabled service with the expected schedule
```
# kubectl get cronjobs -A | grep log
services      logical-backup-keycloak-postgres   10 2 * * *     False     0        83m             96m
```

* The AWS secrets from the operatorconfiguration were added to the cronjob as expected
```
# kubectl get cronjob logical-backup-keycloak-postgres -n services -o yaml | grep -i access -A1
            - name: AWS_ACCESS_KEY_ID
              value: GJNNYCS6HC8RNH5OQ861
            - name: AWS_SECRET_ACCESS_KEY
              value: PLqkKqULspVwfiNGjmjXa40nx9NaaKKAJB4F3XSD
 ```
 
* Logical backups run and succeed
```
# kubectl logs logical-backup-keycloak-postgres-27914260-cr456 -n services
IPv4
API Endpoint: [https://10.16.0.1:443/api/v1](https://10.16.0.1/api/v1)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 27047    0 27047    0     0  2641k      0 --:--:-- --:--:-- --:--:-- 2641k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 35530    0 35530    0     0  1119k      0 --:--:-- --:--:-- --:--:-- 1119k
+ dump
+ /usr/lib/postgresql/14/bin/pg_dumpall
+ compress
+ pigz
+ upload
+ case $LOGICAL_BACKUP_PROVIDER in
++ estimate_size
++ /usr/lib/postgresql/14/bin/psql -tqAc 'select sum(pg_database_size(datname)::numeric) from pg_database;'
+ aws_upload 7990951
+ declare -r EXPECTED_SIZE=7990951
++ date +%s
+ PATH_TO_BACKUP=s3://postgres-backup/spilo/keycloak-postgres/cfc784f7-81d6-4354-acfe-9cb9ec694b9d/logical_backups/1674855609.sql.gz
+ args=()
+ [[ ! -z 7990951 ]]
+ args+=("--expected-size=$EXPECTED_SIZE")
+ [[ ! -z http://rgw-vip.nmn/ ]]
+ args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
+ [[ ! -z '' ]]
+ [[ ! -z '' ]]
+ aws s3 cp - s3://postgres-backup/spilo/keycloak-postgres/cfc784f7-81d6-4354-acfe-9cb9ec694b9d/logical_backups/1674855609.sql.gz --expected-size=7990951 --endpoint-url=http://rgw-vip.nmn/
/usr/local/lib/python3.6/dist-packages/OpenSSL/crypto.py:8: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography and will be removed in a future release.
  from cryptography import utils, x509
+ aws_delete_outdated
+ [[ -z 2 days ]]
++ date -d '2 days ago' +%F
+ cutoff_date=2023-01-25
+ prefix=spilo/keycloak-postgres/cfc784f7-81d6-4354-acfe-9cb9ec694b9d/logical_backups/
+ args=("--no-paginate" "--output=text" "--prefix=$prefix" "--bucket=$LOGICAL_BACKUP_S3_BUCKET")
+ [[ ! -z http://rgw-vip.nmn/ ]]
+ args+=("--endpoint-url=$LOGICAL_BACKUP_S3_ENDPOINT")
+ [[ ! -z '' ]]
+ aws s3api list-objects --no-paginate --output=text --prefix=spilo/keycloak-postgres/cfc784f7-81d6-4354-acfe-9cb9ec694b9d/logical_backups/ --bucket=postgres-backup --endpoint-url=http://rgw-vip.nmn/ '--query=Contents[?LastModified<='\''2023-01-25'\''].[Key]'
/usr/local/lib/python3.6/dist-packages/OpenSSL/crypto.py:8: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography and will be removed in a future release.
  from cryptography import utils, x509
+ sed -i '$d' /tmp/outdated-backups
++ wc -l
+ count=0
+ [[ 0 == 0 ]]
+ echo 'no outdated backups to delete'
+ return 0
no outdated backups to delete
+ [[ 0 != 0 ]]
+ [[ 0 != 0 ]]
+ [[ 0 != 0 ]]
+ set +x
```

* Postgres backup exists in s3 under the expected spilo path
```
# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key' | grep "spilo/keycloak"
spilo/keycloak-postgres/cfc784f7-81d6-4354-acfe-9cb9ec694b9d/logical_backups/1673980830.sql.gz
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
