### PR TITLE
CASMCMS-8481: Make BOS V2 the default for the Cray CLI bos command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update craycli to 0.71.0 to default 'cray bos' to version v2 (CASMCMS-8481)
 - Update csm-testing to 1.16.21 (CASMINST-6103)
 - Released csm-utils v1.5.1 for recent changes (CASMPET-5937, CASMPET-5787)
 - Update csm-testing to 1.16.19 (CASMPET-6426, CASMPET-6422)

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.70.0-1.x86_64
+    - craycli-0.71.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,6 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.31.1-1.x86_64
-    - craycli-0.70.0-1.x86_64
+    - craycli-0.71.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,6 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
+    - craycli-0.71.0-1.x86_64    
     - cray-cmstools-crayctldeploy-1.11.1-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.19-1.noarch


### PR DESCRIPTION
Make Cray CLI's BOS command default to version v2 rather than v1.

## Summary and Scope

Make Cray CLI's BOS command default to version v2

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8481](issue link)

## Notes for consideration
I do not know if this RPM needs to be included in the SLES* indices used by the compute nodes.
It was present for SLES2 and SLES3, but not SLES4. I added it, but if this was a mistake, then it should be removed from all three locations.

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

