### PR TITLE
CASMPET-2929: Update Keycloak version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-keycloak to 5.0.0 (CASMPET-2929)
 - Release csm-testing v1.16.9,  VSHA-542
 - Update cray-opa to 1.32.1 (CASMPET-6366)
 - Update cray-dns-unbound to 0.7.19 (CASMNET-2070)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 4.1.1
+    version: 5.0.0
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update keycloak to the latest version (20.0.5), and the subchart to the newest version (2.1.1). The latest subchart changed to be called keycloakx to represent keycloak version 17+ with a change to keycloak to quarkus from wildfly. This has no effctive change to our working environments. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-2929](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-2929)
* Documentation changes required in [CASMPET-6399](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6399)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Fanta
  * Drax
  * Dorian

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

Only risks in UI changes. There seems to have less CVEs in the newer version


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

