### PR TITLE
CASM-3619: cray-istio and cray-kiali versions for istio 1.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Release cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.11.8 (CASM-3619)
 - Update cray-dns-unbound to 0.7.17 (CASMNET-2048)
 - Update cf-gitea-import to 1.9.1 (CASMINST-5954)
 - Update cf-gitea-update to 1.0.4 (CASMINST-5955)(CASMINST-5956)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -58,9 +58,9 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.21.12
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.10.6-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.10.6-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.10.6-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
       # Kyverno
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.6.2
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.6.2
@@ -112,11 +112,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.25.0
+    version: 1.26.0
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.28.0   # Update cray-precache-images above on proxyv2 tag change.
+    version: 1.29.0   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager-init
     source: csm-algol60
@@ -156,11 +156,11 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.7.0
+    version: 2.8.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.4.0
+    version: 0.5.0
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updated cray-istio charts and cray-kiali chart versions to support istio 1.11.8.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-3619](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3619)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`


### Test description:

Upgraded istio to 1.11.8, and validated keycloak, kiali, grafana still works.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

