### PR TITLE
CASMNET-2056 1.3

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -34,7 +34,7 @@ artifactory.algol60.net/sat-docker/stable:
 artifactory.algol60.net/csm-docker/stable:
   images:
     cray-canu:
-      - 1.7.0
+      - 1.7.1
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - canu-1.7.0-1.x86_64
+    - canu-1.7.1-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.5-1.x86_64
     - csm-testing-1.14.62-1.noarch


### PR DESCRIPTION
Include CANU 1.7.1 in CSM base packages.  Rolls back a python library in CANU that broke the RPM build.

- Fixes: JIRA (CASMNET-2056)

https://github.com/Cray-HPE/canu/releases/tag/1.7.1

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system
- [ ] I tested this on a vagrant system
- [ ] I tested this on a vshasta system