### PR TITLE
CASMPET-6366: OPA policy change for nexus-keycloak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-opa to 1.29.5 (CASMPET-6366)
 - Update cray-dns-unbound to 0.7.19 (CASMNET-2070)
 - Update cray-dhcp-kea to 0.10.21, cray-dns-powerdns-0.2.8 and cray-powerdns-manager 0.7.6(CASMNET-2067)
 - Update cray-dns-unbound to 0.7.18 (CASMTRIAGE-4913)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.29.4
+    version: 1.29.5
     namespace: opa
   - name: cray-etcd-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This is a bug that was introduced with patching some security holes in Keycloak. The change blocked all authenticated traffic from Nexus to Keycloak for authentication of users on Nexus. The change added some more allowed endpoints for traffic with a system-nexus token. This should also be merged into main once testing has been done.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6366](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6366)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Drax with manual change to the config map and check.

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y 
- Was downgrade tested? If not, why? no just config map change
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

No known risks currently


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

