### PR TITLE
CASMINST-5843, CASMINST-5902, CASMINST-5876: Fix bugs in ims-upload, vcs-upload, and update-vcs-config IUF stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update cf-gitea-import to 1.9.0 (CASMINST-5843)
 - Update cf-gitea-update to 1.0.3 (CASMINST-5843)
 - Update cray-ims-load-artifacts to 2.1.0 (CASMINST-5843)
+- Update cray-nls helm chart to 1.4.51 (CASMINST-5843)
 - Update cray-velero 1.7.1 to 1.7.1-1 (CASMPET-5779)
 - Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update cf-gitea-import to 1.9.0 (CASMINST-5843)
 - Update cf-gitea-update to 1.0.3 (CASMINST-5843)
 - Update cray-ims-load-artifacts to 2.1.0 (CASMINST-5843)
-- Update cray-nls helm chart to 1.4.51 (CASMINST-5843)
+- Update cray-nls helm chart to 1.4.52 (CASMINST-5843)
 - Update cray-velero 1.7.1 to 1.7.1-1 (CASMPET-5779)
 - Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cf-gitea-import to 1.9.0 (CASMINST-5843)
+- Update cf-gitea-update to 1.0.3 (CASMINST-5843)
+- Update cray-ims-load-artifacts to 2.1.0 (CASMINST-5843)
 - Update cray-velero 1.7.1 to 1.7.1-1 (CASMPET-5779)
 - Add cf-gitea-import 1.8.1 (CASMINST-5866)
 - Release csm-testing v1.15.29, Make check_static_routes.sh handle undefined RVR networks (CASMINST-5850) 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.0.1
+      - 2.1.0
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to
@@ -54,10 +54,10 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.8.0
 
     cf-gitea-update:
-      - 1.0.2
+      - 1.0.3
 
     cf-gitea-import:
-      - 1.8.1
+      - 1.9.0
 
     cray-capmc:
       - 2.7.0

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -242,9 +242,9 @@ spec:
     source: csm-algol60
     version: 0.0.1
     namespace: argo
-  - name: cray-nls # TODO: need to bump
+  - name: cray-nls
     source: csm-algol60
-    version: 1.4.49
+    version: 1.4.51
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.51
+    version: 1.4.52
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -242,7 +242,7 @@ spec:
     source: csm-algol60
     version: 0.0.1
     namespace: argo
-  - name: cray-nls
+  - name: cray-nls # TODO: need to bump
     source: csm-algol60
     version: 1.4.49
     namespace: argo


### PR DESCRIPTION
## Summary and Scope

Add changes to the versions of the cray-nls, cf-gitea-import, cf-gitea-update, and cray-ims-load-artifacts images needed for the fixes for CASMINST-5843, CASMINST-5902, and CASMINST-5876.

## Issues and Related PRs

* Resolves [CASMINST-5843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5843)
* Resolves [CASMINST-5902](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5902)
* Resolves [CASMINST-5876](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5876)
* Change will also be needed in `main`

## Testing

### Tested on:

  * `frigg`

### Test description:

- Tested IUF argo runs on Frigg using `deliver-product` stage with Ryan H and Jack S.
- https://argo.cmn.frigg.dev.cray.com/workflows/argo/jesse-test-6-templates-d2dl0-update-vcs-config-xxthq?tab=workflow
- https://argo.cmn.frigg.dev.cray.com/workflows/argo/jesse-test-6-templates-0wtn3-deliver-product-rz8sf?tab=workflow

## Risks and Mitigations

No known risks.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable