### PR TITLE
CASMPET-6439 Increase update-bss job retries

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -185,7 +185,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.12.2
+    version: 2.12.3
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This job is causing test failures due to BSS failing to come up before its retries are exceeded. This updates those retries to fix this issue.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6439](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6439)

## Testing

### Tested on:

  * Local development environment

### Test description:

Back ports a change that was tested in the 1.5 testing pipeline.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

