### PR TITLE
CASMINST-5973 Establish vShasta v2 automated run post csm build [main]

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -196,6 +196,10 @@ pipeline {
                         env.SNYK_RESULTS_SHEET = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-snyk-results.xlsx"
                         env.SNYK_RESULTS_SHEET_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_SHEET}"
                         slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Success!\n- Release distribution: <${env.RELEASE_URL}|${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz>\n- Snyk results: <${env.SNYK_RESULTS_SHEET_URL}|${env.SNYK_RESULTS_SHEET}> (raw scan results: <${env.SNYK_RESULTS_URL}|${env.SNYK_RESULTS_FILENAME}>)")
+                        build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
+                            string(name: "CSM_RELEASE", value: env.RELEASE_VERSION),
+                            string(name: "ENVIRONMENT", value: "yasha")
+                        ])
                     }
                 }
                 failure {


### PR DESCRIPTION
## Summary and Scope

Trigger deployment onto vShasta v2 environment named `yasha`, after successful build. Triggering happens asynchronously (no wait for completion).

## Issues and Related PRs

* Resolves [CASMINST-5973](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5973)

## Testing
### Tested on:

  * `vex`
  * `yasha`

### Test description:

Post-build deployment and test execution was implemented and tested separately `csm-vshatsa-deploy` repo. This change only adds a trigger for already tested job.

## Risks and Mitigations

Low - post-build activity, invoked asynchronously.
