### PR TITLE
CASMINST-5969: hpe-csm-scripts: Linting of minor language and formatting errors

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.6-1.noarch
     - docs-csm-1.5.13-1.noarch
     - goss-servers-1.16.6-1.noarch
-    - hpe-csm-scripts-0.5.1-1.noarch
+    - hpe-csm-scripts-0.5.2-1.noarch
     - iuf-cli-1.5.0_alpha-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Just language and formatting linting of this RPM. No change in behavior.

## Issues and Related PRs

* See [source PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/40) for details
* [csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/757)

## Testing

* See [source PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/40) for details

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
