### PR TITLE
CASMTRIAGE-5163: Update to latest product catalog

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -173,8 +173,10 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/coredns/coredns:
       - 1.10.0
 
-    # Images needed by IUF
+    # Images needed by IUF and possibly non-CSM products
     cray-product-catalog-update:
+      - 1.3.1
+      - 1.3.2
       - 1.8.2
     cray-nexus-setup:
       - 0.9.3

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,13 +126,13 @@ spec:
     namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.7.3
+    version: 1.8.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.7.3
+            tag: 1.8.0
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3
@@ -169,7 +169,7 @@ spec:
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version: 1.3.1
+    version: 1.8.2
     namespace: services
 
   # Cray UAS Manager service


### PR DESCRIPTION
## Summary and Scope

1) Update the overall Cray Product Catalog chart to the latest
2) Update to a version of the barebones image importer that uses the latest Cray Product Catalog updater
3) Explicitly pull in other Cray Product Catalog updater images that may be needed by other products

## Issues and Related PRs

- Resolves [CASMTRIAGE-5163](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5163)
- [cray-import-kiwi-recipe-image source PR](https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/pull/25)
- [image-recipes source PR](https://github.com/Cray-HPE/image-recipes/pull/48)
- [main manifest PR](https://github.com/Cray-HPE/csm/pull/2083)

## Testing

The latest updater version has been available for a while and has been extensively tested. We were already including it in our builds, we just weren't using it for this one thing (the barebones import).

## Risks and Mitigations

Minor risk, especially compared to the certainty of corrupting the product catalog during upgrades.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
