### PR TITLE
CASMTRIAGE-4824 Include `cray-site-init` for SP3

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,5 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
-    - ilorest-3.5.1-1.x86_64
+    - cray-site-init-1.30.0-1.x86_64
     - craycli-0.67.0-1.x86_64
+    - ilorest-3.5.1-1.x86_64


### PR DESCRIPTION
Also include `cray-site-init` in the SP3 manifests to facilitate CSM 1.3 upgrades by not having to know the next SLES OS version ahead of an upgrade.

This way CSM 1.3 users upgrading to 1.4 or newer can simply use CSI from their own distro's repository.

Work to mitigate having this package (and others) duplicated in OS-specific repos is logged in CASMINST-5317.