### PR TITLE
CASMPET-6393 Bump istio to 1.7.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -156,7 +156,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.7.0
+    version: 2.7.1
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This adds the MQTT broker to the ingress gateway and uses it to terminate TLS.

## Issues and Related PRs

* Resolves [CASMPET-6393](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6393)

## Testing


### Tested on:

  * groot

### Test description:

Validated certificates were added and that MQTT worked with this chart change.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable