### PR TITLE
MTL-2025 catch up

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.3-1.x86_64   
     - cray-cmstools-crayctldeploy-1.10.4-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
-    - csm-node-identity-1.0.19-1.noarch
+    - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.15.41-1.noarch


### PR DESCRIPTION
Already baked into the NCNs.

This just aligns CSM to csm-rpms for release/1.4.