### PR TITLE
Improve pre-release valiadation - add deploy branch check, fail early

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -37,6 +37,11 @@ pipeline {
         disableConcurrentBuilds()
     }
 
+    environment {
+        DOCS_CSM_BRANCH = "release/1.4"
+        CSM_VSHASTA_DEPLOY_BRANCH = "release/1.4"
+    }
+
     stages {
         stage('Setup') {
             steps {
@@ -48,6 +53,30 @@ pipeline {
                         }
                         make build/.env
                     """
+                }
+            }
+        }
+
+        stage('Pre-Release Validate') {
+            when { tag "v*" }
+            parallel {
+                stage('Validate docs-csm tag') {
+                    steps {
+                        script {
+                            // verify head of correlated to DOCS-CSM branch has been tagged (built)
+                            // need to explicitly provide name of correlated to DOCS-CSM branch
+                            sh "./verify-docs-csm-tag.sh ${env.DOCS_CSM_BRANCH}"
+                        }
+                    }
+                }
+                stage('Validate csm-vshasta-deploy branch') {
+                    steps {
+                        script {
+                            if ( ! jenkinsUtils.findJob("Cray-HPE", "csm-vshasta-deploy", env.CSM_VSHASTA_DEPLOY_BRANCH) ) {
+                                error("Branch ${env.CSM_VSHASTA_DEPLOY_BRANCH} in csm-vshasta-deploy repo does not exist")
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -105,9 +134,6 @@ pipeline {
                 stage('Init') {
                     steps{
                         script {
-                            // verify head of correlated to DOCS-CSM branch has been tagged (built)
-                            // need to explicitly provide name of correlated to DOCS-CSM branch
-                            sh "./verify-docs-csm-tag.sh release/1.4"
                             env.RELEASE_VERSION = sh(script: './version.sh', returnStdout: true).trim()
                             slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting, see #${env.SLACK_CHANNEL_ALERTS} for details")
                             slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "#439fe0", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - Build starting")
@@ -196,7 +222,7 @@ pipeline {
                         env.SNYK_RESULTS_SHEET = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-snyk-results.xlsx"
                         env.SNYK_RESULTS_SHEET_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_SHEET}"
                         slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Success!\n- Release distribution: <${env.RELEASE_URL}|${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz>\n- Snyk results: <${env.SNYK_RESULTS_SHEET_URL}|${env.SNYK_RESULTS_SHEET}> (raw scan results: <${env.SNYK_RESULTS_URL}|${env.SNYK_RESULTS_FILENAME}>)")
-                        build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
+                        build(job: jenkinsUtils.findJob("Cray-HPE", "csm-vshasta-deploy", env.CSM_VSHASTA_DEPLOY_BRANCH).getFullName(), wait: false, parameters: [
                             string(name: "CSM_RELEASE", value: env.RELEASE_VERSION),
                             string(name: "ENVIRONMENT", value: "vex")
                         ])


### PR DESCRIPTION
## Summary and Scope

Currently, a pre-release check (checking that tip of docs-csm branch has tag) is executed after image validation, at the beginning of `Release`. If it fails, it wastes ~ 10 min of already calculated and verified image indexes. Also, Slack reporting in `post` block outs meaningless message into casm_release_management channel. 

This PR makes the following changes:
1. Introduces `Pre-Release validation` stage, which is executed before regular `Validation`, but only on release event (e.g. when tag is present). This validation fails early, if docs-csm is not tagged. No need to wait for image validation to complete to learn the result.
2. Added one more validation check - we'd want post-build vShasta deployment to happen on dedicated branch (`release/1.4`, `main`, etc). This is needed to maintain accurate test result history over release. New validation chekc verifies, that branch in `csm-vshasta-deploy` repo exists. 

## Testing
### Tested on:

* Jenkins

### Test description:

Verified, that missing branch is properly reported:
https://jenkins.algol60.net/job/Cray-HPE/job/csm/job/feature%252Fpre-release-validation-1.4/3/console
Verified, that existing branch is not reported:
https://jenkins.algol60.net/job/Cray-HPE/job/csm/job/feature%252Fpre-release-validation-1.4/4/console
Verified, that validation is skipped when not on a tag:
https://jenkins.algol60.net/job/Cray-HPE/job/csm/job/feature%252Fpre-release-validation-1.4/5/console

## Risks and Mitigations

Low - minor change in pipeline, easy to rollback.