### PR TITLE
CASMCMS-8496/CASMCMS-8513/CASMCMS-8514/CASMCMS-8529: cmsdev: Test fixes and improvements

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.8-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.9-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.7-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.8-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Fixes bugs causing the BOS and VCS tests to fail on CSM 1.5. Simplifies the BOS test to avoid false failures. Reduces redundancy in test output. Includes additional debug information on failures.

## Issues and Related PRs

- [CASMCMS-8496 source PR](https://github.com/Cray-HPE/cms-tools/pull/93)
- [CASMCMS-8513 source PR](https://github.com/Cray-HPE/cms-tools/pull/96/)
- [CASMCMS-8514 source PR](https://github.com/Cray-HPE/cms-tools/pull/97/)
- Resolves [CASMCMS-8496](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8496), [CASMCMS-8513](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8513), [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514), [CASMTRIAGE-5129](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5129), [CASMTRIAGE-5130](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5130)
- [csm-rpms main manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/818)
- [csm 1.4 manifest backport PR](https://github.com/Cray-HPE/csm/pull/2080) -- only contains part of [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514) changes.
- [csm-rpms 1.4 manifest backport PR](https://github.com/Cray-HPE/csm-rpms/pull/817) -- only contains part of [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514) changes.

[csm-rpms 1.4 second manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/820)
[csm-rpms main second manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/821)

## Testing

See source PRs for details.

## Risks and Mitigations

Low risk. Without these, some tests will always fail on CSM 1.5.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
