### PR TITLE
CASMHMS-5887: Fix PCS power-status ManagementState CSM 1.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,7 +72,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.0.2
+    version: 1.0.3
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

This updates the PCS chart version for CASMHMS-5887 - Fix PCS power-status to use 'unavailable' instead of 'undefined' for ManagementState.

## Issues and Related PRs

* Resolves [CASMHMS-5887](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5887)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/27

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

