### PR TITLE
CASMNET-2070 - CoreDNS: max_fail=0 blocks initial deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-dns-unbound to 0.7.19 (CASMNET-2070)
 - Update cray-dhcp-kea to 0.10.21, cray-dns-powerdns-0.2.8 and cray-powerdns-manager 0.7.6(CASMNET-2067)
 - Update cray-dns-unbound to 0.7.18 (CASMTRIAGE-4913)
 - Update cray-dns-unbound to 0.7.17 (CASMNET-2048)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -47,11 +47,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.18 # update platform.yaml cray-precache-images with this
+    version: 0.7.19 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.18
+        appVersion: 0.7.19
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.21
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.18
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.19
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.8
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.6
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

The change introduced by [CASMTRIAGE-4913](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4913) causes initial deployment to fail as Unbound isn't primed with data because cray-dns-unbound-manager hasn't run yet so queries forwarded to Unbound from CoreDNS fail.

This backs out the CoreDNS configuration change.

## Issues and Related PRs

* Resolves [CASMNET-2070](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2070)

## Testing

### Tested on:

  * `drax`

### Test description:

Tested as part of the fresh install on drax, CoreDNS configuration is as expected without `max_fails 0`.

All Postgres clusters initialised correctly
```
drax-pit:~ # kubectl get postgresql -A
NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
argo        cray-nls-postgres            cray-nls            11        3      1Gi                                     28m   Running
services    cfs-ara-postgres             cfs-ara             11        3      50Gi                                    19m   Running
services    cray-console-data-postgres   cray-console-data   11        3      2Gi                                     19m   Running
services    cray-dns-powerdns-postgres   cray-dns-powerdns   11        3      10Gi                                    26m   Running
services    cray-sls-postgres            cray-sls            11        3      1Gi                                     27m   Running
services    cray-smd-postgres            cray-smd            11        3      100Gi    4             8Gi              26m   Running
services    gitea-vcs-postgres           gitea-vcs           11        3      50Gi                                    16m   Running
services    keycloak-postgres            keycloak            11        3      10Gi                                    28m   Running
spire       spire-postgres               spire               11        3      60Gi     4             4Gi              16m   Running
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable