### PR TITLE
CASM-3985 Bump iuf-cli version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update cray-nls helm chart to 1.4.61 (CASMINST-5988,CASMPET-6336,CASMINST-5982)
 - Update cray-keycloak to 4.0.1 (CASMPET-6305)
 - Remove GBP peers goss tests from ncn-upgrde-test-worker goss suite (CASMINST-5908)
-- Update iuf-cli to 1.4.0 (SCICD-578)
+- Update iuf-cli to 1.4.1 (CASM-3985)
 - Update cf-gitea-import to 1.9.0 (CASMINST-5843)
 - Update cf-gitea-update to 1.0.3 (CASMINST-5843)
 - Update cray-ims-load-artifacts to 2.1.0 (CASMINST-5843)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -37,7 +37,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - docs-csm-1.4.79-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - goss-servers-1.15.32-1.noarch
-    - iuf-cli-1.4.0-1.x86_64
+    - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.14-1.noarch


### PR DESCRIPTION
Need to bump the iuf-cli version to 1.4.1 for CSM 1.4

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [X ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

