### PR TITLE
Prevent Kyverno and Weave Circular Dependency Issue+

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -135,7 +135,7 @@ spec:
           profile: dryrun
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.3.0
+    version: 1.3.2
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

* Remove `kube-system` from Kyverno webhook inspection, this to prevent chicken-and-egg problems with `weave` pod restarts
* Increase pod resource (cpu, memory) requests and limits to avoid resource exhaustion

## Issues and Related PRs

* Resolves [CASMPET-6398](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6398)
* Relates to [CASMSEC-385](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-385) 
* Change will also be needed in `main`
* Future work required by (will edit to add)

## Testing

See https://github.com/Cray-HPE/cray-kyverno/pull/12. 

### Tested on:

  * `Fanta`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

No risks known

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Testing is appropriate and complete, if applicable

