### PR TITLE
CASMCMS-8502: cmsdev: Update dependencies to resolve CVEs

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.6-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.7-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Dependabot reported a couple of CVEs in dependencies of cms-tools.

They aren't critical CVEs and I suspect we aren't using the affected code in a way that would cause us problems, but may as well update the dependencies to avoid the risk. This does that.

I am not backporting to 1.3 since they are not big issues and I don't think we're shipping more RPMs for 1.3. I will backport to 1.4 however.

## Issues and Related PRs

- [csm-rpms main manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/809)
- [csm 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2065)
- [csm-rpms 1.4 manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/810)

## Testing

I tested on wasp to make sure no regressions were introduced.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
