### PR TITLE
CASMTRIAGE-5190: Fix HSM Empty Memory Discovery for EX Hardware CSM 1.3.2

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,8 +20,8 @@ spec:
     namespace: services
     values:
       global:
-        appVersion: 1.58.2
-        testVersion: 1.58.2
+        appVersion: 1.58.3
+        testVersion: 1.58.3
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

Updates the cray-smd chart version for CASMTRIAGE-5190 - Fix HSM Empty Memory Discovery for EX Hardware

## Issues and Related PRs

* Resolves [CASMTRIAGE-5190](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5190)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/108

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

