### PR TITLE
Casmpet 6455 1.3

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.15.0
+    version: 2.15.1
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -139,7 +139,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.2.0
+    version: 1.3.0
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This adds a network policy to limit network access for the DVS namespace.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6455](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6455)

## Testing

### Tested on:

  * drax

### Test description:

Validated that dvs pods could not access other namespaces and that the continued to function properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
