### PR TITLE
CASMCMS-8248: Update gitea for reverse authentication fix

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,7 +159,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.5.2
+    version: 2.5.3
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

Updates the gitea chart to pull in a fix for reverse authentication so that users can login to the UI through keycloak.

## Issues and Related PRs

* Resolves CASMCMS-8248

## Testing

### Tested on:

  * Surtur

### Test description:

Successfully logged into the UI through keycloak

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

