### PR TITLE
CASMINST-6103: Release csm-testing v1.15.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing to 1.15.41 (CASMINST-6103)
 - Update csm-testing to 1.15.40 (CASMPET-6426)
 - update csm-testing to 1.15.39 (CASMPET-6420,CASMCMS-8475,CASMCMS-8475,CASMTRIAGE-5066)
 - update csm-testing to 1.15.35 (CASMTRIAGE-5066)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.19-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.40-1.noarch
+    - csm-testing-1.15.41-1.noarch
     - docs-csm-1.4.86-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.40-1.noarch
+    - goss-servers-1.15.41-1.noarch
     - iuf-cli-1.4.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Found that goss-servers doesn't have access to the HOSTNAME env at startup.   This makes sure it is set to run any tests that need to know the current hostname.

## Issues and Related PRs

* Resolves [CASMINST-6103](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6103)

## Testing

### Tested on:

  * `drax`

### Test description:

Tested without the change and verified that goss-servers service fails.   Tested with this change and verified that the goss-servers services is running and I was able to run the ncn-healthcheck-master endpoint.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

