### PR TITLE
CASM-3813: update cray-nls charts to use v3.4.5 argo server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-nls and cray-iuf to 3.0.1 (CASM-3813)
 - Update cray-nls and cray-iuf to 3.0.0 (CASMPET-6403)
 - Update goss-servers to 1.16.25 (CASMINST-6130)
 - Update cray-keycloak to 5.0.1 (CASMPET-6431)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,11 +244,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update cray-nls and cray-iuf charts to use the latest Argo server version v3.4.5

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASM-3813
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `dorian`
  * Local development environment
  * Virtual Shasta

### Test description:

Upgraded both cray-nls and cray-iuf charts, and verified that argo pods are up and running as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

