### PR TITLE
update pit iso RPM index generation

### DIFF
--- a/hack/list-pit-iso-rpms.sh
+++ b/hack/list-pit-iso-rpms.sh
@@ -4,9 +4,9 @@
 
 SQUASHFS_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/squashfs-tools:0.2.0"
 
-function rpm-list() {
+function rpm-pit-iso-list() {
     while [[ $# -gt 0 ]]; do
-        docker run --rm --privileged -v "$(realpath "$(dirname "$1")"):/data" "$SQUASHFS_TOOLS_IMAGE" /usr/local/bin/list-rpms.sh "/data/$(basename "$1")"
+        docker run --rm --privileged -v "$(realpath "$(dirname "$1")"):/data" "$SQUASHFS_TOOLS_IMAGE" /usr/local/bin/list-pit-iso-rpms.sh "/data/$(basename "$1")"
         shift
     done
 }
@@ -14,4 +14,4 @@ function rpm-list() {
 set -ex
 set -o pipefail
 
-rpm-list "$@" | sort -u
+rpm-pit-iso-list "$@" | sort -u

--- a/release.sh
+++ b/release.sh
@@ -229,18 +229,6 @@ rm -fr "${BUILDDIR}/tmp"
     for url in "${PIT_ASSETS[@]}"; do cmd_retry download_with_sha "$url"; done
 )
 
-# Generate list of installed RPMs; see
-# https://github.com/OSInside/kiwi/blob/master/kiwi/system/setup.py#L1067
-# for how the .packages file is generated.
-#[[ -d "${ROOTDIR}/rpm" ]] || mkdir -p "${ROOTDIR}/rpm"
-#cat "${BUILDDIR}"/installed.deps-*.packages \
-#| sed -e 's/=/-/g' \
-#> "${ROOTDIR}/rpm/pit.rpm-list"
-#| cut -d '|' -f 1-5 \
-#| sed -e 's/(none)//' \
-#| sed -e 's/\(.*\)|\([^|]\+\)$/\1.\2/g' \
-#| sed -e 's/|\+/-/g' \
-
 # Download Kubernetes assets
 (
     mkdir -p "${BUILDDIR}/images/kubernetes"
@@ -267,10 +255,13 @@ if [[ "${EMBEDDED_REPO_ENABLED:-yes}" = "yes" ]]; then
     cat >> "${ROOTDIR}/rpm/images.rpm-list" <<EOF
 kernel-default-debuginfo-5.3.18-24.49.2.x86_64
 EOF
+    # Generate pit iso RPM index
+    "${ROOTDIR}/hack/list-iso-rpms.sh" \
+        "${BUILDDIR}"/pre-install-toolkit-*.iso \
+    > "${ROOTDIR}/rpm/pit.rpm-list"
 
     # Generate RPM index from pit and node images
-    #cat "${ROOTDIR}/rpm/pit.rpm-list" "${ROOTDIR}/rpm/images.rpm-list" \
-    cat "${ROOTDIR}/rpm/images.rpm-list" \
+    cat "${ROOTDIR}/rpm/pit.rpm-list" "${ROOTDIR}/rpm/images.rpm-list" \
     | sort -u \
     | grep -v gpg-pubkey \
     | grep -v aaa_base \


### PR DESCRIPTION
The packages list related to the pit ISO image is no longer being included in assets.sh, so these changes will generate the RPM index related to the pit ISO by directly querying the RPM database in the image itself. The resulting pit ISO RPM index is then combined with the index from the kubernetes and ceph images to create the embedded repo included in the CSM tarball. 