### PR TITLE
CASMTRIAGE-5124 backport to release/1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-nls helm chart to 1.4.65 (CASMTRIAGE-5124)
 - Update iuf-cli to 1.4.5 (CASM-4058)
 - Update csm-testing to 1.15.42 (CASMINST-6130)
 - Update iuf-cli to 1.4.4 (CASM-4056)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -244,7 +244,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 1.4.64
+    version: 1.4.65
     namespace: argo
   - name: cray-hnc-manager
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Issue: Try to run management node rollout with Management_Master first, then Management_Worker next. The second run doesn't work, and it keeps trying to do Management_Master.

Root cause: Patch activity was not implemented as a true patching capability ... it was basically replacing input parameters whenever it received a patch request where the input parameters at least had the media directory set. In a particular case, the admin was not even specifying media directory on the command line, and hence because of the absence of media directory, the change from Management_Master to Management_Worker was not being persisted.

Fix: Use proper patching capability, where a struct with pointers is used to unmarshal the incoming json so that we can detect the difference between an empty value that was part of the JSON patch and a nil pointer which means nothing was set for that attribute.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5124](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5124)

## Testing

Tested on Gamora and wrote unit tests.

### Test description:

Tried to reproduce before the fix and after.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

