### PR TITLE
(CSM 1.4) CASMHMS-5911: Pull in newer cray-hms-hmcollector chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -60,7 +60,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.11
+    version: 2.16.0
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -301,6 +301,7 @@ spec:
           repo: shasta-firmware
       cray-hms-hmcollector:
         hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
+        hmcollector_external_hostname: 'hmcollector.hmnlb.{{ network.dns.external }}'
       cray-hms-meds:
         ntpserver_host: time-hmn:123
         ntpserver_host_use_ip: ""


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
CASMHMS-5911: Pull in newer cray-hms-hmcollector chart that adds `hmcollector.hmnlb.$SYSTEM_NAME.$SITE_DOMAIN` to the list of hosts for the collectors virtual service.

Also updated customizations.yaml to pass the value hmcollector_external_hostname to the collector helm chart to pass system specific hostname

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5911](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5911)


## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Mug

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

For collector testing see: https://github.com/Cray-HPE/hms-hmcollector-charts/pull/20





## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

