### PR TITLE
CASMINST-6194: also put cloud-init-required rpms in the SP3 repo

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -27,3 +27,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - craycli-0.71.0-1.x86_64
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
+
+# To support SP3 storage nodes with SP4 K8S nodes:
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
+  rpms:
+    - canu-1.7.1-1.x86_64
+    - csm-testing-1.15.43-1.noarch
+    - goss-servers-1.15.43-1.noarch


### PR DESCRIPTION
## Summary and Scope

In order to support SP3 storage nodes with SP4 K8S nodes, also put the rpms required by cloud-init into the sp3 repo.