### PR TITLE
CASMINST-6238: Back out HSM CT Test Changes from CSM 1.4

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,9 +16,12 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 5.0.3
+    version: 5.0.0
     namespace: services
     values:
+      global:
+        appVersion: 2.2.1
+        testVersion: 2.2.1
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

Fix CT test issues for HSM caused by unintentionally bringing in CSM 1.5 CT functionality.

## Issues and Related PRs

* Resolves [CASMINST-6238](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6238)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/110

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

