### PR TITLE
Properly pass helm chart overrides specified from loftsman manifests …

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -15,8 +15,14 @@ function extract-repos() {
 }
 
 function extract-charts() {
+    # The following will output a tab separated values (TSV) of:
+    # 0. Release Name
+    # 1. Helm chart source
+    # 2. Helm chart name
+    # 3. Helm chart version
+    # 4. Helm chart value overrides in base64 encoded JSON.
     docker run --rm -i "$YQ_IMAGE" e -N -o json '.spec.charts' - < "$1" \
-    | jq -r '.[] | (.releaseName // .name) + "\t" + (.source) + "\t" + (.name) + "\t" + (.version) + "\t" + (.values | [paths(scalars) as $path | {"key": $path | join("."), "value": getpath($path)}] | map("\(.key)=\(.value|tostring)") | join(","))'
+    | jq -r '.[] | (.releaseName // .name) + "\t" + (.source) + "\t" + (.name) + "\t" + (.version) + "\t" + (.values | @base64)'
 }
 
 function get-customizations() {
@@ -33,7 +39,16 @@ function extract-images() {
     echo >&2 "+ ${args[@]}"
 
     local -a flags=()
-    [[ -n "$4" ]] && flags+=(--set "$4")
+
+    # Destination file to contain helm chart overrides from the manifest if any are present.
+    # If they are not present, then this will just be an empty file.
+    valuesfile="$6"
+    mkdir -p "$(dirname "$valuesfile")"
+
+    # Convert the base64 encoded JSON into a YAML file containing the helm chart overrides.
+    # Write out the values unmodified to the values file for "helm template" to use with the "-f" option.  
+    echo $4 | base64 -d  | docker run --rm -i "$YQ_IMAGE" e -P - > "${valuesfile}"
+    flags+=(-f "${valuesfile}")
 
     local -a cacheflags=()
     if [[ -n "$5" ]]; then
@@ -102,7 +117,8 @@ fi
 
 manifest_name="$(docker run --rm -i "$YQ_IMAGE" e -N '.metadata.name' - < "$manifest")"
 cachedir="${ROOTDIR}/build/images/charts/${manifest_name}"
-echo >&2 "+ ${manifest} [cache: ${cachedir}]"
+valuesdir="${ROOTDIR}/build/images/values/${manifest_name}"
+echo >&2 "+ ${manifest} [cache: ${cachedir}, values: ${valuesdir}]"
 
 helm env >&2
 
@@ -122,7 +138,8 @@ parallel $P_OPT docker pull $YQ_IMAGE >&2
 declare -i idx=0
 extract-charts "$manifest" | while read release repo chart version values; do
     cachefile="${cachedir}/$(printf '%02d' $idx)-${release}-${version}.yaml"
+    valuesfile="${valuesdir}/$(printf '%02d' $idx)-${release}-${version}.yaml"
     ((idx++)) || true
     filter-releases "$chart" "$@" || continue
-    extract-images "$repo" "$chart" "$version" "$values" "$cachefile"
+    extract-images "$repo" "$chart" "$version" "$values" "$cachefile" "$valuesfile"
 done | sort -u


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Properly pass helm chart overrides specified from loftsman manifests to "helm template" when extracting docker container images. 

### Background

Before this change the `images/extract.sh` script would fail to handle any helm chart overrides that contain arrays. The JQ statement that the `extract-charts` function was using would output a comma separated list of values and use `.` to separated keys for nested objects. 

For example, here is example value overrides from a manifest:
```yaml
global:
  appVersion: 2.23.0
kafkaBrokers:
  - BrokerAddress: cluster-kafka-bootstrap.sma.svc.cluster.local:9092
    TopicsToPublish:
      - cray-telemetry-temperature
      - cray-telemetry-voltage
      - cray-telemetry-power
      - cray-telemetry-energy
      - cray-telemetry-fan
      - cray-telemetry-pressure
      - cray-telemetry-humidity
      - cray-telemetry-liquidflow
      - cray-fabric-telemetry
      - cray-fabric-perf-telemetry
      - cray-fabric-crit-telemetry
      - cray-dmtf-resource-event
      - cray-fabric-health-events
  - BrokerAddress: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092
    TopicsToPublish:
      - cray-dmtf-resource-event
``` 

The old JQ statement in the `extract-charts` function would generate the following:
```
global.appVersion=2.23.0,kafkaBrokers.0.BrokerAddress=cluster-kafka-bootstrap.sma.svc.cluster.local:9092,kafkaBrokers.0.TopicsToPublish.0=cray-telemetry-temperature,kafkaBrokers.0.TopicsToPublish.1=cray-telemetry-voltage,kafkaBrokers.0.TopicsToPublish.2=cray-telemetry-power,kafkaBrokers.0.TopicsToPublish.3=cray-telemetry-energy,kafkaBrokers.0.TopicsToPublish.4=cray-telemetry-fan,kafkaBrokers.0.TopicsToPublish.5=cray-telemetry-pressure,kafkaBrokers.0.TopicsToPublish.6=cray-telemetry-humidity,kafkaBrokers.0.TopicsToPublish.7=cray-telemetry-liquidflow,kafkaBrokers.0.TopicsToPublish.8=cray-fabric-telemetry,kafkaBrokers.0.TopicsToPublish.9=cray-fabric-perf-telemetry,kafkaBrokers.0.TopicsToPublish.10=cray-fabric-crit-telemetry,kafkaBrokers.0.TopicsToPublish.11=cray-dmtf-resource-event,kafkaBrokers.0.TopicsToPublish.12=cray-fabric-health-events,kafkaBrokers.1.BrokerAddress=cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092,kafkaBrokers.1.TopicsToPublish.0=cray-dmtf-resource-event
```

The above would be supplied with `--set` to helm, and fields that were supposed to be arrays turned into objects. This would cause any helm charts that that are expecting arrays to fail templating.

### Fix
The fix was to pass the values from the manifest unmodifed to helm when the chart is templated. Instead of a comma seperated list of items, the `extract-charts`  function outputs a BASE64 encoded JSON of the override values. The JSON output was base64'd so that BASH wouldn't split the contents, and just have it be treated as one value.

In the `extract-images` function right before helm charts are templated the base64'd JSON data is converted to YAML and writen out to a YAML file. The yaml file is provided to `helm template` with  the `-f` argument. 


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

