### PR TITLE
Add support for upgrade to bitnami etcd chart from old operator

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -96,7 +96,7 @@ spec:
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60
-    version: 0.4.2
+    version: 0.4.3
     namespace: services
   - name: cray-velero
     source: csm-algol60
@@ -126,10 +126,6 @@ spec:
     source: csm-algol60
     version: 1.30.0
     namespace: opa
-  - name: cray-etcd-operator
-    source: csm-algol60
-    version: 0.17.3
-    namespace: operators
   - name: cray-vault-operator
     source: csm-algol60
     version: 1.2.0
@@ -220,8 +216,12 @@ spec:
     namespace: operators
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.4.3
-    namespace: operators
+    version: 0.5.0
+    namespace: services
+  - name: cray-etcd-migration-setup
+    source: csm-algol60
+    version: 1.0.1
+    namespace: services
   - name: cray-metallb
     source: csm-algol60
     version: 1.1.1

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -55,6 +55,11 @@ function unbound_psp_check() {
 # CRUS is removed in CSM 1.6, and should be removed during the upgrade, if it exists
 undeploy -n services cray-crus
 
+#
+# cray-etcd-backup moving from operators to services namespace, uninstall prior to upgrade.
+#
+undeploy -n operators cray-etcd-backup
+
 # Ceph CSI upgrade will require an outage to remove the deployments to move them to namespaces from the default namespace.
 
 echo "Removing current ceph csi provisioners.  This will cause PVC movement between nodes to be inactive for approx 5 minutes."
@@ -125,6 +130,11 @@ fi
 
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
+
+#
+# Remove the old etcd operator now that new manifests have been applied
+#
+undeploy -n operators cray-etcd-operator
 
 set +x
 cat >&2 <<EOF


### PR DESCRIPTION
## Summary and Scope

This is an initial checkin with basic backup/restore functionality working for bitnami chart's integration with S3 and support for upgrade.

## Issues and Related PRs

* Resolves [CASMPET-6182](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6182)

## Testing

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'restore_from_backup cray-bos db-2023-03-01_01-00'
Scaling etcd statefulset down to zero...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
statefulset.apps/cray-bos-bitnami-etcd env updated
Deleting existing PVC's...
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
Scaling etcd statefulset back up to three members...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-7b87987d9c...
statefulset.apps/cray-bos-bitnami-etcd env updated
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'list_backups cray-bos'
cray-bos/db-2023-02-27_23-00
cray-bos/db-2023-02-28_17-05
cray-bos/cray-bos_etcd_migration.snapshot.db
cray-bos/db-2023-02-24_00-00
cray-bos/db-2023-02-24_21-00
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'create_backup cray-bos brad-did-this-thrice'
Taking snapshot from cray-bos-bitnami-etcd-0...
Pushing newly created snapshot /snapshots/cray-bos-bitnami-etcd/db-2023-03-01_14-57 to S3 as brad-did-this-thrice for cray-bos
upload: snapshots/cray-bos-bitnami-etcd/db-2023-03-01_14-57 to s3://etcd-backup/cray-bos/brad-did-this-thrice
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'list_backups cray-bos' | grep thrice
cray-bos/brad-did-this-thrice
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl exec -it -n services $(kubectl get po -n services -l 'app.kubernetes.io/name=cray-etcd-backup' -o jsonpath={.items[0].metadata.name}) -- /bin/sh -c 'restore_from_backup cray-bos brad-did-this-thrice'
Downloading brad-did-this-thrice from S3 for cray-bos
download: s3://etcd-backup/cray-bos/brad-did-this-thrice to snapshots/cray-bos-bitnami-etcd/brad-did-this-thrice
Scaling etcd statefulset down to zero...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-7977d754f8...
statefulset.apps/cray-bos-bitnami-etcd env updated
Deleting existing PVC's...
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
Scaling etcd statefulset back up to three members...
statefulset.apps/cray-bos-bitnami-etcd scaled
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-547b4d6f46...
Waiting for 1 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-547b4d6f46...
statefulset.apps/cray-bos-bitnami-etcd env updated
```

### Tested on:

  * Virtual Shasta

### Test description:

Lots of iterations

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable