### PR TITLE
CASM-4054: Bump iuf-cli version to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update iuf-cli to 1.4.3 (CASM-4054)
 - Update craycli to 0.71.0 to default 'cray bos' to version v2 (CASMCMS-8481)
 - Update csm-testing to 1.15.41 (CASMINST-6103)
 - Update csm-testing to 1.15.40 (CASMPET-6426)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - docs-csm-1.4.88-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - goss-servers-1.15.41-1.noarch
-    - iuf-cli-1.4.1-1.x86_64
+    - iuf-cli-1.4.3-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.14-1.noarch


### PR DESCRIPTION
This version of the cli enhances the debugability significantly.


