### PR TITLE
Update HBTD chart for ETCD changes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -48,7 +48,7 @@ spec:
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 2.1.4
+    version: 3.0.0
     namespace: services
   - name: cray-hms-hmnfd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates HBTD chart to use ETCD  break-out chart. This is necessary for ETCD due to the changes in the upcoming k8s 1.22.

Once we move to k8s 1.22 these changes are not backwards compatible.

This was missed in the original PR for this work.

## Issues and Related PRs

* Resolves
* [CASMHMS-5870](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5870)

* These changes are ONLY FOR CSM 1.5, they will not work in older CSMs

## Testing

### Tested on:

  * Virtual Shasta Ashton

### Test description:

Manually upgraded and downgraded all charts. Verified as much as I could in the environment that the services worked after the upgrades and data was preserved in the ETCD instance.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

