### PR TITLE
CASMCMS-8432: Update cfs-ara to fix UI access (1.4)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -75,7 +75,7 @@ spec:
   # These are alphabetized; please keep them so.
   - name: cfs-ara
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates cfs-ara to fix an issue where the UI was only accessible via ip and not url.

## Issues and Related PRs

* Resolves CASMCMS-8432

## Testing

### Tested on:

  * Lemondrop

### Test description:

Deployed change and accessed UI

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

