### PR TITLE
CASMINST-6080 Align versions of goss-servers and csm-testing

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -36,7 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.15.36-1.noarch
     - docs-csm-1.4.83-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.32-1.noarch
+    - goss-servers-1.15.36-1.noarch
     - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

CASMINST-6080 - fix goss-servers configuration on PIT node.
New release `v1.15.36` was already created for `csm-testing` and `goss-servers` packages (we have 2 packages produced from single repo). Version for `csm-testing` was already bumped in manifest with https://github.com/Cray-HPE/csm/pull/1953. This PR is to align version of `goss-servers` with version of `csm-testing`.

## Issues and Related PRs

* Resolves [CASMINST-6080](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6080)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Installed modified packages and tested that `goss-servers` systemd service can start on `pit` node.

## Risks and Mitigations
Low - fixing testing config which was never working before.
