### PR TITLE
Change bgp test to test only the worker being rebuilt (CASMTRIAGE-5164)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.28-1.noarch
+    - csm-testing-1.16.29-1.noarch
     - docs-csm-1.5.34-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.27-1.noarch
+    - goss-servers-1.16.29-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Change bgp test when run after worker rebuild to only check that worker.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5164

### Testing

* `surtur`

```
ncn-w003:~ # TARGET_NCN=ncn-w003 GOSS_BASE=/opt/cray/tests/install/ncn SW_ADMIN_PASSWORD='!nitial0' /opt/cray/tests/install/ncn/scripts/check_bgp_neighbors_established_brad.sh
NAME      DATA   AGE
metallb   1      3d5h
CAN
Running: canu validate network bgp --verbose --network all --password XXXXXXXX
PASS
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
