### PR TITLE
Fix etcd backup test

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.22-1.noarch
+    - csm-testing-1.16.24-1.noarch
     - docs-csm-1.5.25-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.22-1.noarch
+    - goss-servers-1.16.24-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Add grace period in etcd test that checks for backups

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6446

### Testing

* ashton

```
ncn-m002:~ # bash -x /tmp/foo.sh 2>&1 | grep -e old_enough -e Pass
++ check_ss_old_enough cray-bos
++ old_enough=0
++ old_enough=1
+ old_enough=1
+ result=Pass
+ '[' Pass == Pass ']'
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
