### PR TITLE
CASMINST-6097 Add HMS CT tests and CMS service tests

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.25-1.noarch
+    - csm-testing-1.16.27-1.noarch
     - docs-csm-1.5.28-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.25-1.noarch
+    - goss-servers-1.16.27-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Brings in version `1.16.27` of `csm-testing` and `goss-servers`, which supports additional test suites for HMS and CMS post-installation testing.

FYI - this supersedes https://github.com/Cray-HPE/csm/pull/2041.

## Issues and Related PRs

* Resolves [CASMINST-6097](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6097)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Tested in vShasta by overriding stock `csm-testing` and `goss-servers` packages and running tests:
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-vshasta-deploy/detail/feature%2Fhms-cms-tests/40/tests

New tests are executed, output recorded.

## Risks and Mitigations

Low - test framework only.
