### PR TITLE
CASMHMS-5823: Add vshasta specific manifest to deploy RIE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,6 +102,21 @@ deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
 
+# Deploy Vshasta specific services
+function is_vshasta_node {
+    # This is the best check for an image specifically booted to vshasta
+    [[ -f /etc/google_system ]] && return 0
+
+    # metal images can still be booted on GCP, so check if there are any disks vendored by Google
+    # if not, we conclude that this is not GCP
+    lsblk --noheadings -o vendor | grep -q Google
+    return $?
+}
+
+if is_vshasta_node; then
+    deploy "${BUILDDIR}/manifests/vshasta.yaml"
+fi
+
 set +x
 cat >&2 <<EOF
 + CSM applications and services deployed

--- a/manifests/vshasta.yaml
+++ b/manifests/vshasta.yaml
@@ -1,0 +1,14 @@
+apiVersion: manifests/v1beta1
+metadata:
+  name: vshasta
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: csm-redfish-interface-emulator
+    source: csm-algol60
+    version: 0.1.0
+    namespace: services


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
This PR add a loftsman manifest for services that are indented to only be installed in vshasta and not baremetal CSM. The function `is_vshasta_node` is the same check that is used in our Goss tests to determine if they are running in a vshasta environment. https://github.com/Cray-HPE/csm-testing/blob/main/goss-testing/automated/run-ncn-tests.sh#L48-L56

Currently the new vshasta manifest contains the new RIE helm chart. This helm chart deploys the CSM Redfish Interface Emulator (RIE) into a CSM system. By default the RIE helm chart will add a single chassis of emulated mountain hardware to system, and have it discovered automatically by MEDS just like real hardware. This will enable the running of the HMS CT tests in vshasta, as the tests expect for some hardware to be discovered to properly exercise the HMS service.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5823

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Drax
  * Virtual Shasta - Dorian

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? N/A

#### Vshasta - Dorian testing
I put the required RIE artifacts (docker image and helm chart) and manifest into the existing extracted CSM release tarball at `/var/www/ephemeral/csm-1.5.0-alpha.17`, and made a copy of `install.sh` with my changes in this PR. I also commented out the lines that called `deploy` on the other manifests.

I verified that the install.sh script was able to detect that is was running on vshasta and successfully deployed the `csm-redfish-interface-emulator` helm chart, and the emulated hardware was discovered successfully. 
```
pit:/var/www/ephemeral/csm-1.5.0-alpha.17 # ./install_rie.sh 
++ dirname ./install_rie.sh
+ ROOTDIR=.
+ source ./lib/version.sh
++ : csm-1.5.0-alpha.17
++ return 0
+ source ./lib/install.sh
++ : https://packages.local
++ : registry.local
++ export NEXUS_URL
++ : .
++ podman_run_flags=(--network host)
++ declare -a podman_run_flags
++ [[ no == \y\e\s ]]
++ requires curl find podman realpath
++ [[ 4 -gt 0 ]]
++ command -v curl
++ shift
++ [[ 3 -gt 0 ]]
++ command -v find
++ shift
++ [[ 2 -gt 0 ]]
++ command -v podman
++ shift
++ [[ 1 -gt 0 ]]
++ command -v realpath
++ shift
++ [[ 0 -gt 0 ]]
++ vendor_images=()
++ declare -a vendor_images
+ : ./build
+ mkdir -p ./build
+ mkdir -p ./build/manifests
+ find ./manifests -name '*.yaml'
+ read manifest
++ basename ./manifests/platform.yaml
+ manifestgen -i ./manifests/platform.yaml -c ./build/customizations.yaml -o ./build/manifests/platform.yaml
+ read manifest
++ basename ./manifests/core-services.yaml
+ manifestgen -i ./manifests/core-services.yaml -c ./build/customizations.yaml -o ./build/manifests/core-services.yaml
+ read manifest
++ basename ./manifests/vshasta.yaml
+ manifestgen -i ./manifests/vshasta.yaml -c ./build/customizations.yaml -o ./build/manifests/vshasta.yaml
+ read manifest
++ basename ./manifests/nexus.yaml
+ manifestgen -i ./manifests/nexus.yaml -c ./build/customizations.yaml -o ./build/manifests/nexus.yaml
+ read manifest
++ basename ./manifests/keycloak-gatekeeper.yaml
+ manifestgen -i ./manifests/keycloak-gatekeeper.yaml -c ./build/customizations.yaml -o ./build/manifests/keycloak-gatekeeper.yaml
+ read manifest
++ basename ./manifests/sysmgmt.yaml
+ manifestgen -i ./manifests/sysmgmt.yaml -c ./build/customizations.yaml -o ./build/manifests/sysmgmt.yaml
+ read manifest
++ basename ./manifests/storage.yaml
+ manifestgen -i ./manifests/storage.yaml -c ./build/customizations.yaml -o ./build/manifests/storage.yaml
+ read manifest
++ basename ./manifests/velero-1.7-upgrade.yaml
+ manifestgen -i ./manifests/velero-1.7-upgrade.yaml -c ./build/customizations.yaml -o ./build/manifests/velero-1.7-upgrade.yaml
+ read manifest
+ [[ -f ./hpe-signing-key.asc ]]
+ kubectl create secret generic hpe-signing-key -n services --from-file=gpg-pubkey=./hpe-signing-key.asc --dry-run=client --save-config -o yaml
+ kubectl apply -f -
secret/hpe-signing-key configured
+ is_vshasta_node
+ [[ -f /etc/google_system ]]
+ return 0
+ deploy ./build/manifests/vshasta.yaml
+ loftsman ship --charts-path ./helm --manifest-path ./build/manifests/vshasta.yaml
2023-03-22T17:52:50Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-03-22T17:52:50Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~
  
2023-03-22T17:52:50Z INF Ensuring that the loftsman namespace exists command=ship
2023-03-22T17:52:50Z INF Loftsman will use the packaged charts at ./helm as the Helm install source command=ship
2023-03-22T17:52:50Z INF Running a release for the provided manifest at ./build/manifests/vshasta.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing csm-redfish-interface-emulator v0.1.0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-03-22T17:52:50Z INF Running helm install/upgrade with arguments: upgrade --install csm-redfish-interface-emulator helm/csm-redfish-interface-emulator-0.1.0.tgz --namespace services --create-namespace --set global.chart.name=csm-redfish-interface-emulator --set global.chart.version=0.1.0 chart=csm-redfish-interface-emulator command=ship namespace=services version=0.1.0
2023-03-22T17:52:55Z INF Release "csm-redfish-interface-emulator" has been upgraded. Happy Helming!
NAME: csm-redfish-interface-emulator
LAST DEPLOYED: Wed Mar 22 17:52:51 2023
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
 chart=csm-redfish-interface-emulator command=ship namespace=services version=0.1.0
2023-03-22T17:52:55Z INF Ship status: success. Recording status, manifest to configmap loftsman-vshasta in namespace loftsman command=ship
2023-03-22T17:52:55Z INF Recording log data to configmap loftsman-vshasta-ship-log in namespace loftsman command=ship
+ set +x
+ CSM applications and services deployed
install.sh: OK
```

