### PR TITLE
CASMCMS-8356: Update BOS for PCS and bitnami chart changes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -90,7 +90,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.9
+    version: 2.1.0
     namespace: services
     timeout: 10m
   - name: cray-cfs-api


### PR DESCRIPTION
## Summary and Scope

Updates the BOS chart to pull in changes to use PCS, and changes to the etcd chart to use the bitnami base-chart.

## Issues and Related PRs

* Resolves CASMCMS-8356

## Testing

### Tested on:

  * Ashton

### Test description:

Deployed and verified BOS functionality.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

