### PR TITLE
MTL-2071 Include the new `libCSM` framework

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -44,3 +44,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.2.43-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
+    - python3.10-libcsm-0.0.2-1.noarch


### PR DESCRIPTION
This new framework (https://github.com/Cray-HPE/libCSM) will be used for various things going forward.

This is very safe to pull into the tarball, including this at least gets this in place for if/when docs-csm requires installing it.
