### PR TITLE
(CSM 1.3.2) CASMHMS-5911: Pull in newer cray-hms-hmcollector chart that adds hmcollector.hmnlb.$SYSTEM_NAME.$SITE_DOMAIN to the list of hosts for the collectors virtual service.

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -15,6 +15,12 @@ function extract-repos() {
 }
 
 function extract-charts() {
+    # The following will output a tab separated values (TSV) of:
+    # 0. Release Name
+    # 1. Helm chart source
+    # 2. Helm chart name
+    # 3. Helm chart version
+    # 4. Helm chart value overrides in base64 encoded JSON.
     docker run --rm -i "$YQ_IMAGE" e -N -o json '.spec.charts' - < "$1" \
     | jq -r '.[] | (.releaseName // .name) + "\t" + (.source) + "\t" + (.name) + "\t" + (.version) + "\t" + (.values | @base64)'
 }
@@ -34,9 +40,13 @@ function extract-images() {
 
     local -a flags=()
 
+    # Destination file to contain helm chart overrides from the manifest if any are present.
+    # If they are not present, then this will just be an empty file.
     valuesfile="$6"
     mkdir -p "$(dirname "$valuesfile")"
 
+    # Convert the base64 encoded JSON into a YAML file containing the helm chart overrides.
+    # Write out the values unmodified to the values file for "helm template" to use with the "-f" option.  
     echo $4 | base64 -d  | docker run --rm -i "$YQ_IMAGE" e -P - > "${valuesfile}"
     flags+=(-f "${valuesfile}")
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -60,8 +60,30 @@ spec:
     namespace: services
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.15.11
+    version: 2.16.0
     namespace: services
+    values:
+      global:
+        appVersion: 2.23.0
+      kafkaBrokers:
+        - BrokerAddress: cluster-kafka-bootstrap.sma.svc.cluster.local:9092
+          TopicsToPublish:
+            - cray-telemetry-temperature
+            - cray-telemetry-voltage
+            - cray-telemetry-power
+            - cray-telemetry-energy
+            - cray-telemetry-fan
+            - cray-telemetry-pressure
+            - cray-telemetry-humidity
+            - cray-telemetry-liquidflow
+            - cray-fabric-telemetry
+            - cray-fabric-perf-telemetry
+            - cray-fabric-crit-telemetry
+            - cray-dmtf-resource-event
+            - cray-fabric-health-events
+        - BrokerAddress: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092
+          TopicsToPublish:
+            - cray-dmtf-resource-event
   - name: cray-hms-scsd
     source: csm-algol60
     version: 2.1.5

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -300,6 +300,7 @@ spec:
           repo: shasta-firmware
       cray-hms-hmcollector:
         hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
+        hmcollector_external_hostname: 'hmcollector.hmnlb.{{ network.dns.external }}'
       cray-hms-meds:
         ntpserver_host: time-hmn:123
         ntpserver_host_use_ip: ""


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in newer cray-hms-hmcollector chart that adds hmcollector.hmnlb.$SYSTEM_NAME.$SITE_DOMAIN to the list of hosts for the collectors virtual service. Additional overrides are required for the 2.16.0 chart to maintain backwards compatibility with how the collector works in CSM 1.3. 

Also updated customizations.yaml to pass the value hmcollector_external_hostname to the collector helm chart to pass in system specific hostname for fresh installs of CSM 1.3.2.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5911](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5911)
## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Sutur
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?  N/A
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? N/A

#### Before
Here is the existing virtual service for the collector.
```
ncn-m001:~/rsjostrand/collector # kubectl -n services get vs cray-hms-hmcollector-ingress
NAME                           GATEWAYS          HOSTS              AGE
cray-hms-hmcollector-ingress   ["hmn-gateway"]   ["10.94.100.71"]   105d
```

Here is the behavior of the of the IP address 10.94.100.71. The JSON payload malformed! message means that the collector was reached.
```
ncn-m001:~/rsjostrand/collector # curl -X POST -d {} http://10.94.100.71 -i
HTTP/1.1 400 Bad Request
date: Fri, 10 Feb 2023 18:29:30 GMT
content-length: 23
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 0
server: istio-envoy

JSON payload malformed!

ncn-m001:~/rsjostrand/collector # curl -X POST -d {} -k  https://10.94.100.71 -i
HTTP/2 400
date: Fri, 10 Feb 2023 18:29:34 GMT
content-length: 23
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 6
server: istio-envoy
```

Here is the behavior of https://hmcollector.hmnlb.surtur.hpc.amslabs.hpecorp.net -. The 404 is coming from istio.
```
ncn-m001:~/rsjostrand/collector # curl -X POST -d {} http://hmcollector.hmnlb.surtur.hpc.amslabs.hpecorp.net -i
HTTP/1.1 404 Not Found
date: Fri, 10 Feb 2023 18:29:37 GMT
server: istio-envoy
connection: close
content-length: 0

ncn-m001:~/rsjostrand/collector # curl -X POST -d {} https://hmcollector.hmnlb.surtur.hpc.amslabs.hpecorp.net -i
HTTP/2 404
date: Fri, 10 Feb 2023 18:29:44 GMT
server: istio-envoy

```

#### After
Here is the existing virtual service for the collector with the system hostname.

```
ncn-m001:~/rsjostrand/collector # kubectl -n services get vs cray-hms-hmcollector-ingress
NAME                           GATEWAYS          HOSTS                                                                 AGE
cray-hms-hmcollector-ingress   ["hmn-gateway"]   ["10.94.100.71","hmcollector.hmnlb.surtur.hpc.amslabs.hpecorp.net"]   105d
```

Here is the behavior of the of the IP address 10.94.100.71. The JSON payload malformed! message means that the collector was reached.

```
ncn-m001:~/rsjostrand/collector # curl -X POST -d {} http://10.94.100.71 -i
HTTP/1.1 400 Bad Request
date: Fri, 10 Feb 2023 18:21:27 GMT
content-length: 23
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 0
server: istio-envoy

JSON payload malformed!

ncn-m001:~/rsjostrand/collector # curl -X POST -d {} -k  https://10.94.100.71 -i
HTTP/2 400
date: Fri, 10 Feb 2023 18:21:32 GMT
content-length: 23
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 1
server: istio-envoy

JSON payload malformed!
```

Here is the behavior of hmcollector.hmnlb.mug.dev.cray.com. The JSON payload malformed! message means that the collector was reached.

```
ncn-m001:~/rsjostrand/collector # curl -X POST -d {} http://hmcollector.hmnlb.surtur.hpc.amslabs.hpecorp.net -i
HTTP/1.1 400 Bad Request
date: Fri, 10 Feb 2023 18:22:13 GMT
content-length: 23
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 1
server: istio-envoy

JSON payload malformed!

ncn-m001:~/rsjostrand/collector # curl -X POST -d {} https://hmcollector.hmnlb.surtur.hpc.amslabs.hpecorp.net -i
HTTP/2 400
date: Fri, 10 Feb 2023 18:22:34 GMT
content-length: 23
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 1
server: istio-envoy

JSON payload malformed!
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

