### PR TITLE
Update bitnami docker image with latest (CASMPET-6365)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,7 +220,7 @@ spec:
     namespace: services
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.5.3
+    version: 0.5.4
     namespace: services
   - name: cray-etcd-migration-setup
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Later code for bitnami etcd chart and fixes for CLBO after power off/on.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6365

### Testing

* `ashton`

Scale down to zero and back up to three members:

```
etcd 19:09:19.70
etcd 19:09:19.70 Welcome to the Bitnami etcd container
etcd 19:09:19.71 Subscribe to project updates by watching https://github.com/bitnami/containers
etcd 19:09:19.72 Submit issues and feature requests at https://github.com/bitnami/containers/issues
etcd 19:09:19.73
etcd 19:09:19.74 INFO  ==> ** Starting etcd setup **
etcd 19:09:19.77 INFO  ==> Validating settings in ETCD_* env vars..
etcd 19:09:19.80 WARN  ==> You set the environment variable ALLOW_NONE_AUTHENTICATION=yes. For safety reasons, do not use this flag in a production environment.
etcd 19:09:19.82 INFO  ==> Initializing etcd
etcd 19:09:19.83 INFO  ==> Generating etcd config file using env variables
etcd 19:09:19.92 INFO  ==> Detected data from previous deployments
etcd 19:09:19.94 DEBUG ==> Setting data directory permissions to 700 in a recursive way (required in etcd >=3.4.10)
etcd 19:09:20.04 DEBUG ==> There are no enough active endpoints!
etcd 19:09:20.05 WARN  ==> Cluster not responding!
etcd 19:09:20.07 INFO  ==> Restoring etcd cluster from snapshot
Deprecated: Use `etcdutl snapshot restore` instead.

2023-04-12T19:09:20Z	info	snapshot/v3_snapshot.go:248	restoring snapshot	{"path": "/snapshots/cray-bos-bitnami-etcd/db-2023-04-12_19-01", "wal-dir": "/bitnami/etcd/data/member/wal", "data-dir": "/bitnami/etcd/data", "snap-dir": "/bitnami/etcd/data/member/snap", "stack": "go.etcd.io/etcd/etcdutl/v3/snapshot.(*v3Manager).Restore\n\tgo.etcd.io/etcd/etcdutl/v3@v3.5.7/snapshot/v3_snapshot.go:254\ngo.etcd.io/etcd/etcdutl/v3/etcdutl.SnapshotRestoreCommandFunc\n\tgo.etcd.io/etcd/etcdutl/v3@v3.5.7/etcdutl/snapshot_command.go:147\ngo.etcd.io/etcd/etcdctl/v3/ctlv3/command.snapshotRestoreCommandFunc\n\tgo.etcd.io/etcd/etcdctl/v3/ctlv3/command/snapshot_command.go:129\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:856\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.1.3/command.go:960\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:897\ngo.etcd.io/etcd/etcdctl/v3/ctlv3.Start\n\tgo.etcd.io/etcd/etcdctl/v3/ctlv3/ctl.go:107\ngo.etcd.io/etcd/etcdctl/v3/ctlv3.MustStart\n\tgo.etcd.io/etcd/etcdctl/v3/ctlv3/ctl.go:111\nmain.main\n\tgo.etcd.io/etcd/etcdctl/v3/main.go:59\nruntime.main\n\truntime/proc.go:255"}
2023-04-12T19:09:20Z	info	membership/store.go:141	Trimming membership information from the backend...
2023-04-12T19:09:20Z	info	membership/cluster.go:421	added member	{"cluster-id": "5a9864fc76d9fc6f", "local-member-id": "0", "added-peer-id": "2b4984dc5c79bd55", "added-peer-peer-urls": ["http://cray-bos-bitnami-etcd-2.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"]}
2023-04-12T19:09:20Z	info	membership/cluster.go:421	added member	{"cluster-id": "5a9864fc76d9fc6f", "local-member-id": "0", "added-peer-id": "6a95fcc74f1f8616", "added-peer-peer-urls": ["http://cray-bos-bitnami-etcd-1.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"]}
2023-04-12T19:09:20Z	info	membership/cluster.go:421	added member	{"cluster-id": "5a9864fc76d9fc6f", "local-member-id": "0", "added-peer-id": "75c23b83965f55de", "added-peer-peer-urls": ["http://cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"]}
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
