### PR TITLE
VSHA-553 Update cms-ipxe to 1.11.2 for vshasta support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- update cms-ipxe to 1.11.2 for vShasta support
 - update cray-console-data, node and operator for stability improvements
 - update cray-dns-unbound to 0.7.20 (CASMTRIAGE-5155)
 - Update cray-powerdns-manager to 0.8.0 (CASMNET-2082)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -86,7 +86,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.11.1
+    version: 1.11.2
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update cms-ipxe to 1.11.2 to support vShasta. The cms-ipxe customizations can now be set up to tell cray-ipxe to generate the KPXE binaries needed by vShasta to support CSM mediated network boot of nodes.

This is a backward compatible restoration of previously lost funtionality.

## Issues and Related PRs

* Resolves [VSHA-553](https://jira-pro.its.hpecorp.net:8443/browse/VSHA-553)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Configured cms-ipxe for KPXE binaries and verified that I could pull the binary through cray-tftp and that the resulting binary was, indeed, a KPXE binary. Removed the special configuration and verified that the original EFI binary was generated.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

There are no known risks resulting from this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

