### PR TITLE
CASMPET-6426:  Release csm-testing v1.15.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing to 1.15.40 (CASMPET-6426)
 - update csm-testing to 1.15.39 (CASMPET-6420,CASMCMS-8475,CASMCMS-8475,CASMTRIAGE-5066)
 - update csm-testing to 1.15.35 (CASMTRIAGE-5066)
 - Update cray-opa to 1.29.5 (CASMPET-6366)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.39-1.noarch
+    - csm-testing-1.15.40-1.noarch
     - docs-csm-1.4.85-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.39-1.noarch
+    - goss-servers-1.15.40-1.noarch
     - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This adds the goss-check-taints test.   This test runs on master nodes only and checks that the node-role.kubernetes.io/master:NoSchedule taint exists for the node on which the test is running.  This test has been added to the ncn-healthcheck-master.yaml suite to be run anytime NCN healthcheck tests are run on master nodes and it has been added to the  ncn-upgrade-tests-master.yaml suite to be run after each master node is upgraded.

## Issues and Related PRs

* Resolves [CASMPET-6426](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6426)
* Related to [CASMTRIAGE-5049](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5049)

## Testing

### Tested on:

  * `fanta`
  * Virtual Shasta - `beau`

### Test description:

Fanta is a system where we recently found that the master taint is missing on m002.   I ran this test on both m002 where it failed and on m003 where it passed.   I ran it with both the ncn-healthcheck-master.yaml and ncn-upgrade-tests-master.yaml suites.

I also ran this on beau to make sure it works in vshasta.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

