### PR TITLE
CASMNET-2079 - Update cray-dns-powerdns to pull in cray-postgresql to maintain postgres support with K8s 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Upgrade cray-dns-powerdns to 0.3.0 to use cray-postgresl subchart (CASMNET-2079)
+- Upgrade cray-dns-powerdns to 0.3.0 to use cray-postgresql subchart (CASMNET-2079)
 - Update csm-testing to 1.16.17 (CASMPET-6424,CASMPET-6425)
 - Update csm-testing to 1.16.13 (CASMPET-6283, CASMINST-6080 and fix shell check errors)
 - Update csm-testing to 1.16.12 (CASMTRIAGE-5066)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Upgrade cray-dns-powerdns to 0.3.0 to use cray-postgresl subchart (CASMNET-2079)
 - Update csm-testing to 1.16.17 (CASMPET-6424,CASMPET-6425)
 - Update csm-testing to 1.16.13 (CASMPET-6283, CASMINST-6080 and fix shell check errors)
 - Update csm-testing to 1.16.12 (CASMTRIAGE-5066)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -56,7 +56,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.2.8 # update platform.yaml cray-precache-images with this
+    version: 0.3.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.21
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.19
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.8
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.6
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15


### PR DESCRIPTION
## Summary and Scope

Pull in new cray-postgresql subchart in order to maintain compatibility with K8s 1.22 / CSM 1.5

## Issues and Related PRs

* Resolves [CASMNET-2079](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2079)

## Testing

### Tested on:

  * `ashton`
  * Virtual Shasta

### Test description:

* Upgraded `cray-powerdns-manager` to this release and checked that cray-dns-powerdns database and service came up and was responding to DNS queries.
* Verified chart could be rolled back to previous release and continued to respond to queries.
* Uninstalled existing `cray-powerdns-manager` release then installed chart and checked cray-dns-powerdns database came up and server was populated by `cray-powerdns-manager`

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable