### PR TITLE
CASMPET-6426:  Release csm-testing v1.16.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing to 1.16.19 (CASMPET-6426)
 - Update csm-testing to 1.16.17 (CASMPET-6424,CASMPET-6425)
 - Update csm-testing to 1.16.13 (CASMPET-6283, CASMINST-6080 and fix shell check errors)
 - Update csm-testing to 1.16.12 (CASMTRIAGE-5066)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,9 +33,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.17-1.noarch
+    - csm-testing-1.16.19-1.noarch
     - docs-csm-1.5.21-1.noarch
-    - goss-servers-1.16.17-1.noarch
+    - goss-servers-1.16.19-1.noarch
     - hpe-csm-scripts-0.5.3-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This adds the goss-check-taints test.   This test runs on master nodes only and checks that the node-role.kubernetes.io/master:NoSchedule taint exists for the node on which the test is running.  This test has been added to the ncn-healthcheck-master.yaml suite to be run anytime NCN healthcheck tests are run on master nodes and it has been added to the  ncn-upgrade-tests-master.yaml suite to be run after each master node is upgraded.

## Issues and Related PRs

* Resolves [CASMPET-6426](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6426)
* Related to [CASMTRIAGE-5049](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5049)

## Testing

### Tested on:

  * `fanta`
  * Virtual Shasta - `beau`

### Test description:

Fanta is a system where we recently found that the master taint is missing on m002.   I ran this test on both m002 where it failed and on m003 where it passed.   I ran it with both the ncn-healthcheck-master.yaml and ncn-upgrade-tests-master.yaml suites.

I also ran this on beau to make sure it works in vshasta.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

