### PR TITLE
CASMCMS-8450/CASMCMS-8460: Do not run tftp on master NCNs; tftp use correct ipxe version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,11 +134,11 @@ spec:
     namespace: services
   - name: cray-tftp
     source: csm-algol60
-    version: 1.8.2
+    version: 1.8.4
     namespace: services
   - name: cray-tftp-pvc
     source: csm-algol60
-    version: 1.8.2
+    version: 1.8.4
     namespace: services
   - name: csm-config
     source: csm-algol60


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/1946