### PR TITLE
HMS CT test updates for HSM, CAPMC, and PCS

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 5.0.1
+    version: 5.0.2
     namespace: services
     values:
       cray-service:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -40,7 +40,7 @@ spec:
     namespace: services
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 4.0.1 
+    version: 4.0.2
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
@@ -68,7 +68,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.2.0
+    version: 1.2.1
     namespace: services
 
   # CMS

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.8-1.noarch
     - docs-csm-1.5.16-1.noarch
     - goss-servers-1.16.8-1.noarch
-    - hpe-csm-scripts-0.5.2-1.noarch
+    - hpe-csm-scripts-0.5.3-1.noarch
     - iuf-cli-1.5.0_alpha-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change includes many additions, updates, and fixes to the HMS CT tests for the HSM, CAPMC, and PCS services.

### Issues and Related PRs

Resolves many tickets, but primarily epic [CASMHMS-5747](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5747)
Encapsulating all of this work in one Manifest PR ticket  [CASMHMS-5940](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5940)

See:

- https://github.com/Cray-HPE/hms-smd/pull/107
- https://github.com/Cray-HPE/hms-capmc/pull/83
- https://github.com/Cray-HPE/hms-power-control/pull/29

### Testing

These changes were tested with local instances of the hms-simulation-environment using the small_mountain and one_of_each_blade hardware configurations, as well as in the runCT GitHub Actions pipeline. Additionally, the HSM and CAPMC changes were verified on Surtur by deploying the new versions of the services, running the tests, and confirming that they all passed.

### Risks and Mitigations

Low risk, testing changes only.