### PR TITLE
CASMPET-6455: Fixup chart build (meta) to address build issue

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.3.0
+    version: 1.3.1
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
Address build failure due to partial annotations on chart. 