### PR TITLE
CASMCMS-8399: Remove CRUS from Cray CLI

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.67.0-1.x86_64
+    - craycli-0.70.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,4 +25,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-cmstools-crayctldeploy-1.11.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
-    - craycli-0.67.0-1.x86_64
+    - craycli-0.70.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Remove CRUS from the Cray CLI.

## Issues and Related PRs

* Part of the [remove CRUS from CSM 1.6 epic](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396).
* [csm-rpms manifest PR](https://github.com/Cray-HPE/csm/pull/1754)
