### PR TITLE
CASMCMS-8485: Remove unused outdated non-test content from cmsdev

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.3-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.4-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

This PR removes sections of the cmsdev tool which have not been updated or used in years. The features being removed were never documented to customers. Nothing that is documented or used is altered or removed.

## Issues and Related PRs

* [csm-rpms manifest PR]()
* [CASMCMS-8485](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8485)
* [Source PR:](https://github.com/Cray-HPE/cms-tools/pull/83)

## Testing

See source PR for details.

## Risks and Mitigations

Very low risk. Even so, because it is getting late in the CSM 1.4 release, I decided to only make this change for CSM 1.5.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
