### PR TITLE
CASMPET-6447 Update csm-testing to v1.16.25

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.22-1.noarch
+    - csm-testing-1.16.25-1.noarch
     - docs-csm-1.5.25-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
     - goss-servers-1.16.22-1.noarch


### PR DESCRIPTION
This updates csm-testing RPM to v1.16.25, which includes updated tests for spire and cray-spire charts.