### PR TITLE
Revert "CASMCMS-8481: Make Cray CLI's BOS command default to version v2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
-- Update craycli to 0.71.0 to default 'cray bos' to version v2 (CASMCMS-8481)
+
 - Update csm-testing to 1.15.41 (CASMINST-6103)
 - Update csm-testing to 1.15.40 (CASMPET-6426)
 - update csm-testing to 1.15.39 (CASMPET-6420,CASMCMS-8475,CASMCMS-8475,CASMTRIAGE-5066)

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.71.0-1.x86_64
+    - craycli-0.67.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
-    - craycli-0.71.0-1.x86_64
+    - craycli-0.67.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - craycli-0.71.0-1.x86_64    
     - cray-cmstools-crayctldeploy-1.10.2-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.19-1.noarch


### PR DESCRIPTION
Reverts Cray-HPE/csm#1990