### PR TITLE
tapms: bump docker and chart version to match (CASMTRIAGE-5215)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -190,5 +190,5 @@ spec:
   # Tapms service
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.10
+    version: 0.0.11
     namespace: tapms-operator


### PR DESCRIPTION
### Summary and Scope

Bump docker and chart versions to match.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5215

### Testing

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
