### PR TITLE
CASMPET-6424-1.5 : Fix two csm-vshasta-deploy test failures (CASMPET-6424,6425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing to 1.16.17 (CASMPET-6424,CASMPET-6425)
 - Update csm-testing to 1.16.13 (CASMPET-6283, CASMINST-6080 and fix shell check errors)
 - Update csm-testing to 1.16.12 (CASMTRIAGE-5066)
 - Update cray-keycloak to 5.0.0 (CASMPET-2929)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.13-1.noarch
+    - csm-testing-1.16.17-1.noarch
     - docs-csm-1.5.20-1.noarch
-    - goss-servers-1.16.13-1.noarch
+    - goss-servers-1.16.17-1.noarch
     - hpe-csm-scripts-0.5.3-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Fixes two csm-vshasta-deploy test failures.
* goss-k8s-velero-no-failed-backups - needed to wait for backup to be deleted from k8s perspective
* k8s_postgres_clusters_have_leaders - need to update based on log changes with recent postgres changes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves 
[CASMPET-6425](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6425)
csm-vshasta-deploy test failure : k8s_postgres_clusters_have_leaders
[CASMPET-6424](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6424)
csm-vshasta-deploy test failure : goss-k8s-velero-no-failed-backups

* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after - This will cover earlier changes as I expect the RPM v1.16.17 will be the most recent for today's meeting

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta v2 (dorian)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

