### PR TITLE
CASMPET-6447 Update cray-spire to 1.1.2

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -184,7 +184,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.1.1
+    version: 1.1.2
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This adds a timeout for curl to prevent the curl command from getting stuck and preventing the configuration of spire-agent on NCNs in a timely manner. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves  [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing

### Tested on:

  * Local development environment

### Test description:

Validated that all the pods started appropriately in kind. There is currently no available environment to test this change.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, no test environment available
- Was downgrade tested? If not, why? N, no test environment available
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

There may be additional issues causing test failures. Due to the lack of a proper test environment I cannot guarantee this will solve the issue.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
