### PR TITLE
CASMTRIAGE-5050/CASMCMS-8461/CASMCMS-8463: Update csm-config, csm-ssh-keys, and import-images

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,13 +126,13 @@ spec:
     namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.7.2
+    version: 1.7.3
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.7.2
+            tag: 1.7.3
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3
@@ -147,7 +147,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.8
+    version: 1.15.9
     namespace: services
     values:
       cray-import-config:

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,8 +31,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.3-1.x86_64
     - cray-site-init-1.30.4-1.x86_64
     - csm-node-identity-1.0.19-1.noarch
-    - csm-ssh-keys-1.5.0-1.noarch
-    - csm-ssh-keys-roles-1.5.0-1.noarch
+    - csm-ssh-keys-1.5.1-1.noarch
+    - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.15.35-1.noarch
     - docs-csm-1.4.82-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

Resolves:
- [CASMTRIAGE-5050](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5050)
- [CASMCMS-8461](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8461)
- [CASMCMS-8463](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8463)

main PR:
https://github.com/Cray-HPE/csm/pull/1949

See source PRs for details:
- https://github.com/Cray-HPE/csm-config/pull/109
- https://github.com/Cray-HPE/csm-config/pull/111
- https://github.com/Cray-HPE/ansible-execution-environment/pull/34
- https://github.com/Cray-HPE/image-recipes/pull/41

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

