### PR TITLE
Bring in latest multus image for CVE remediation

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -92,11 +92,6 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/library/openjdk:
       - 11-jre-slim
 
-    # Multus required by platform
-    # XXX See also ghcr.io/k8snetworkplumbingwg/multus-cni below
-    docker.io/nfvpe/multus:
-      - v3.7
-
     # XXX Is this missing from cray-sysmgmt-health?
     docker.io/prom/pushgateway:
       - v0.8.0
@@ -120,6 +115,7 @@ artifactory.algol60.net/csm-docker/stable:
     # Multus required by platform
     ghcr.io/k8snetworkplumbingwg/multus-cni:
       - v3.9.1
+      - v3.9.3
 
     # CoreDNS required by platform
     # XXX See also docker.io/coredns/coredns:1.6.2 above

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -50,7 +50,7 @@ spec:
       # Kubernetes
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.1
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:v1.8.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.21.12
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.21.12


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5862

```
ncn-m001:~ # kubectl get po -n kube-system kube-multus-ds-rq822 -o yaml | grep image.*cni*
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
```

```
ncn-m001:~ # kubectl get po -A | grep multus
kube-system   kube-multus-ds-b69n8               1/1     Running   0          13m
kube-system   kube-multus-ds-c522m               1/1     Running   0          13m
kube-system   kube-multus-ds-csx4j               1/1     Running   0          13m
kube-system   kube-multus-ds-rq822               1/1     Running   0          13m
kube-system   kube-multus-ds-x7zrq               1/1     Running   0          13m
```

```
ncn-m001:~ # crictl images | grep multus
artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni            v3.9.1              fa00a8f836cb8       170MB
artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni            v3.9.3              5494352f99256       83.7MB
```
#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a craystack system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant environment (if yes, please include results or a description of the test)
 
### Idempotency
 
Yes
 
### Risks and Mitigations
 
Low