### PR TITLE
Add missing parms to cephfs storage class with sp3 image (CASMPET-6471)

### DIFF
--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -15,4 +15,4 @@ spec:
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs
-    version: 3.6.2
+    version: 3.6.3


### PR DESCRIPTION
### Summary and Scope

Add missing parms to cephfs storage class with sp3 image

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6471

### Testing

* `vex`

```
pit:~ # kubectl get sc ceph-cephfs-external -o yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{},"name":"ceph-cephfs-external"},"parameters":{"clusterID":"e1b63294-d356-11ed-a56f-42010afc0104","csi.storage.k8s.io/controller-expand-secret-name":"csi-cephfs-secret","csi.storage.k8s.io/controller-expand-secret-namespace":"default","csi.storage.k8s.io/node-stage-secret-name":"csi-cephfs-secret","csi.storage.k8s.io/node-stage-secret-namespace":"default","csi.storage.k8s.io/provisioner-secret-name":"csi-cephfs-secret","csi.storage.k8s.io/provisioner-secret-namespace":"default","fsName":"cephfs","pool":"cephfs.cephfs.data"},"provisioner":"cephfs.csi.ceph.com"}
  creationTimestamp: "2023-04-05T18:31:25Z"
  name: ceph-cephfs-external
  resourceVersion: "839435"
  uid: 6745e47a-8665-455b-bcfb-1e193c274769
parameters:
  clusterID: e1b63294-d356-11ed-a56f-42010afc0104
  csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret
  csi.storage.k8s.io/controller-expand-secret-namespace: default
  csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
  csi.storage.k8s.io/node-stage-secret-namespace: default
  csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
  csi.storage.k8s.io/provisioner-secret-namespace: default
  fsName: cephfs
  pool: cephfs.cephfs.data
provisioner: cephfs.csi.ceph.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
