### PR TITLE
CASMINST-6130: Release csm-testing v1.16.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Update csm-testing to 1.16.23 (CASMINST-6130)
+- Update goss-servers to 1.16.25 (CASMINST-6130)
 - Update cray-keycloak to 5.0.1 (CASMPET-6431)
 - Update craycli to 0.71.0 to default 'cray bos' to version v2 (CASMCMS-8481)
 - Update csm-testing to 1.16.21 (CASMINST-6103)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing to 1.16.23 (CASMINST-6130)
 - Update cray-keycloak to 5.0.1 (CASMPET-6431)
 - Update craycli to 0.71.0 to default 'cray bos' to version v2 (CASMCMS-8481)
 - Update csm-testing to 1.16.21 (CASMINST-6103)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -37,7 +37,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.25-1.noarch
     - docs-csm-1.5.26-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.23-1.noarch
+    - goss-servers-1.16.25-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.22-1.noarch
+    - csm-testing-1.16.23-1.noarch
     - docs-csm-1.5.25-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.22-1.noarch
+    - goss-servers-1.16.23-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
## Summary and Scope

The HOSTNAME var being set in start-goss-servers.sh doesn't handle the hostname of the pit in vshasta because it is just "pit".   I removed the grep filter that was being used on the hostname.   It was only there because I borrowed the regex from run-ncn-tests.sh.   It is not necessary in this case.   This change will all the goss-servers service to not fail if the node has an unexpected hostname.

## Issues and Related PRs

* Resolves [CASMINST-6130](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6130)

## Testing

### Tested on:

  * `fanta`
  * Virtual Shasta - `cilium`

### Test description:

On both fanta's m002 and cilium's pit node, I started the goss-servers service and made sure that there were no errors.  I also ran `curl http://ncn-m002.hmn:8997/ncn-healthcheck-master` on fanta to make sure the endpoint still works.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

