### PR TITLE
CASMPET-6420 1.4 : fix test to not fail when LDAP server not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- update csm-testing to 1.15.39 (CASMPET-6420,CASMCMS-8475,CASMCMS-8475,CASMTRIAGE-5066)
 - update csm-testing to 1.15.35 (CASMTRIAGE-5066)
 - Update cray-opa to 1.29.5 (CASMPET-6366)
 - Update cray-dns-unbound to 0.7.19 (CASMNET-2070)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,10 +33,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.36-1.noarch
+    - csm-testing-1.15.39-1.noarch
     - docs-csm-1.4.84-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.36-1.noarch
+    - goss-servers-1.15.39-1.noarch
     - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This test now checks to see whether an LDAP server has been configured and does not FAIL when no LDAP server is configured.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6420](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6420)/[CAST-32467](https://jira-pro.its.hpecorp.net:8443/browse/CAST-32467)
Also includes CASMCMS-8475,CASMCMS-8475,CASMTRIAGE-5066
* Change will also be needed in `release/1.3 and release/1.4`
* Future work required by NA
* Documentation changes required in [NA
* Merge with/before/after `TBD`

## Testing

### Tested on:

  * groot (airgpapped)
  * wasp (not airgapped)

### Test description:

Original test vs fixed version
* groot - air gapped where LDAP is not configured
```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns.yaml validate
F

Failures/Skipped:

Title: Resolve external DNS
Meta:
    desc: Validates external DNS name resolves. If the test fails, the configured LDAP server was not pingable. Refer to 'operations/network/dns/Troubleshoot_Common_DNS_Issues.md' in the CSM documentation to troubleshoot external DNS issues.
    sev: 0
Command: resolve_external_dns: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 1.566s
Count: 1, Failed: 1, Skipped: 0

ncn-m001:/opt/cray/tests/install/ncn/tests # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns-fix.yaml validate
.

Total Duration: 1.544s
Count: 1, Failed: 0, Skipped: 0
```
* wasp - non airgapped where LDAP is configured
```
 ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns.yaml validate
.

Total Duration: 3.149s
Count: 1, Failed: 0, Skipped: 0

ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns-fix.yaml validate
.

Total Duration: 3.194s
Count: 1, Failed: 0, Skipped: 0
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable



