### PR TITLE
CASMCMS-8473: Run tftp file transger subtest on workers not masters

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.31.0-1.x86_64
     - craycli-0.67.0-1.x86_64
     - ilorest-3.5.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,14 +29,15 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.2-1.x86_64
     - cray-site-init-1.31.0-1.x86_64
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.36-1.noarch
+    - csm-testing-1.15.37-1.noarch
     - docs-csm-1.4.83-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.36-1.noarch
+    - goss-servers-1.15.37-1.noarch
     - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.37-1.noarch
+    - csm-testing-1.15.38-1.noarch
     - docs-csm-1.4.83-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.37-1.noarch
+    - goss-servers-1.15.38-1.noarch
     - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

- Modifies cmsdev tool to omit tftp file transfer subtest on master NCNs
- Updates Goss suite to run that test on worker NCNs

## Issues and Related PRs

- [csm main backport manifest PR](https://github.com/Cray-HPE/csm/pull/1964)
- [csm-rpms 1.4 manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/780)
- [csm-rpms main backport manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/781)
- Resolves [CASMCMS-8473](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8473)
- Problem created by the change made in [CASMCMS-8450](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8450)
- Problem reported by [CASMTRIAGE-5071](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5071)
- [cmsdev test tool source PR](https://github.com/Cray-HPE/cms-tools/pull/73)
- [csm-testing Goss source PR](https://github.com/Cray-HPE/csm-testing/pull/458)

## Testing

See source PRs for details.

## Risks and Mitigations

Low risk -- change is minimal, and without it, the test will fail every time it is run on a master NCN (which is usually where it is run).
