### PR TITLE
CASMPET-6421 Add dual spire charts

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,7 +180,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.12.1
+    version: 2.13.1
+    namespace: spire
+  - name: cray-spire
+    source: csm-algol60
+    version: 1.1.1
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This adds the cray-spire chart and moves the spire chart into maintenance mode in order to support migration from spire 0.12.2 to spire 1.5.5.