### PR TITLE
Bump canu to 1.7.0

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -34,7 +34,7 @@ artifactory.algol60.net/sat-docker/stable:
 artifactory.algol60.net/csm-docker/stable:
   images:
     cray-canu:
-      - 1.6.20
+      - 1.7.0
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - canu-1.6.20-1.x86_64
+    - canu-1.7.0-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.5-1.x86_64
     - csm-testing-1.14.62-1.noarch


### PR DESCRIPTION
Include CANU 1.7.0 in CSM base packages.  Includes dozens of bugfixes as well as customer acceptance required changes.

- Fixes: JIRA (CASMNET-2056)

#### Issue Type

- RFE Pull Request

Full gamut of changes at:  https://github.com/Cray-HPE/canu/releases/tag/1.7.0

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system
- [ ] I tested this on a vagrant system
- [ ] I tested this on a vshasta system
