### PR TITLE
CRAYSAT-1705: Bump cray-sat to 3.21.4

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.3
+      - 3.21.4
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.3"
+sat_version="3.21.4"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

Normally, a BOS v2 staged session will reach the state "running" when it is considered finished staging. However, if that BOS v2 staged session does not apply to any components (for example, when a limit parameter is used that does not overlap with any of the nodes in the session template), the session will go straight to "complete" instead.

Rename the `target_state` argument to the BOSV2SessionWaiter to `target_states` and change the type to a list of acceptable target states. This allows us to call it with the single state "complete" when waiting on a non-staged session and to call it with the states "complete" and "running" when waiting on a staged session.

## Issues and Related PR

* Resolves [CRAYSAT-1705](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1705)

## Testing

### Tested on:

  * locally on macbook
  * gamora

### Test description:

Added new unit tests. Tested on gamora as follows:

* Run `sat bootsys boot --stage bos-operations --staged-session` using a session template that applies to application nodes, but pass `--bos-limit Compute`. The session should finish and `sat bootsys` should return.
* Run the same test as above but pass two session templates: one for compute nodes and one for UANs. Both should finish and `sat bootsys` should return. Only computes should be staged.
* Run the same test as above but without `--staged-session`. The computes should actually be rebooted.

## Risks and Mitigations

This is a pretty small change that just adds an additional acceptable target state for staged BOS v2 sessions.

Unit tests cover the changed code.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
