### PR TITLE
CASMCMS-8540: Update cf-gitea-import version to resolve security vulnerability

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -55,7 +55,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.0.4
 
     cf-gitea-import:
-      - 1.9.1
+      - 1.9.3
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
main backport of https://github.com/Cray-HPE/csm/pull/2111