### PR TITLE
CASMTRIAGE-4913 - Local DNS resolution fails when upstream DNS is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-dns-unbound to 0.7.18 (CASMTRIAGE-4913)
 - Release cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.11.8 (CASM-3619)
 - Update cray-dns-unbound to 0.7.17 (CASMNET-2048)
 - Update cf-gitea-import to 1.9.1 (CASMINST-5954)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.17 # update platform.yaml cray-precache-images with this
+    version: 0.7.18 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.17
+        appVersion: 0.7.18
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.20
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.17
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.18
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.7
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

* Disable CoreDNS health checking of `cray-dns-unbound` so it can never be marked as down by CoreDNS.
* Enable Unbound probing of upstream DNS servers and decrease probe interval so connection to site DNS can be recovered quicker in the event of disruption.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4913](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4913), [CAST-32143](https://jira-pro.its.hpecorp.net:8443/browse/CAST-32143)

## Testing

### Tested on:

  * `surtur`
  * Local development environment
  * Virtual Shasta

### Test description:

Deployed chart to surtur and verified that Unbound can no longer be blocked by CoreDNS when the spine CMN uplink ports are shutdown.

Before
```
ncn-m001:~ # curl -s http://10.16.0.10:9153/metrics | grep healthch
# HELP coredns_forward_healthcheck_broken_total Counter of the number of complete failures of the healthchecks.
# TYPE coredns_forward_healthcheck_broken_total counter
coredns_forward_healthcheck_broken_total 5.4406385e+07
# HELP coredns_forward_healthcheck_failures_total Counter of the number of failed healthchecks.
# TYPE coredns_forward_healthcheck_failures_total counter
coredns_forward_healthcheck_failures_total{to="10.92.100.225:53"} 142663
```
After
```
ncn-m001:~ # curl -s http://10.16.0.10:9153/metrics | grep healthch
# HELP coredns_forward_healthcheck_broken_total Counter of the number of complete failures of the healthchecks.
# TYPE coredns_forward_healthcheck_broken_total counter
coredns_forward_healthcheck_broken_total 0
```
Also verified that DNS no longer takes several minutes to recover once connectivity was restored.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

