### PR TITLE
MTL-2076 New `libcsm`

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -33,5 +33,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
     - bos-reporter-2.0.7-1.x86_64 
-    - python3.9-libcsm-0.0.2-1.noarch
+    - libcsm-0.0.4-1.noarch
 


### PR DESCRIPTION
The new `libCSM` uses a `virtualenv`, no longer installing into the system Python environment. The package still depends on `python39-base` or `python310-base` (for SP3 and SP4 respectively) to be installed.

This entailed a package name change since it is now all-inclusive, the canonical naming of `pythonXY-<name>` is only applicable to packages installing into the system Python environment.
