### PR TITLE
CASMTRIAGE-4994 bump csm-testing to 1.15.32

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,10 +33,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.0-1.noarch
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - csm-testing-1.15.30-1.noarch
+    - csm-testing-1.15.32-1.noarch
     - docs-csm-1.4.72-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.30-1.noarch
+    - goss-servers-1.15.32-1.noarch
     - iuf-cli-1.4.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

    ~/workspace/csm-testing(release/1.4=)$ git log --oneline v1.15.30..v1.15.32
    a322e4d (HEAD -> release/1.4, tag: v1.15.32, origin/release/1.4) [Backport release/1.4] CASMTRIAGE-4994 Turn off goss-bond-members-have-links on vShasta (#443)
    ea46c21 (tag: v1.15.31) CASMPET-6345 1.4 : Update goss test to handle post build and rebuild cases for worker mount usage (#440)
    608b6fb CASMINST-5908-csm-1.4 - updated check_bgp_neighbors.sh to load switch admin password from vault (#437)

## Issues and Related PRs

* Resolves [CASMTRIAGE-4994](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4994)
* Resolves [CASMPET-6345](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6345)
* Resolves [CASMINST-5908](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5908)

