### PR TITLE
CASM-3859: Use cray-nexus-setup 0.9.1 in IUF

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -183,4 +183,4 @@ artifactory.algol60.net/csm-docker/stable:
     cray-product-catalog-update:
       - 1.8.2
     cray-nexus-setup:
-      - 0.9.0
+      - 0.9.1


### PR DESCRIPTION
## Summary and Scope

This commit updates the version of cray-nexus-setup from 0.9.0 to 0.9.1 to include bug fixes required for IUF.

## Issues and Related PRs

CASM-3859

## Testing

Tested the image independently and verified the stable version exists

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

