### PR TITLE
CASMTRIAGE-4899 - fix console-operator post-install helm hook.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -109,14 +109,14 @@ spec:
     source: csm-algol60
     version: 1.6.2
     namespace: services
+  - name: cray-console-operator
+    source: csm-algol60
+    version: 1.6.2
+    namespace: services
+    timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
     version: 1.7.2
-    namespace: services
-    timeout: 20m0s
-  - name: cray-console-operator
-    source: csm-algol60
-    version: 1.6.1
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

The post-install hook on this corrects any wrong dir ownership and permissions on the shared PVC so it needs to run after install AND upgrade. This is the chart that creates the PVC, so this is the one that should fix the ownership and permissions. 

Code PR:
https://github.com/Cray-HPE/console-operator/pull/42

## Issues and Related PRs
* Resolves [CASMTRIAGE-4899](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4899)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I used helm to install/uninstall this and console-node together in every combination I could think of. If node is installed first, it will wait in 'pending' until the PVC is created when operator is installed. The operator install/upgrade will create the PVC and fix the ownership and permissions of the dirs needed. If operator is installed first, it will create the PVC and node installs and starts correctly without issue.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be low risk, but I thought that with the update to the console-node helm charts as well...

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
