### PR TITLE
Be specific about podman graphOption index (CASMTRIAGE-5174)

### DIFF
--- a/hack/load-container-image.sh
+++ b/hack/load-container-image.sh
@@ -58,7 +58,7 @@ if command -v podman >/dev/null 2>&1; then
 	transport="containers-storage"
 	run_opts="--rm --network none --privileged --ulimit=host"
 
-        fuse_exe=$(podman info -f json | jq -r ".store.graphOptions[].Executable")
+        fuse_exe=$(podman info -f json | jq -r '.store.graphOptions["overlay.mount_program"].Executable')
         if [ "$fuse_exe" == "/usr/bin/fuse-overlayfs" ]; then
           skopeo_dest="${transport}:${image}"
         else


### PR DESCRIPTION
### Summary and Scope

Change parsing of podman output to allow for other graphOption array entries.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5174

### Testing

* `beau`

```
pit:~ # podman info -f json | jq -r '.store.graphOptions["overlay.mount_program"].Executable'
/usr/bin/fuse-overlayfs
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
