### PR TITLE
CASMCMS-8495: cmsdev: Update default CLI BOS version to v2

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64   
-    - cray-cmstools-crayctldeploy-1.10.4-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.5-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
1.4 backport of https://github.com/Cray-HPE/csm/pull/2043