### PR TITLE
CASMTRIAGE-4950 - update the csm version of the barebones image and recipe.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,13 +126,13 @@ spec:
     namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.7.1
+    version: 1.7.2
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.7.1
+            tag: 1.7.2
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3


### PR DESCRIPTION
## Summary and Scope

Update the csm release to 1.4 in the name of the barebones image and recipe installed with csm.

Code PR: https://github.com/Cray-HPE/image-recipes/pull/39

## Issues and Related PRs
* Resolves [CASMTRIAGE-4950](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4950)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed via helm on surtur and verified the name of the image and recipe was at the correct 'csm-1.4' instead of the incorrect 'csm-1.3'.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing the name of the installed files.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
