### PR TITLE
CASMPET-6447 Bump cray-spire to 1.1.3

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -184,7 +184,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.1.1
+    version: 1.1.3
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This adds a backoff to the update-bss job and adds a 15 second timer to its curl command. This should allow it to complete properly when run from our csm test pipeline.

## Issues and Related PRs

* Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing


### Tested on:

  * drax

### Test description:

Generated the job template using helm template and applied it on drax with some minor modifications so it worked with the existing spire install.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, no environment available
- Was downgrade tested? If not, why? N, no environment available
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Limited testing was done due to the lack of an environment to install the full chart. However, due to the small change in this PR the testing should be enough to determine that the job will be applied and run successfully.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
