### PR TITLE
CASMCMS-8470: csm-config: Use artifactory authentication instead of unauthenticated mirrors

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,7 +147,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.9
+    version: 1.15.10
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Updates to csm-config with a slightly modified build process. Resulting image should be identical, but it will save us confusion in the future by updating the manifest to point to this one.

Source PR:
https://github.com/Cray-HPE/csm-config/pull/114

No main PR -- this is being included as part of a different PR for main branch.

## Risks and Mitigations

Very low risk. No change to csm-config itself.
