### PR TITLE
CASMSEC-383: Opa-gatekeeper namespace clean-up in the upgrade

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,47 +67,8 @@ undeploy -n gatekeeper-system gatekeeper-constraints
 undeploy -n gatekeeper-system gatekeeper-policy-library
 undeploy -n gatekeeper-system gatekeeper
 
-cluster_role=$(kubectl get clusterrole | grep gatekeeper | awk '{print $1}')
-rc=$?
-if [[ ${rc} -ne 0 ]]
-then
-    echo -n "ERROR: Command pipeline failed (return code $?): " 1>&2
-    echo "kubectl get clusterrole | grep gatekeeper | awk '{print $1}'" 1>&2
-elif [[ ${cluster_role} > 0 ]]
-then
-    echo "Clusterroles related to Gatekeeper are present in the system."
-        for i in $cluster_role; do
-                kubectl delete clusterrole $i
-                rc=$?
-                if [[ ${rc} -ne 0 ]]
-                then
-                        echo "ERROR while deleting cluster role $i check and delete manually."
-                else
-                        echo "Deleted the cluster role $i successfully"
-                fi
-        done
-fi
-
-cluster_rolebindings=$(kubectl get rolebinding -n gatekeeper-system | awk '{print $1}' | awk  '(NR>1)')
-rc=$?
-if [[ ${rc} -ne 0 ]]
-then
-    echo -n "ERROR: Command pipeline failed (return code $?): " 1>&2
-    echo "kubectl get rolebinding -n gatekeeper-system | awk '{print $1}' | awk  '(NR>1)'" 1>&2
-elif [[ ${cluster_rolebindings} > 0 ]]
-then
-    echo "cluster_rolebindings related to Gatekeeper are present in the system."
-        for i in $cluster_rolebindings; do
-                kubectl delete rolebinding $i
-                rc=$?
-                if [[ ${rc} -ne 0 ]]
-                then
-                        echo "ERROR while deleting rolebinding $i check and delete manually."
-                else
-                        echo "Deleted cluster rolebindings $i successfully"
-                fi
-        done
-fi
+# Checks for gatekeeper-system namespace on the system.
+# Delete if it is still present on the system.
 
 gatekeeper_namespace=$(kubectl get namespaces | grep -i gatekeeper-system)
 rc=$?
@@ -115,7 +76,7 @@ if [[ ${rc} -ne 0 ]]
 then
         echo -n "ERROR: Command pipeline failed (return code $?): " 1>&2
         echo "kubectl get namespaces | grep -i gatekeeper-system"
-elif [[ ${cluster_rolebindings} > 0 ]]
+elif [[ ${gatekeeper_namespace} > 0 ]]
 then
         echo "gatekeeper-system namespace is present on the system"
         kubectl delete namespace gatekeeper-system

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -74,7 +74,7 @@ gatekeeper_namespace=$(kubectl get namespaces | grep -i gatekeeper-system)
 rc=$?
 if [[ ${rc} -ne 0 ]]
 then
-        echo -n "ERROR: Command pipeline failed (return code $?): " 1>&2
+        echo -n "WARNING: Command pipeline failed (return code $?): " 1>&2
         echo "kubectl get namespaces | grep -i gatekeeper-system"
 elif [[ ${gatekeeper_namespace} > 0 ]]
 then
@@ -83,7 +83,7 @@ then
         rc=$?
         if [[ ${rc} -ne 0 ]]
         then
-                echo "ERROR while deleting gatekeeper-system namespace check and delete manually."
+                echo "WARNING: while deleting gatekeeper-system namespace check and delete manually."
         else
                 echo "gatekeeper-system namespace deleted successfully"
         fi


### PR DESCRIPTION
## Summary and Scope

Remove, Namespace, Custerroles and Rolebindings related to opa gatekeeper

## Testing

```
ncn-m001:/tmp/pradeep/jan21 # ./gatekeeper.sh
Clusterroles related to Gatekeeper are present in the system.
gatekeeper-manager-role
Deleted the cluster role gatekeeper-manager-role successfully
gatekeeper-policy-manager-crd-view
Deleted the cluster role gatekeeper-policy-manager-crd-view successfully
cluster_rolebindings related to Gatekeeper are present in the system.
gatekeeper-manager-rolebinding
Deleted cluster rolebindings gatekeeper-manager-rolebinding successfully
gatekeeper-system namespace is present on the system
gatekeeper-system Active 128d
gatekeeper-system namespace deleted successfully
```

### Tested on:

MUG

### Test description:

The commands which remove namespace, clusterroles, rolebindings are tested separately and they are working. These commands are integrated to upgrade.sh script.
 

