### PR TITLE
Change bgp test to test only the worker being rebuilt (CASMTRIAGE-5164)

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.71.0-1.x86_64
-    - csm-testing-1.15.43-1.noarch
-    - goss-servers-1.15.43-1.noarch
+    - csm-testing-1.15.44-1.noarch
+    - goss-servers-1.15.44-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,10 +34,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.43-1.noarch
+    - csm-testing-1.15.44-1.noarch
     - docs-csm-1.4.99-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.43-1.noarch
+    - goss-servers-1.15.44-1.noarch
     - iuf-cli-1.4.5-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Change bgp test when run after worker rebuild to only check that worker.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5164

### Testing

* `surtur`

```
ncn-w003:~ # TARGET_NCN=ncn-w003 GOSS_BASE=/opt/cray/tests/install/ncn SW_ADMIN_PASSWORD='!nitial0' /opt/cray/tests/install/ncn/scripts/check_bgp_neighbors_established_brad.sh
NAME      DATA   AGE
metallb   1      3d5h
CAN
Running: canu validate network bgp --verbose --network all --password XXXXXXXX
PASS
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
