### PR TITLE
CASMINST-5954: Bumping gitea-import to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cf-gitea-import to 1.9.1 (CASMINST-5954)
 - Update cf-gitea-update to 1.0.4 (CASMINST-5955)(CASMINST-5956)
 - Update cray-nls helm chart to 1.4.55 (CASMINST-5679)
 - Update cray-keycloak to 4.0.1 (CASMPET-6305)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -57,7 +57,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.0.4
 
     cf-gitea-import:
-      - 1.9.0
+      - 1.9.1
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Release critical bug fix for IUF Alice release. Small change to gracefully handle a git error while importing VCS content if folder is empty while committing.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5954](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5954)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `frigg`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- IUF workflows through Frigg, verified log outputs and results.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

