### PR TITLE
hpe-csm-scripts RPM: set-bmc-ntp-dns: Improved arg parsing

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.5-1.noarch
     - docs-csm-1.6.9-1.noarch
     - goss-servers-1.16.5-1.noarch
-    - hpe-csm-scripts-0.5.0-1.noarch
+    - hpe-csm-scripts-0.5.1-1.noarch
     - iuf-cli-1.5.0_alpha-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Fixes some errors and inconsistencies with the argument parsing of the set-bmc-ntp-dns script. Backwards compatible except for fixing previous bad behavior.

See [source PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/39) for details.

## Issues and Related PRs

- Fixes: [CASMINST-2557](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-2557)
- [1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/1826)
- [1.3 manifest PR](https://github.com/Cray-HPE/csm/pull/1827)
- [main csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/741)
- [1.4 csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/742)
- [1.3 csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/743)

## Testing

Tested on fanta. See [source PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/39) for details.

## Risks and Mitigations

Low risk -- no change to the script logic itself, only to its argument parsing and validation.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

