### PR TITLE
CASMINST-5851

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.56
+    version: 1.4.57
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Finally fixes [CASMINST-5851](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5851)

The previous fix didn't work on lemondrop.

I hot-patched a new fix on lemondrop and let it run for a few days. It seems the new fix that was hot-patched has not produced any duplicate workflows.

About the new fix: it tweaks the timeout value for metacontroller from 10s to 30s. This gives enough time for the first call to complete on large stages such as deliver-product.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5851](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5851)

## Testing

lemondrop

### Test description:

Ran `IUF run` multiple times and didn't notice any duplicate workflows.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

