### PR TITLE
CASMNET-2056 main

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -34,7 +34,7 @@ artifactory.algol60.net/sat-docker/stable:
 artifactory.algol60.net/csm-docker/stable:
   images:
     canu:
-      - 1.7.0
+      - 1.7.1
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - bos-reporter-2.0.7-1.x86_64
-    - canu-1.7.0-1.x86_64
+    - canu-1.7.1-1.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64


### PR DESCRIPTION
Include CANU 1.7.1 in CSM base packages.  Rolls back a python library in CANU that broke the RPM build.

- Fixes: JIRA (CASMNET-2056)

https://github.com/Cray-HPE/canu/releases/tag/1.7.1

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system
- [ ] I tested this on a vagrant system
- [ ] I tested this on a vshasta system