### PR TITLE
update variable name and comments related to kernel-default-debuginfo

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -22,6 +22,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# Multi-arch management clusters are not supported.
+NCN_ARCH='x86_64'
+
+# NOTE: The kernel-default-debuginfo package version needs to be aligned
+# to the KERNEL_VERSION. Always verify and update the correct version of 
+# the kernel-default-debuginfo package when changing the KERNEL_VERSION 
+# by doing a zypper search for the corresponding kernel-default-debuginfo package 
+# in the SLE-Module-Basesystem update_debug repo
+KERNEL_DEFAULT_DEBUGINFO_VERSION='5.3.18-150300.59.87.1.${NCN_ARCH}'
+
 PIT_ASSETS=(
     https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.8-20221013160829.iso
     https://artifactory.algol60.net/artifactory/csm-images/stable/cray-pre-install-toolkit/1.8.8/cray-pre-install-toolkit-sle15sp3.x86_64-1.8.8-20221013160829.packages

--- a/release.sh
+++ b/release.sh
@@ -255,9 +255,10 @@ if [[ "${EMBEDDED_REPO_ENABLED:-yes}" = "yes" ]]; then
         "${BUILDDIR}"/images/storage-ceph/storage-ceph-*.squashfs \
     > "${ROOTDIR}/rpm/images.rpm-list"
 
-    cat >> "${ROOTDIR}/rpm/images.rpm-list" <<EOF
-kernel-default-debuginfo-5.3.18-24.49.2.x86_64
-EOF
+    #append kernel-default-debuginfo package to rpm list 
+    if [ ! -z "$KERNEL_DEFAULT_DEBUGINFO_VERSION" ]; then
+        echo "kernel-default-debuginfo-${KERNEL_DEFAULT_DEBUGINFO_VERSION}" >> "${ROOTDIR}/rpm/images.rpm-list"
+    fi
 
     # Generate RPM index from pit and node images
     cat "${ROOTDIR}/rpm/pit.rpm-list" "${ROOTDIR}/rpm/images.rpm-list" \


### PR DESCRIPTION
## Summary and Scope

These changes support the alignment of the version of the kernel-default-debuginfo package to the KERNEL_VERSION 
in assets.sh, and append the specified kernel-default-debuginfo package to the embedded repo in release.sh

## Issues and Related PRs

* Resolves [CASMINST-6059](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6059)

## Testing

Verified the approach works in v1.4.0-beta.69

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

