### PR TITLE
CASMHMS-5944 Add -p option to HMS CT test wrapper to print pod logs

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -37,7 +37,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.19-1.noarch
     - docs-csm-1.5.22-1.noarch
     - goss-servers-1.16.19-1.noarch
-    - hpe-csm-scripts-0.5.3-1.noarch
+    - hpe-csm-scripts-0.5.4-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This change adds a '-p' command line option to the HMS CT test wrapper script that will print the logs of failed test pods to stdout at the end of the test run. By default it is not enabled since we only want to print the test run summary under normal conditions during CSM installs and upgrades. We plan to enable this option in the vShasta CI/CD pipeline when executing under goss so that more debugging output can be collected when failures occur.

### Issues and Related PRs

* Resolves CASMHMS-5944.

### Testing

This change was tested on Dorian by executing different sets of HMS CT tests using the updated wrapper script and verifying that the correct pods logs were printed under various conditions.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.