### PR TITLE
updates to add embedded repo to nexus at install

### DIFF
--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -71,6 +71,7 @@ nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERS
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3-compute" "csm-${RELEASE_VERSION}-sle-15sp3-compute"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4"         "csm-${RELEASE_VERSION}-sle-15sp4"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute" "csm-${RELEASE_VERSION}-sle-15sp4-compute"
+nexus-upload raw "${ROOTDIR}/rpm/embedded" "csm-${RELEASE_VERSION}-embedded"
 
 clean-install-deps
 

--- a/nexus-repositories.yaml
+++ b/nexus-repositories.yaml
@@ -103,3 +103,19 @@ type: group
 group:
   memberNames:
   - csm-0.0.0-sle-15sp4-compute
+
+---
+name: csm-0.0.0-embedded
+format: raw
+storage:
+  blobStoreName: csm
+---
+name: csm-embedded
+format: raw
+storage:
+  blobStoreName: csm
+type: group
+group:
+  memberNames:
+  - csm-0.0.0-embedded
+


### PR DESCRIPTION
## Summary and Scope

These changes to install the "embedded" repo currently available only in the release tarball into nexus at install time.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5108](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5018)

## Testing

Manually tested adding changes to nexus-requirements.yaml and lib/setup-nexus.sh by creating and executing analogous files on Groot.

### Tested on:

  * Groot
  
### Test description:

Ran a test script to create and populate the csm-1.3.1-embedded repo on Groot

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? No
- Was upgrade tested? No
- Was downgrade tested? No
- 
## Risks and Mitigations

No known risks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

