### PR TITLE
CASMNET-2048 - Reduce time cray-dns-unbound caches negative responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-dns-unbound to 0.7.17 (CASMNET-2048)
 - Update cf-gitea-import to 1.9.1 (CASMINST-5954)
 - Update cf-gitea-update to 1.0.4 (CASMINST-5955)(CASMINST-5956)
 - Update cray-nls helm chart to 1.4.55 (CASMINST-5679)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.16 # update platform.yaml cray-precache-images with this
+    version: 0.7.17 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.16
+        appVersion: 0.7.17
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.20
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.16
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.17
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.7
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

During investigation of [CAST-32143](https://jira-pro.its.hpecorp.net:8443/browse/CAST-32143) it was found that in the event of a customer DNS server blip `cray-dns-unbound` can cache a negative response for an hour.

This PR reduces the amount of time Unbound caches a negative response allowing DNS to heal quicker in the event of a customer DNS server outage.

## Issues and Related PRs

* Resolves [CASMNET-2048](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2048)

## Testing

### Tested on:

  * `surtur`
  * Customer test system

### Test description:

Rolled out new version and verified it behaves as expected. This change has also been soak tested on a customer TDS.

Verified `cray-dns-unbound` can be rolled back to the previous release successfully.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
