### PR TITLE
Increase size of common etcd snapshot PVC (CASMPET-6419)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -224,7 +224,7 @@ spec:
     namespace: services
   - name: cray-etcd-migration-setup
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: services
   - name: cray-metallb
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Increase size of etcd cephfs pvc for snapshots.  Going with 200G which should leave more than enough space based on audit of current usage of the etcd-backups bucket:

```
11958904 ~12G (mug)
14889340 ~14G (baldar)
17817388 ~17G (shandy)
21434928 ~21G (hela)
```

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6419

### Testing

* `ashton`

```
ncn-m002:~ # kubectl get pvc -n services bitnami-etcd-snapshotter -o json | jq -r .spec.resources.requests.storage
200G
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
