### PR TITLE
MTL-2076 New `libcsm`

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -27,3 +27,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cray-site-init-1.30.2-1.x86_64
     - craycli-0.70.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
+    - libcsm-0.0.4-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -44,4 +44,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.2.44-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
-    - python3.10-libcsm-0.0.2-1.noarch
+    - libcsm-0.0.4-1.noarch


### PR DESCRIPTION
The new `libCSM` uses a `virtualenv`, no longer installing into the system Python environment. The package still depends on `python39-base` or `python310-base` (for SP3 and SP4 respectively) to be installed.

This entailed a package name change since it is now all-inclusive, the canonical naming of `pythonXY-<name>` is only applicable to packages installing into the system Python environment.
