### PR TITLE
CASMINST-6194 Undo SP4/SP3 repo tom-foolery

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,14 +23,11 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
+    - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.71.0-1.x86_64
+    - csm-testing-1.15.43-1.noarch
+    - goss-servers-1.15.43-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 
-# To support SP3 storage nodes with SP4 K8S nodes:
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
-  rpms:
-    - canu-1.7.1-1.x86_64
-    - csm-testing-1.15.43-1.noarch
-    - goss-servers-1.15.43-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - bos-reporter-2.0.7-1.x86_64
-    - canu-1.7.1-1.x86_64
+    - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64


### PR DESCRIPTION
Pull `canu`, `csm-testing`, and `goss-servers` from their SP3 repo to keep things kosher.

PR #2075 pulled these from SP4 repos into the SP3 CSM repo definition, but `csm-testing` and `goss-servers` were already published to an SP3 endpoint. `canu` recently had SP3 builds disabled, and these were toggled back on last night.
