### PR TITLE
CASMINST-6052 Enhance goss - add stdout/stderr to junit output [release/1.4]

### DIFF
--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - hpe-csm-goss-package-0.3.13-20210615152800_aae8d77.noarch
+    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - loftsman-1.2.0-1.x86_64
     - platform-utils-1.4.3-1.noarch


### PR DESCRIPTION
### Summary and Scope

- Needed by: [CASMINST-6052](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6052)

#### Issue Type

- RFE Pull Request

Adopt new (forked from upstream and locally modified) version of goss, which now supports adding `<system-output/>` and `<system-err/>` tags in Junit output format, for goss tests of type `command`. As a result, most of the times the reason of test failure is immediately visible in Jenkins report.

### Prerequisites

- [x] I tested this on a vshasta system

New goss package was explicitly installed, tests re-ran with new package and results exported int temporary Jenkins job. results look as expected (system out is included into report).

### Risks and Mitigations
Low - modification to test framework only.