### PR TITLE
CASMTRIAGE-5190: Fix HSM Empty Memory Discovery for EX Hardware

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 5.0.2
+    version: 7.0.1
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Updates the cray-smd chart version for CASMTRIAGE-5190 - Fix HSM Empty Memory Discovery for EX Hardware

## Issues and Related PRs

* Merge after https://github.com/Cray-HPE/csm/pull/2104
* Resolves [CASMTRIAGE-5190](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5190)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/108

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

