### PR TITLE
CASMPET-6447 Update spire-agent socket paths in tests

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.27-1.noarch
+    - csm-testing-1.16.28-1.noarch
     - docs-csm-1.5.29-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
     - goss-servers-1.16.27-1.noarch


### PR DESCRIPTION
## Summary and Scope

The /root/spire path is obsolete and should be changed to it's new path, /var/lib/spire.

## Issues and Related PRs

* Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing

No environments available to test.

### Test description:

This is another attempt to fix a test being run in the CSM 1.5 test pipeline.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This may not be the issue, but it should still be updated.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
