### PR TITLE
CASMPET-6447 Bump cray-spire to 1.1.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -184,7 +184,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.1.3
+    version: 1.1.4
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

- Fixed incorrect namespace in cray-spire networkpolicy
- Fixed /tokens path permission issues between request-ncn-join-token and spire-agent 1.5.5
- Increased the time spire-update-bss will take to attempt to update BSS and how long it keeps the job pods around.

## Issues and Related PRs

* Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * yasha
  * Local development environment

### Test description:

Validated Charts changes fixed the issue on yasha

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should fix it.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
