### PR TITLE
CASM-4058: Bump the iuf-cli release to 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update iuf-cli to 1.4.5 (CASM-4058)
 - Update iuf-cli to 1.4.4 (CASM-4056)
 - Update iuf-cli to 1.4.3 (CASM-4054)
 - Update craycli to 0.71.0 to default 'cray bos' to version v2 (CASMCMS-8481)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - docs-csm-1.4.90-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - goss-servers-1.15.41-1.noarch
-    - iuf-cli-1.4.4-1.x86_64
+    - iuf-cli-1.4.5-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.14-1.noarch


### PR DESCRIPTION
Bump the iuf-cli release to version 1.4.5.

