### PR TITLE
CASMTRIAGE-5190: Fix HSM Empty Memory Discovery for EX Hardware CSM 1.4

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 5.0.0
+    version: 5.0.3
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Updates the cray-smd chart version for CASMTRIAGE-5190 - Fix HSM Empty Memory Discovery for EX Hardware

This also pulls in the following HSM changes to CSM 1.4:
- Added CT test coverage for most remaining APIs.
- Fixed several CT test bugs and made various improvements.
- Moved hardware-sensitive CT tests into separate stage.
- CASMHMS-5863 - Added Reacquire() function to the reservations client library.
- CASMHMS-5902: Linting of language in API spec (no content changes); corrected markdown formatting issue in changelog

All of which are not functional changes to HSM itself.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5190](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5190)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/108

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


