### PR TITLE
CRAYSAT-1700: Update cray-sat image version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.2
+      - 3.21.3
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.2"
+sat_version="3.21.3"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -248,7 +248,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.63
+    version: 1.4.64
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update the cray-sat image version to 3.21.3 to update SAT's default BOS version, as well as a few small security fixes.

## Issues and Related PRs

* Resolves [CRAYSAT-1700](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1700)



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

