### PR TITLE
CASMCMS-8457: Update gitea chart and customizations for new postgres base chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.5.3
+    version: 2.6.0
     namespace: services
     values:
       keycloakImage:

--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -583,14 +583,6 @@ spec:
         uriPrefix: /vcs
         externalHostname: vcs.cmn.{{ network.dns.external }}
         cray-service:
-          sqlCluster:
-            volumeSize: 50Gi
-            instanceCount: 3
-            enabled: true
-            users:
-              service_account: []
-            databases:
-              service_db: service_account
           sealedSecrets:
             - '{{ kubernetes.sealed_secrets.gitea | toYaml }}'
       capsules-warehouse-server:


### PR DESCRIPTION
## Summary and Scope

Updates the gitea chart and customizations to use the new postgres operator and base-chart.

## Issues and Related PRs

* Resolves CASMCMS-8457

## Testing

### Tested on:

  * Dorian

### Test description:

Deployed changes with new customizations and verified that data was migrated and gitea was functioning

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

