### PR TITLE
MTL-2071 Include the new `libCSM` framework

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -33,4 +33,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.7-1.x86_64 
+    - python3.9-libcsm-0.0.2-1.noarch
 


### PR DESCRIPTION
This new framework (https://github.com/Cray-HPE/libCSM) will be used for various things going forward.

This is very safe to pull into the tarball, including this at least gets this in place for if/when docs-csm requires installing it.
