### PR TITLE
Reintroduce etcd-operator until etcd charts convert to bitnami (CASMPET-6374)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -210,6 +210,10 @@ spec:
     source: csm-algol60
     version: 0.7.0
     namespace: services
+  - name: cray-etcd-operator
+    source: csm-algol60
+    version: 0.17.3
+    namespace: operators
   - name: cray-etcd-defrag
     source: csm-algol60
     version: 0.3.0


### PR DESCRIPTION
## Summary and Scope

Will need to remove when K8S 1.22 lands, but let's keep it in longer to give etcd clusters time to convert to bitnami.

## Issues and Related PRs

* Resolves [CASMPET-6374](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6374)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