#### Baremetal - Drax testing
I put the required RIE artifacts (docker image and helm chart) and manifest into the existing extracted CSM release tarball on drax and made a copy of `install.sh` with my changes in this PR. I also commented out the lines that called `deploy` on the other manifests.

I verified that the install.sh script was able to detect that is was running on baremetal and ignored the vshasta manifest 

```
ncn-m001:~/rsjostrand/csm/csm # ./install_rie.sh
++ dirname ./install_rie.sh
+ ROOTDIR=.
+ source ./lib/version.sh
++ : csm-1.5.0-alpha.17
++ return 0
+ source ./lib/install.sh
++ : https://packages.local
++ : registry.local
++ export NEXUS_URL
++ : .
++ podman_run_flags=(--network host)
++ declare -a podman_run_flags
++ [[ no == \y\e\s ]]
++ requires curl find podman realpath
++ [[ 4 -gt 0 ]]
++ command -v curl
++ shift
++ [[ 3 -gt 0 ]]
++ command -v find
++ shift
++ [[ 2 -gt 0 ]]
++ command -v podman
++ shift
++ [[ 1 -gt 0 ]]
++ command -v realpath
++ shift
++ [[ 0 -gt 0 ]]
++ vendor_images=()
++ declare -a vendor_images
+ : ./build
+ mkdir -p ./build
+ [[ -f ./build/customizations.yaml ]]
+ kubectl get secrets -n loftsman site-init -o 'jsonpath={.data.customizations\.yaml}'
+ base64 -d
+ mkdir -p ./build/manifests
+ find ./manifests -name '*.yaml'
+ read manifest
++ basename ./manifests/storage.yaml
+ manifestgen -i ./manifests/storage.yaml -c ./build/customizations.yaml -o ./build/manifests/storage.yaml
+ read manifest
++ basename ./manifests/keycloak-gatekeeper.yaml
+ manifestgen -i ./manifests/keycloak-gatekeeper.yaml -c ./build/customizations.yaml -o ./build/manifests/keycloak-gatekeeper.yaml
+ read manifest
++ basename ./manifests/core-services.yaml
+ manifestgen -i ./manifests/core-services.yaml -c ./build/customizations.yaml -o ./build/manifests/core-services.yaml
+ read manifest
++ basename ./manifests/velero-1.7-upgrade.yaml
+ manifestgen -i ./manifests/velero-1.7-upgrade.yaml -c ./build/customizations.yaml -o ./build/manifests/velero-1.7-upgrade.yaml
+ read manifest
++ basename ./manifests/sysmgmt.yaml
+ manifestgen -i ./manifests/sysmgmt.yaml -c ./build/customizations.yaml -o ./build/manifests/sysmgmt.yaml
+ read manifest
++ basename ./manifests/nexus.yaml
+ manifestgen -i ./manifests/nexus.yaml -c ./build/customizations.yaml -o ./build/manifests/nexus.yaml
+ read manifest
++ basename ./manifests/platform.yaml
+ manifestgen -i ./manifests/platform.yaml -c ./build/customizations.yaml -o ./build/manifests/platform.yaml
+ read manifest
++ basename ./manifests/vshasta.yaml
+ manifestgen -i ./manifests/vshasta.yaml -c ./build/customizations.yaml -o ./build/manifests/vshasta.yaml
+ read manifest
+ [[ -f ./hpe-signing-key.asc ]]
+ is_vshasta_node
+ [[ -f /etc/google_system ]]
+ lsblk --noheadings -o vendor
+ grep -q Google
+ return 1
+ set +x
+ CSM applications and services deployed
install.sh: OK
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

