### PR TITLE
Updates to TDS settings and run on 4 worker node systems (CASMTRIAGE-5110)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,9 +53,9 @@ mkdir -p "$BUILDDIR"
 [[ -f "${BUILDDIR}/customizations.yaml" ]] && rm -f "${BUILDDIR}/customizations.yaml"
 kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > "${BUILDDIR}/customizations.yaml"
 
-# lower cpu request for tds systems (3 workers)
+# lower cpu request for tds systems (4 workers)
 num_workers=$(kubectl get nodes | grep ncn-w | wc -l)
-if [ $num_workers -le 3 ]; then
+if [ $num_workers -le 4 ]; then
   dist=$(uname | awk '{print tolower($0)}')
   ${ROOTDIR}/shasta-cfg/utils/bin/${dist}/yq m -i --overwrite "${BUILDDIR}/customizations.yaml" "${ROOTDIR}/tds_cpu_requests.yaml"
   kubectl delete secret -n loftsman site-init


### PR DESCRIPTION
### Summary and Scope

Cleanup tds script for metallb daemonset and run on new PoR systems with 4 workers.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5110

### Testing

* frigg

Prior to running three workers were at 99%:

```
  Resource           Requests            Limits
  --------           --------            ------
  cpu                43749m (68%)        596250m (931%)
  memory             161364476672 (59%)  811658718464 (301%)
  Resource           Requests           Limits
  --------           --------           ------
  cpu                41774m (65%)       609850m (952%)
  memory             96787884288 (35%)  758387690752 (281%)
  Resource           Requests         Limits
  --------           --------         ------
  cpu                4936m (7%)       71600m (111%)
  memory             7817211136 (2%)  130756455680 (48%)
  Resource           Requests            Limits
  --------           --------            ------
  cpu                50504m (78%)        593350m (927%)
  memory             159602868992 (59%)  819905768704 (304%)
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
