### PR TITLE
CASMHMS-5917: Fix PCS to handle /v1/* URIs inside the service mesh

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -72,7 +72,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.0.3
+    version: 1.2.0
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

Update the PCS chart version to change PCS to handle /v1/* URIs inside the service mesh.

## Issues and Related PRs

* Resolves [CASMHMS-5917](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5917)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/28

## Risks and Mitigations

None. PCS still also accepts /* URIs inside the service mesh.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

