### PR TITLE
CASMPET-6438: (CSM 1.5/main) kyverno prevents weave-net daemonset from creating pods

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -84,7 +84,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.3.0
+    version: 1.5.1
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION

## Summary and Scope

Version number bump up for main branch due to the fix in CASMPET-6438

## Testing

https://github.com/Cray-HPE/cray-kyverno/pull/13