### PR TITLE
setup-nexus.sh: use labels to match only the nexus pod

### DIFF
--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -18,7 +18,7 @@ url=packages.local
 while [[ $nexus_resources_ready -eq 0 ]] && [[ "$counter" -le "$counter_max" ]]; do
     nexus_check_configmap=$(kubectl -n services get cm cray-dns-unbound -o json 2>&1 | jq '.binaryData."records.json.gz"' -r 2>&1 | base64 -d 2>&1| gunzip - 2>&1|jq 2>&1|grep $url|wc -l)
     nexus_check_dns=$(dig $url +short |wc -l)
-    nexus_check_pod=$(kubectl get pods -n nexus| grep nexus | grep -v Completed | awk {' print $3 '})
+    nexus_check_pod=$(kubectl get pods -n nexus -l app=nexus --no-headers -o custom-columns=":status.phase")
 
     if [[ "$nexus_check_dns" -eq "1" ]] && [[ "$nexus_check_pod" == "Running" ]]; then
         echo "$url is in dns."


### PR DESCRIPTION
## Summary and Scope

Prerequisites fails when it shouldn't matching two pods with nexus in their name.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [[issue id](issue link)](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5038)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Found the issue on Surtur and validated the fix there as well to move past the issue for testing another issue.

### Tested on:

  * Surtur
  * Local development environment
  * Virtual Shasta

### Test description:

See above

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? n/a
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? n/a
- Were new tests (or test issues/Jiras) created for this change? n/a

## Risks and Mitigations

No known risks, but upgrades will likely fail as there are two pods with the string nexus in the nexus namespace:

```
 # kubectl get pods -n nexus 
NAME                         READY   STATUS    RESTARTS   AGE
cray-precache-images-55d6x   1/1     Running   0          29d
cray-precache-images-ljs5q   1/1     Running   0          29d
cray-precache-images-lqbkp   1/1     Running   0          29d
nexus-6fd9757ffb-qxbhx       2/2     Running   0          24h
nexus-pvc-check              2/2     Running   3          3d21h
```


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

