### PR TITLE
CASMCMS-8495: cmsdev: Update default CLI BOS version to v2

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.4-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.5-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update cmsdev test tool to reflect change in Cray CLI defaults. See [source PR](https://github.com/Cray-HPE/cms-tools/pull/87) for details.

## Issues and Related PRs

- [Source PR](https://github.com/Cray-HPE/cms-tools/pull/87)
- Test failures caused by [CASMCMS-8481](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8481)
- Resolves [CASMCMS-8495](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8495)
- [csm-rpms main manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/804)
- [csm 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2044)
- [csm-rpms 1.4 manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/805)

## Testing

See [source PR](https://github.com/Cray-HPE/cms-tools/pull/87) for details.

## Risks and Mitigations

Without this change, the cmsdev bos test will fail on all CSM 1.4+ systems.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
