### PR TITLE
CASMINST-5679: Update cray-nls chart version to 1.4.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-nls helm chart to 1.4.55 (CASMINST-5679)
 - Update cray-keycloak to 4.0.1 (CASMPET-6305)
 - Remove GBP peers goss tests from ncn-upgrde-test-worker goss suite (CASMINST-5908)
 - Update iuf-cli to 1.4.0 (SCICD-578)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.53
+    version: 1.4.55
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Removes unused fields from IUF Product Manifest schema.

(cherry picked from commit 2231b292f8a50012e865a9104294bc2e48a8ac41)

## Issues and Related PRs

* Resolves [CASMINST-5679](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5679)
* Merge the PR that updates the helm chart version first: https://github.com/Cray-HPE/cray-nls-charts/pull/30

## Testing

### Tested on:

  * Local development environment

### Test description:

See https://github.com/Cray-HPE/cray-nls/pull/158

## Risks and Mitigations

Low risk.

See https://github.com/Cray-HPE/cray-nls/pull/158

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

