### PR TITLE
CASMCMS-8423 - fix linting errors due to build pipeline changes.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,16 +107,16 @@ spec:
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 1.6.2
+    version: 1.6.3
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.6.2
+    version: 1.6.3
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 1.7.2
+    version: 1.7.3
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

There was a new version of 'go' installed on the image for the build pipeline. The new 'gofmt' linter objected to a couple of the comments and forced us to change them to allow the linting step to complete happily so the build would complete.

Code PR's:
https://github.com/Cray-HPE/console-node/pull/71
https://github.com/Cray-HPE/console-data/pull/39
https://github.com/Cray-HPE/console-operator/pull/44

## Issues and Related PRs
* Resolves [CASMCMS-8423](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8423)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed the new version on surtur and verified the console services work correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y 
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing the format of comments.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
