### PR TITLE
Bump cray-opa to 1.32.3

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: cert-manager-init
   - name: cray-opa
     source: csm-algol60
-    version: 1.32.1
+    version: 1.32.3
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -184,7 +184,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.1.4
+    version: 1.3.0
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
[SKERN-6686](https://jira-pro.its.hpecorp.net:8443/browse/SKERN-6686):

cray-opa: Add a cos-config-service API in OPA rule and related unit tests.
cray-spire: Add workloads for cos-config-service.

[CASMCMS-8463](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8436)

cray-opa: This mod grants several specific verb privilege to accounts that match the tenant-admin role. The tenant-admin role is applied to specific keycloak groups for individual tenants, and will be populated to the group automatically via tapms instantiation of tenants.