### PR TITLE
CASMMON-295 Monitor the SMF Kafka server and zookeeper

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -215,7 +215,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.4
+    version: 0.26.40
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope
Need patched version of SMA-1.7 that allows Nersc to install HPE-built software and keep their scalability settings. 
e.g. rsyslog-aggregator config file needs to persist, a number of instances of rsyslog-aggregator, kafka, elasticsearch need to persist, and es-curator needs to create indexes with the configured number of shards. The Kafka partition count needs to persist. 

## Issues and Related PRs
[CASMSMF-7353](https://jira-pro.its.hpecorp.net:8443/browse/CASMSMF-7353)

* Resolves [CASMMON-296](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-296) and [CASMMON-295](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-295)

## Testing
_List the environments in which these changes were tested._

### Tested on:
  * `<drax>`
  * Local development environment
  * Virtual Shasta
![image](https://user-images.githubusercontent.com/110656037/232461912-fddb77c8-7652-49d5-8f35-e5fadfc53dc3.png)
![image](https://user-images.githubusercontent.com/110656037/232462028-486c71ca-5cdd-455e-8f02-2bf2fc813198.png)

### Test description:
Tested successfully.
- Was the upgrade tested? Yes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact