### PR TITLE
CASMUSER-3131: Add craycli and cray-uai-util to csm-config

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -146,7 +146,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.1
+    version: 1.15.2
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Install `craycli` and `cray-uai-util` through CSM CFS. Previously this was still being done in the COS kiwi recipe. All other packages from CSM had been migrated to CSM CFS (BOS, CFS, etc).

## Issues and Related PRs

* Resolves [CASMUSER-3131]

## Testing

  * `baldar`
 
### Test description:

Upgraded cos-config and created a COS kiwi recipe that did not install `cray-uai-util` or `craycli`. Updated `cos-config` included the change to add these two packages during CFS.

Here are results showing the packages in a running compute (without this change), and the packages installed in the modified image
```
ncn-m001:~ # ssh x8000c0s1b0n1 rpm -qa | egrep "craycli|uai"
cray-uai-util-2.1.0-1.x86_64
craycli-0.66.0-1.x86_64
ncn-m001:~ #

# Modified image chroot env
ncn-m001:~ # chroot /mnt/developer/alanm/compute/squashfs-root/
ncn-m001:/ #
ncn-m001:/ # rpm -qa | egrep "craycli|uai"
cray-uai-util-2.1.0-1.x86_64
craycli-0.66.0-1.x86_64
ncn-m001:/ # exit
exit

# NCN craycli version
ncn-m001:~ # rpm -q craycli
craycli-0.66.0-1.x86_64
```

## Risks and Mitigations

Low risk. Omitting the CSM layer will omit craycli and cray-uai-util, but that is the correct behavior. CSM should be installing packages it provides.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

