### PR TITLE
CASM-3760: Update ims-load-artifacts image version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.1.0
+      - 2.2.0
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
## Summary and Scope

Update ims-load-artifacts image version to support skipping existing images (requested by UAN).
Depends on https://github.com/Cray-HPE/ims-python-helper/pull/25/files getting merged and a 2.2.0 release being created.
Also needs backport to 1.4 release branch.
## Issues and Related PRs

* Resolves [CASM-3760](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3760)
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

