### PR TITLE
CASMCMS-8248: Update gitea for reverse authentication fix

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,13 +34,17 @@ spec:
 
   # HMS
   # Install any operators first, wait for them to come up before continuing.
+  - name: cray-hms-trs-operator
+    source: csm-algol60
+    version: 2.0.3
+    namespace: operators
   - name: cray-hms-bss
     source: csm-algol60
-    version: 2.1.6
+    version: 2.1.5
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 4.0.1
+    version: 3.0.6
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
@@ -56,7 +60,7 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.16.0
+    version: 2.15.11
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
@@ -66,67 +70,63 @@ spec:
     source: csm-algol60
     version: 2.0.4
     namespace: services
-  - name: cray-power-control
-    source: csm-algol60
-    version: 1.0.2
-    namespace: services
 
   # CMS
-  - name: cfs-ara
+  - name: cray-ims
     source: csm-algol60
-    version: 1.0.1
-    namespace: services
-  - name: cfs-hwsync-agent
-    source: csm-algol60
-    version: 1.9.0
-    namespace: services
-  - name: cfs-trust
-    source: csm-algol60
-    version: 1.6.3
-    namespace: services
-  - name: cms-ipxe
-    source: csm-algol60
-    version: 1.11.1
-    namespace: services
-  - name: cray-bos
-    source: csm-algol60
-    version: 2.0.9
-    namespace: services
-    timeout: 10m
-  - name: cray-cfs-api
-    source: csm-algol60
-    version: 1.12.1
-    namespace: services
-  - name: cray-cfs-batcher
-    source: csm-algol60
-    version: 1.8.0
+    version: 3.7.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.1
+    version: 1.16.5
     namespace: services
-  - name: cray-console-data
+  - name: cray-cfs-api
+    source: csm-algol60
+    version: 1.11.2
+    namespace: services
+  - name: cray-cfs-batcher
+    source: csm-algol60
+    version: 1.7.34
+    namespace: services
+  - name: cfs-trust
     source: csm-algol60
     version: 1.6.2
     namespace: services
+  - name: cfs-hwsync-agent
+    source: csm-algol60
+    version: 1.8.1
+    namespace: services
+  - name: gitea
+    source: csm-algol60
+    version: 2.5.3
+    namespace: services
+    values:
+      keycloakImage:
+        tag: 3.6.1
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.6.2
+    version: 1.6.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 1.7.2
+    version: 1.6.0
     namespace: services
     timeout: 20m0s
-  - name: cray-csm-barebones-recipe-install
+  - name: cray-console-data
     source: csm-algol60
-    version: 1.7.1
+    version: 1.6.1
     namespace: services
-    values:
-      cray-import-kiwi-recipe-image:
-        import_image:
-          image:
+  - name: cray-crus
+    source: csm-algol60
+    version: 1.11.1
+    namespace: services
+  - name: cray-tftp
+    source: csm-algol60
+    version: 1.8.0
+    namespace: services
+  - name: cray-tftp-pvc
+    source: csm-algol60
             tag: 1.7.1
   - name: cray-ims
     source: csm-algol60
@@ -187,4 +187,3 @@ spec:
   - name: cray-tapms-operator
     source: csm-algol60
     version: 0.0.10
-    namespace: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Updates the gitea chart to pull in a fix for reverse authentication so that users can login to the UI through keycloak.

## Issues and Related PRs

* Resolves CASMCMS-8248

## Testing

### Tested on:

  * Surtur

### Test description:

Successfully logged into the UI through keycloak

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

