### PR TITLE
Casmpet 5937 main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Released csm-utils v1.5.1 for recent changes (CASMPET-5937)
+- Released csm-utils v1.5.1 for recent changes (CASMPET-5937, CASMPET-5787)
 - Update csm-testing to 1.16.19 (CASMPET-6426, CASMPET-6422)
 - Upgrade cray-dns-powerdns to 0.3.0 to use cray-postgresql subchart (CASMNET-2079)
 - Update csm-testing to 1.16.17 (CASMPET-6424,CASMPET-6425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Released csm-utils v1.5.1 for recent changes (CASMPET-5937)
 - Update csm-testing to 1.16.19 (CASMPET-6426, CASMPET-6422)
 - Upgrade cray-dns-powerdns to 0.3.0 to use cray-postgresql subchart (CASMNET-2079)
 - Update csm-testing to 1.16.17 (CASMPET-6424,CASMPET-6425)

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -30,6 +30,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-yq-package-3.4.1-20210615153837_40f15a6.noarch
     - loftsman-1.2.0-1.x86_64
-    - platform-utils-1.5.0-1.noarch
+    - platform-utils-1.5.1-1.noarch
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64


### PR DESCRIPTION
Update to index to pull in v1.5.1 released version of csm-utils
Update changelog: - Released csm-utils v1.5.1 for recent changes (CASMPET-5937, CASSMPET-5787)

### This pulls in changes for:
* CASMPET-5937
* CASMPET-5787

### Summary and Scope
Master - CASMPET-5937: When the ncnGetXnames.sh tool fails to obtain a token, only print unavailable

Update the ncnGetXnames tool to handle a missing TOKEN, check metal.no-wipe status via NCN bootparameters rather than bootscript. Fix bug in ncnHealthChecks handling missing TOKEN. In both ncnGetXnames and ncnHealthChecks add ssh timeout.

### Testing
Tested on dorian, 1.5.0-alpha.15, 1.5.0-alpha.17.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low - well tested.

### Requires:
N/A