### PR TITLE
(main) CASMHMS-5914: Pull in new hardware-topology-assistant to fix some bugs

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -62,7 +62,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Utility to help make changes for adding river cabinets
     hardware-topology-assistant:
-    - 0.1.0
+    - 0.2.0
 
     iuf:
     - v0.1.2


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in new hardware-topology-assistant to fix some bugs related to adding river cabinets.  https://github.com/Cray-HPE/hardware-topology-assistant/pull/2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5914](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5914)

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * `Mug`
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

I tested the new hardware-topology-assistant on Mug with Mug's current CCJ file to ensure that the tool did not make any changes. 

I performed extensive local testing to add 2 river cabinets to an existing system. 

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

