### PR TITLE
CASMNET-2082 - Create short zones and DNAME records in PowerDNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-powerdns-manager to 0.8.0 (CASMNET-2082)
 - Update cray-nls and cray-iuf to 3.0.2 (CASMTRIAGE-5124)
 - Update cray-nls and cray-iuf to 3.0.1 (CASM-3813)
 - Update cray-nls and cray-iuf to 3.0.0 (CASMPET-6403)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -61,5 +61,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.7.6
+    version: 0.8.0 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -70,7 +70,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.21
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.19
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.6
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.0
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

Create "short" zones in PowerDNS (`nmn` for example) and an associated DNAME record linking it to the fully qualified domain.

This allows PowerDNS to respond to short name queries so the caller doesn't need to know the FQDN of the system e.g.
```
ncn-m001:~ # host api.nmnlb 10.92.100.85
Using domain server:
Name: 10.92.100.85
Address: 10.92.100.85#53
Aliases:

api.nmnlb.mug.hpc.amslabs.hpecorp.net has address 10.92.100.71
api.nmnlb is an alias for api.nmnlb.mug.hpc.amslabs.hpecorp.net.
nmnlb has DNAME record nmnlb.mug.hpc.amslabs.hpecorp.net.
```

## Issues and Related PRs

* Resolves [CASMNET-2082](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2082) and [CASMNET-1806](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1806)


## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Deployed on mug, all short zones are created successfully.
```
/ $ pdnsutil list-all-zones
252.10.in-addr.arpa
mug.hpc.amslabs.hpecorp.net
106.10.in-addr.arpa
107.10.in-addr.arpa
hsn.mug.hpc.amslabs.hpecorp.net
100.92.10.in-addr.arpa
1.10.in-addr.arpa
253.10.in-addr.arpa
254.10.in-addr.arpa
hmn.mug.hpc.amslabs.hpecorp.net
100.94.10.in-addr.arpa
nmn.mug.hpc.amslabs.hpecorp.net
can.mug.hpc.amslabs.hpecorp.net
162.102.10.in-addr.arpa
can
mtl.mug.hpc.amslabs.hpecorp.net
hmnlb
nmnlb
mtl
cmn.mug.hpc.amslabs.hpecorp.net
nmn
cmn
hmn
hsn
hmnlb.mug.hpc.amslabs.hpecorp.net
nmnlb.mug.hpc.amslabs.hpecorp.net
```
Short zones contain the required DNAME record.
```
/ $ pdnsutil list-zone hmn
$ORIGIN .
hmn	3600	IN	DNAME	hmn.mug.hpc.amslabs.hpecorp.net
hmn	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
hmn	3600	IN	SOA	primary.mug.hpc.amslabs.hpecorp.net hostmaster.hmn 2023032401 10800 3600 604800 3600
```
Manual testing shows the DNAME record is functioning as expected.
```
ncn-m001:~ # host ncn-m001.hmn 10.92.100.85
Using domain server:
Name: 10.92.100.85
Address: 10.92.100.85#53
Aliases:

x3000c0s1b0n0.hmn.mug.hpc.amslabs.hpecorp.net has address 10.254.1.4
ncn-m001.hmn is an alias for ncn-m001.hmn.mug.hpc.amslabs.hpecorp.net.
ncn-m001.hmn.mug.hpc.amslabs.hpecorp.net is an alias for x3000c0s1b0n0.hmn.mug.hpc.amslabs.hpecorp.net.
hmn has DNAME record hmn.mug.hpc.amslabs.hpecorp.net.
```
Performance testing was carried out using all records for the NCNs.

## Risks and Mitigations

This behaviour isn't free, DNAME use increases DNS server load due to the extra query required to retrieve the fully qualified domain name. Performance testing has showed that performance is roughly on par with regular lookups with slightly worse latency.

### Lookup of NMN short name of all NCNs (e.g. `ncn-m001.nmn`)
```
[Status] Command line: dnsperf -s 10.92.100.85 -d /tmp/shortname.nmn -c 256 -T 16 -n 100000 -S 15 -l 120
[Status] Sending queries (to 10.92.100.85:53)
[Status] Started at: Wed Apr  5 08:54:26 2023
[Status] Stopping after 120.000000 seconds or 100000 runs through file
1680684881.515434: 32619.716471
1680684896.528085: 32668.847094
1680684911.543153: 32584.734215
[Status] Testing complete (end of file)

Statistics:

  Queries sent:         1900000
  Queries completed:    1900000 (100.00%)
  Queries lost:         0 (0.00%)

  Response codes:       NOERROR 1900000 (100.00%)
  Average packet size:  request 30, response 165
  Run time (s):         58.340388
  Queries per second:   32567.489952

  Average Latency (s):  0.002552 (min 0.000036, max 0.069408)
  Latency StdDev (s):   0.008129
```

### Lookup of fully qualified NMN record of all NCNs (e.g. `ncn-m001.nmn.mug.hpc.amslabs.hpecorp.net`)
```
/ $  dnsperf -s 10.92.100.85 -d /tmp/fqdn.nmn  -c 256 -T 16 -n 100000 -S 15 -l 120
DNS Performance Testing Tool
Version 2.11.0

[Status] Command line: dnsperf -s 10.92.100.85 -d /tmp/fqdn.nmn -c 256 -T 16 -n 100000 -S 15 -l 120
[Status] Sending queries (to 10.92.100.85:53)
[Status] Started at: Wed Apr  5 08:55:38 2023
[Status] Stopping after 120.000000 seconds or 100000 runs through file
1680684953.827400: 32234.548309
1680684968.840103: 32236.699813
1680684983.852104: 32222.220076
[Status] Testing complete (end of file)

Statistics:

  Queries sent:         1900000
  Queries completed:    1900000 (100.00%)
  Queries lost:         0 (0.00%)

  Response codes:       NOERROR 1900000 (100.00%)
  Average packet size:  request 58, response 102
  Run time (s):         59.023437
  Queries per second:   32190.602523

  Average Latency (s):  0.002586 (min 0.000031, max 0.063771)
  Latency StdDev (s):   0.007779
```
### Lookup of FQDN NMN record of all NCNs (e.g. `x3000c0s1b0n0.nmn.mug.hpc.amslabs.hpecorp.net`)
```
/ $  dnsperf -s 10.92.100.85 -d /tmp/xname.nmn  -c 256 -T 16 -n 100000 -S 15 -l 120
DNS Performance Testing Tool
Version 2.11.0

[Status] Command line: dnsperf -s 10.92.100.85 -d /tmp/xname.nmn -c 256 -T 16 -n 100000 -S 15 -l 120
[Status] Sending queries (to 10.92.100.85:53)
[Status] Started at: Wed Apr  5 08:57:18 2023
[Status] Stopping after 120.000000 seconds or 100000 runs through file
1680685053.528111: 31949.216533
1680685068.540153: 32537.478912
1680685083.544107: 32167.054098
[Status] Testing complete (end of file)

Statistics:

  Queries sent:         1900000
  Queries completed:    1900000 (100.00%)
  Queries lost:         0 (0.00%)

  Response codes:       NOERROR 1900000 (100.00%)
  Average packet size:  request 63, response 79
  Run time (s):         58.895479
  Queries per second:   32260.540745

  Average Latency (s):  0.002584 (min 0.000035, max 0.069005)
  Latency StdDev (s):   0.007694
```

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

