### PR TITLE
CASMINST-5926: Update ims-load-artifacts container image version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.2.0
+      - 2.2.1
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
## Summary and Scope

Update ims-load-artifacts container image version to fix small IUF bug.

## Issues and Related PRs

* Resolves [CASMINST-5926](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5926)

## Testing

### Tested on:

  * `frigg`

### Test description:

Tested using test harness script linked in this PR: https://github.com/Cray-HPE/ims-python-helper/pull/27

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

