### PR TITLE
CASMINST-5878 - fix post install hook in console-node helm chart.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -111,7 +111,7 @@ spec:
     namespace: services
   - name: cray-console-node
     source: csm-algol60
-    version: 1.7.1
+    version: 1.7.2
     namespace: services
     timeout: 20m0s
   - name: cray-console-operator


### PR DESCRIPTION
## Summary and Scope

This hook is working on a PVC that is created by the console-operator helm chart. If this chart is deployed before the operator chart, the hook will fail since that PVC isn't created yet. Do not run the hook on an install, just an upgrade since the upgrade case should have the operator already deployed hence the PVC will exist.

I also added a condition to delete the hook job when complete no matter what. The presence of the hook job can keep a handle on the PVC and not allow it to be removed when uninstalling the chart.

Code PR:
https://github.com/Cray-HPE/console-node/pull/68

csm-1.4 Manifest PR:
https://github.com/Cray-HPE/csm/pull/1773

## Issues and Related PRs
* Resolves [CASMINST-5878](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5878)

## Testing
### Tested on:
  * `Fanta`
  * Local development environment
  * Virtual Shasta

### Test description:

I did helm install/uninstall/upgrade operations in every order I could think of, including with the cray-console-operator chart to insure everything works as it is supposed to.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as just working with helm hooks and I tested all possible combinations.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable