### PR TITLE
CASMTRIAGE-5003: Update csm-config for Compute package install changes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -142,7 +142,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.2
+    version: 1.15.4
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Updates csm-config to include a change to only install packages to Compute nodes during image customization and not at boot time.

## Issues and Related PRs

* Resolves CASMTRIAGE-5003

## Testing

### Tested on:

  * Surtur
 
### Test description:

Ran the update against a node to confirm the role did not run

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

