### PR TITLE
CASMPET-6323 and CASMINST-5988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update cray-dns-unbound to 0.7.17 (CASMNET-2048)
 - Update cf-gitea-import to 1.9.1 (CASMINST-5954)
 - Update cf-gitea-update to 1.0.4 (CASMINST-5955)(CASMINST-5956)
-- Update cray-nls helm chart to 1.4.59 (CASMINST-5988)
+- Update cray-nls helm chart to 1.4.60 (CASMINST-5988,CASMPET-6336)
 - Update cray-keycloak to 4.1.1 to fix Keylcoak ldap certificate bug (CASMPET-6305)
 - Update iuf-cli 1.0.0-1 to 1.5.0_alpha-1
 - Update cf-gitea-import to 1.9.0 (CASMINST-5843)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update cray-dns-unbound to 0.7.17 (CASMNET-2048)
 - Update cf-gitea-import to 1.9.1 (CASMINST-5954)
 - Update cf-gitea-update to 1.0.4 (CASMINST-5955)(CASMINST-5956)
-- Update cray-nls helm chart to 1.4.55 (CASMINST-5679)
+- Update cray-nls helm chart to 1.4.59 (CASMINST-5988)
 - Update cray-keycloak to 4.1.1 to fix Keylcoak ldap certificate bug (CASMPET-6305)
 - Update iuf-cli 1.0.0-1 to 1.5.0_alpha-1
 - Update cf-gitea-import to 1.9.0 (CASMINST-5843)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.58
+    version: 1.4.59
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.59
+    version: 1.4.60
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR contains fixes for the following two issues:
* [CASMPET-6323](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6323) IUF abort taking a long time / hanging when pressing Ctrl+C
* [CASMINST-5988](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5988) BREAK/FIX: management-node-rollout breaks with "default" product containing jinja templates

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves:
  * [CASMPET-6323](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6323)
  * [CASMINST-5988](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5988)
* Change will also be needed in docs-csm, cray-nls, cray-nls-charts, csm

## Testing

gamora, lemondrop

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Adhoc testing

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

