### PR TITLE
CASMCMS-8531: Update cf-gitea-import to 1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cf-gitea-import to 1.9.4 (CASMCMS-8531)
 - update cray-console-data, node and operator for stability improvements
 - update cray-dns-unbound to 0.7.20 (CASMTRIAGE-5155)
 - Update cray-powerdns-manager to 0.8.0 (CASMNET-2082)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -55,7 +55,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.0.4
 
     cf-gitea-import:
-      - 1.9.3
+      - 1.9.4
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
## Summary and Scope

Updates cf-gitea-import to use a shallow clone that reduces memory consumption.

## Issues and Related PRs

* Resolves CASMCMS-8531

## Testing

### Tested on:

  * Mug

### Test description:

See cf-gitea-import PR

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

