### PR TITLE
Fix logic for etcd backup test (CASMPET-6461) (superseded by #2046)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.25-1.noarch
+    - csm-testing-1.16.26-1.noarch
     - docs-csm-1.5.27-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.25-1.noarch
+    - goss-servers-1.16.26-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
### FYI (@mtupitsyn)  - no need to merge, this is superseded by https://github.com/Cray-HPE/csm/pull/2046.

### Summary and Scope

Fix logic for detecting statefulset age.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6461

### Testing

* yasha

```
ncn-m002:/opt/cray/tests/install/ncn/scripts # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-etcd-backups.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 0.582s
Count: 2, Failed: 0, Skipped: 0
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
