### PR TITLE
MTL-2132 Downgrade storage-CEPH

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -51,10 +51,11 @@ PIT_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=0.4.68
+# NOTE: MTL-2132 makes an executive decision to explicitly pull in a different kernel for storage nodes for this release.
+STORAGE_CEPH_IMAGE_ID=0.3.59
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
+    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/5.3.18-150300.59.87-default-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/initrd.img-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.xz"
 )
 


### PR DESCRIPTION
Due to CASMTRIAGE-5033's persistence, we are pulling the old 1.3 storage-ceph images into 1.4.0. This entails pulling in an old kernel as well.
