### PR TITLE
CASMINST-5879 PCS CT test updates for production systems CSM-1.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,7 +72,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: services
 
   # CMS


### PR DESCRIPTION
### Summary and Scope

This change updates the non-disruptive PCS CT tests for issues encountered in production environments vs. the runCT simulated environments in the build pipeline. The power-status test now avoids running against the CAN node since it has no ComponentEndpoint which is required to retrieve power-status. It also moves the power-status test cases for Chassis and ChassisBMC to the build pipeline bucket since these components aren't always guaranteed to be present in HSM in production environments.

### Issues and Related PRs

* Resolves CASMINST-5879 in CSM-1.4

### Testing

This change was tested by running the updated tests in the build pipeline, verifying that they passed, and that the Chassis and ChassisBMC power-status tests executed in the new test stage.

### Risks and Mitigations

Low risk.