### PR TITLE
MTL-2097 Deprecation Notice

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
-    - cray-site-init-1.26.4-1.x86_64
+    - cray-site-init-1.26.5-1.x86_64
     - csm-testing-1.14.61-1.noarch
     - goss-servers-1.14.61-1.noarch
     - metal-basecamp-1.2.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.6.20-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
-    - cray-site-init-1.26.3-1.x86_64
+    - cray-site-init-1.26.4-1.x86_64
     - csm-testing-1.14.61-1.noarch
     - goss-servers-1.14.61-1.noarch
     - metal-basecamp-1.2.0-1.x86_64


### PR DESCRIPTION
- MTL-2097 Brings in a deprecation notice
- MTL-2081 Prevents `csi config init empty` from clobbering an existing `system_config.yaml`