### PR TITLE
CASMCMS-8512/CASMTRIAGE-5163: Fix problems with product catalog & gitea

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -172,8 +172,10 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/coredns/coredns:
       - 1.10.0
 
-    # Images needed by IUF
+    # Images needed by IUF and possibly non-CSM products
     cray-product-catalog-update:
+      - 1.3.1
+      - 1.3.2
       - 1.8.2
     cray-nexus-setup:
       - 0.9.3

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.6.0
+    version: 2.6.1
     namespace: services
     values:
       keycloakImage:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -121,13 +121,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.7.3
+    version: 1.8.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.7.3
+            tag: 1.8.0
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3
@@ -164,7 +164,7 @@ spec:
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version: 1.3.1
+    version: 1.8.2
     namespace: services
 
   # Cray UAS Manager service


### PR DESCRIPTION
## Summary and Scope

This includes two things:

1. [CASMTRIAGE-5163](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5163): main backport of [this 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2082)
2. [CASMCMS-8512](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8512): Update to a Gitea chart with a typo fixed, so that the database backups will work

The Gitea fix is only needed for CSM 1.5.

## Issues and Related PRs

- [gitea source PR](https://github.com/Cray-HPE/gitea/pull/45)

## Testing

See source PR.

## Risks and Mitigations

Low risk. And without this, the VCS database will not be backed up.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
