### PR TITLE
CASMINST-5920: Use cray-nexus-setup version 0.9.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -179,4 +179,4 @@ artifactory.algol60.net/csm-docker/stable:
     cray-product-catalog-update:
       - 1.8.2
     cray-nexus-setup:
-      - 0.9.1
+      - 0.9.2


### PR DESCRIPTION
Test Description: Verified image exists.

See: CASMINST-5920, https://github.com/Cray-HPE/nexus-setup/pull/22

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

