### PR TITLE
CASMHMS-5919: Fix PCS hardware scan

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -68,7 +68,7 @@ spec:
     namespace: services
   - name: cray-power-control
     source: csm-algol60
-    version: 1.2.1
+    version: 1.2.2
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

This updates the cray-power-control chart for CASMHMS-5919 - Fix PCS hardware scan hang

## Issues and Related PRs

* Resolves [CASMHMS-5919](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5919)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/30


## Risks and Mitigations

none


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

