### PR TITLE
CASM-3854 Grok-exporter to be scheduled on all master nodes. Sorting order of operations based on installation time in IUF and log time panel in Goss dashboards.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -168,7 +168,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.12
+    version: 0.26.13
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

`cray-sysmgmt-health-grok-exporter` is currently scheduled only on `ncn-m001` master node based on a few pieces of documentation suggesting goss tests are run on `ncn-m001`. Found out that the service needs to be available on `ncn-m002` and `ncn-m003` as well for parsing the goss test result logs if they are run on these masters based on conversation with @mharding-hpe.

This PR modifies the deployment of grok-exporter to have the grok-exporter instances on all masters  - m001, m002 and m003.

Added order of dropdowns for products/ stages/operations based on installation time in IUF timing dashboard.

Added another panel in the goss test dashboard to check the log timestamp.

## Issues and Related PRs

* Resolves [CASM-3854](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3854)
* Change will also be needed in `<release-1.4 or release-1.6>`
* Documentation changes made in [CASMINST-5893](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5893)

## Testing
_List the environments in which these changes were tested._
### Tested on:
  * `frigg`
  * Local development environment
  * Virtual Shasta

### Test description:

The changes were tested and success verified.
ncn-m001:/mnt/developer/sum/goss # kubectl get all -l app=grok-exporter -n sysmgmt-health -o wide
NAME                                                   READY   STATUS    RESTARTS   AGE     IP          NODE       NOMINATED NODE   READINESS GATES
pod/cray-sysmgmt-health-grok-exporter-d68865c8-p52nz   1/1     Running   0          3m12s   10.44.0.6   ncn-m003   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-d68865c8-pfzcf   1/1     Running   0          3m12s   10.32.0.8   ncn-m002   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-d68865c8-sc49l   1/1     Running   0          15h     10.34.0.4   ncn-m001   <none>           <none>

NAME                                        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE   SELECTOR
service/cray-sysmgmt-health-grok-exporter   ClusterIP   10.25.105.12   <none>        9144/TCP   18h   app=grok-exporter

NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS      IMAGES                                                                                   SELECTOR
deployment.apps/cray-sysmgmt-health-grok-exporter   3/3     3            3           18h   grok-exporter   artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest   app=grok-exporter

NAME                                                         DESIRED   CURRENT   READY   AGE   CONTAINERS      IMAGES                                                                                   SELECTOR
replicaset.apps/cray-sysmgmt-health-grok-exporter-d68865c8   3         3         3       15h   grok-exporter   artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest   app=grok-exporter,pod-template-hash=d68865c8


![image](https://user-images.githubusercontent.com/110656037/216277219-9a47019d-cb01-4e24-958f-76774470ae69.png)
![image](https://user-images.githubusercontent.com/110656037/216277545-ed6c476c-5ddc-465f-a925-ae95cbb65bc5.png)

-  Upgrade is tested.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable