### PR TITLE
CASMPET-6352 Bump spire to 2.10.2

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -201,7 +201,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.10.1
+    version: 2.10.2
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This adds the dvs-mqtt workloads for use with the dvs-mqtt-client.

## Issues and Related PRs

* Resolves [CASMPET-6352](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6352)

## Testing

### Tested on:

  * mug
 
### Test description:

Validated I could request a dvs-mqtt workload JWT after upgrading the spire chart and rolling the spire-server stateful set.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, no need. A downgrade will not remove entries.
- Were new tests (or test issues/Jiras) created for this change? N
 
## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
