### PR TITLE
CASMPET-6398 Bump kyverno to 1.4.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -84,7 +84,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.4.0
+    version: 1.4.1
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The daemonset-controller is not able to create the weave pod because it cannot get to kyverno to call the webhook.

## Testing

Before Change
-------------

```
pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-45np9                                                   2/2     Running            0          2m21s   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-67ttc                                                   2/2     Running            1          2d16h   10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-92tls                                                   0/2     Terminating        1          2d16h   10.252.1.11   ncn-m002   <none>           <none>
kube-system      weave-net-g9d5f                                                   2/2     Running            0          77s     10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-nfwxb                                                   2/2     Running            0          3m13s   10.252.1.12   ncn-m003   <none>           <none>
pit:~ # journalctl -u kubelet | grep webhook
.
.
.
Mar 15 07:45:12 ncn-m002 kubelet[14609]: I0315 07:45:12.693060   14609 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-9r5x2" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.26.61.128:443: connect: no route to host"
Mar 15 07:45:22 ncn-m002 kubelet[14609]: I0315 07:45:22.704503   14609 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-9r5x2" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.26.61.128:443: connect: no route to host"
Mar 15 07:45:32 ncn-m002 kubelet[14609]: I0315 07:45:32.688340   14609 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-9r5x2" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.26.61.128:443: connect: no route to host"
Mar 15 07:45:42 ncn-m002 kubelet[14609]: I0315 07:45:42.708703   14609 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-9r5x2" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.26.61.128:443: connect: no route to host"
Mar 15 07:45:52 ncn-m002 kubelet[14609]: I0315 07:45:52.692738   14609 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-9r5x2" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.26.61.128:443: connect: no route to host"
ncn-m002:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-6dqds                                                   2/2     Running            0          45m     10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-9r5x2                                                   0/2     Terminating        0          44m     10.252.1.11   ncn-m002   <none>           <none>
kube-system      weave-net-ct5mg                                                   2/2     Running            0          37m     10.252.1.12   ncn-m003   <none>           <none>
kube-system      weave-net-sbh22                                                   2/2     Running            0          38m     10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-vdnk8                                                   2/2     Running            0          46m     10.252.1.9    ncn-w003   <none>           <none>
ncn-m002:~ #
```

After change
------------

```
pit:~ # kubectl edit configmap cray-kyverno -n kyverno
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
data:
  generateSuccessEvents: "false"
  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'
  webhooks: '[{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system"]}]}}]'
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: cray-kyverno
    meta.helm.sh/release-namespace: kyverno
  creationTimestamp: "2023-03-12T11:37:44Z"
  labels:
    app: kyverno
    app.kubernetes.io/component: kyverno
    app.kubernetes.io/instance: cray-kyverno
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyverno
    app.kubernetes.io/part-of: kyverno
    app.kubernetes.io/version: v2.3.3
    helm.sh/chart: kyverno-v2.3.3
  name: cray-kyverno
  namespace: kyverno
  resourceVersion: "3968894"
  uid: 96549bfb-fbe1-4781-a25f-a39b69dfe0b0
pit:~ # kubectl get cm cray-kyverno -n kyverno -o yaml
apiVersion: v1
data:
  generateSuccessEvents: "false"
  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'
  webhooks: '[{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system"]}]}}]'
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: cray-kyverno
    meta.helm.sh/release-namespace: kyverno
  creationTimestamp: "2023-03-12T11:37:44Z"
  labels:
    app: kyverno
    app.kubernetes.io/component: kyverno
    app.kubernetes.io/instance: cray-kyverno
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyverno
    app.kubernetes.io/part-of: kyverno
    app.kubernetes.io/version: v2.3.3
    helm.sh/chart: kyverno-v2.3.3
  name: cray-kyverno
  namespace: kyverno
  resourceVersion: "4011782"
  uid: 96549bfb-fbe1-4781-a25f-a39b69dfe0b0
pit:~ #
pit:~ # kubectl rollout restart daemonset weave-net -n kube-system
daemonset.apps/weave-net restarted
pit:~ #
pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-4m8nx                                                   2/2     Running            0          100s    10.252.1.11   ncn-m002   <none>           <none>
kube-system      weave-net-58mqr                                                   2/2     Running            0          2m25s   10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-874bd                                                   2/2     Running            0          3m7s    10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-8stwz                                                   2/2     Running            0          3m53s   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-knxcq                                                   2/2     Running            0          53s     10.252.1.12   ncn-m003   <none>           <none>
pit:~ # journalctl -u kubelet | grep webhook
pit:~ #
```

### Tested on:

Dorian
