### PR TITLE
CASMINST-5898: Add CA configmap to argo namespace

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -140,7 +140,7 @@ spec:
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
-    version: 0.6.0
+    version: 0.8.0
     namespace: pki-operator
   - name: cray-certmanager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Add CAs (via configmap) to `argo` namespace. 

## Issues and Related PRs

* Resolves [CASMINST-5898](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5898)
* Change will also be needed in `main`
* Merge before mainstream PRs associated with [CASMINST-5843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5843) (actually already merged, this is then needed to fix any fresh install/upgrade to ~ 1.6/main)
* 1.4 PR for this already merged https://github.com/Cray-HPE/trustedcerts-operator/pull/12

## Testing

Tested using local operator test (makefile based). Also deployed to `Frigg` system and verified. 

### Tested on:

  * `Frigg`
  * Local development environment

## Risks and Mitigations

Minimal risk. Just adds `argo` to list of namespaces to distribute CA configmap to. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
