### PR TITLE
CASMHMS-5640 Move hardware-sensitive HMS CT tests into separate stage

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 5.0.0
+    version: 5.0.1
     namespace: services
     values:
       cray-service:

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.5-1.noarch
     - docs-csm-1.6.8-1.noarch
     - goss-servers-1.16.5-1.noarch
-    - hpe-csm-scripts-0.4.5-1.noarch
+    - hpe-csm-scripts-0.5.0-1.noarch
     - iuf-cli-1.5.0_alpha-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change adds documentation for a new hardware-checks test stage that is separate from the rest of the HMS tests. The tests are optional and do not block CSM installs or upgrades.

### Issues and Related PRs

* Resolves CASMHMS-5640

### Testing

This change was tested in the build pipeline, as well as on Surtur by deploying the updated tests and wrapper scripts, executing various sets of tests and hardware checks, and verifying that they all passed. Testing was also completed to verify that both test and hardware-check failures were handled properly.

### Risks and Mitigations

Low risk, impacts HMS CT testing only.