### PR TITLE
Update cms-ipxe to 1.11.1 (Papaya)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.11.0
+    version: 1.11.1
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bumps cms-ipxe to 1.11.1 to enhance LACP capabilities in support of NMN bonding on UANs.

