### PR TITLE
CASMNET-2085: Update enable-chn.yml to noop during CFS IC; CASMINST-6131: Allow CFS to set credentials in NCN images

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -142,7 +142,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.1
+    version: 1.16.2
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -142,7 +142,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.0
+    version: 1.16.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

* csm-config 1.16.1: To facilitate adding `enable-chn.yml` into default bootprep automation files for NCNs, allow `enable-chn.yml` to be a no-op during CFS Image Customization ([CASMNET-2085](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2085))

* csm-config 1.16.2: Modify CFS plays so that SSH keys and root passwords are set during NCN image customization. ([CASMINST-6131](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6131))

## Issues and Related PRs

* Resolves [CASMNET-2085](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2085)
* Resolves [CASMINST-6131](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6131)

## Testing

### CASMNET-2085

  * `lemondrop`
  
Tested an image build using `sat bootprep`. The additional CFS layer shows up in the image build, but it is skipped. Checked all three NCN image builds (kubernetes-worker, kubernetes-master, storage):
```
Running enable_chn.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Worker:!cfs_image] ********************************************
skipping: no hosts matched

...

Running enable_chn.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Worker:!cfs_image] ********************************************
skipping: no hosts matched

...

Running enable_chn.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: Management_Worker

PLAY [Management_Worker:!cfs_image] ********************************************
skipping: no hosts matched
```

### CASMINST-6131

Customized an image on wasp. Verified that the play succeeded. Downloaded the resulting image and verified that its root SSH keys and password had indeed been updated.

## Risks and Mitigations

### CASMNET-2085

The risk is that `hpc-csm-software-recipe` is updated before this change to `csm-config` is in place. To mitigate that, `hpc-csm-software-recipe` will not be updated until a CSM build is available that contains this change.

### CASMINST-6131

Low risk to include this change -- up until September of last year, this is how the plays worked anyway. This is just restoring that previous behavior. Excluding this change means that customers cannot use CFS to update the credentials in their images, meaning they must either leave them with outdated credentials, or use a less user-friendly method to update them.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

