### PR TITLE
CASMCMS-8514/CASMCMS-8529 cmsdev: Simplify BOS test, provide additional debug information on failures.

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64   
-    - cray-cmstools-crayctldeploy-1.10.6-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.7-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64   
-    - cray-cmstools-crayctldeploy-1.10.7-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.8-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Minor simplifcations to BOS test to avoid potential false failures.

[csm-rpms 1.4 manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/817)

Also included the fix for CASMCMS-8529 to provide additional debug information on test failures.

## Testing

I tested on wasp to verify that the BOS test still worked, and to verify that no regression bugs were introduced.

## Risks and Mitigations

Small change. Worth the risk to avoid BOS false failures.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
