### PR TITLE
CASMTRIAGE-4994 bump csm-testing to 1.16.8

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.16.6-1.noarch
+    - csm-testing-1.16.8-1.noarch
     - docs-csm-1.5.15-1.noarch
-    - goss-servers-1.16.6-1.noarch
+    - goss-servers-1.16.8-1.noarch
     - hpe-csm-scripts-0.5.2-1.noarch
     - iuf-cli-1.5.0_alpha-1.x86_64
     - manifestgen-1.3.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

    ~/workspace/csm-testing(main=)$ git log --oneline v1.16.6..v1.16.8
    656747f (tag: v1.16.8, origin/main, main) CASMTRIAGE-4994 Turn off goss-bond-members-have-links on vShasta (#442)
    452161d (tag: v1.16.7) [Backport main] CASMPET-6345 1.4 : Update goss test to handle post build and rebuild cases for worker mount usage (#441)

* Resolves [CASMTRIAGE-4994](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4994)
* Resolves [CASMPET-6345](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6345)
