### PR TITLE
CASMCMS-8301: Update craycli to 0.68.0 for new BOS fields

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.67.0-1.x86_64
+    - craycli-0.68.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,4 +25,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-cmstools-crayctldeploy-1.11.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
-    - craycli-0.67.0-1.x86_64
+    - craycli-0.68.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Updates the craycli to include the BOS clear-state option.  Also pulls in some linting changes.

## Issues and Related PR

* Resolves CASMCMS-8301

## Testing

See craycli PRs for testing info

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

