### PR TITLE
CASMPET-6431: Update keycloak for startup scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-keycloak to 5.0.1 (CASMPET-6431)
 - Update csm-testing to 1.16.21 (CASMINST-6103)
 - Released csm-utils v1.5.1 for recent changes (CASMPET-5937, CASMPET-5787)
 - Update csm-testing to 1.16.19 (CASMPET-6426, CASMPET-6422)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.0.0
+    version: 5.0.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This fixed a change in the keycloak upstream chart that took the startup scripts and mounted them but never ran them. They have now been moved to an init container as documented in the upstream notes. The change allowed for self signed certs for ldap as well as RSA implementation to work again.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6431](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6431)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Dorian

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

