### PR TITLE
Read-only api cleanup to follow CSM standards (CASMPET-6433)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -190,5 +190,5 @@ spec:
   # Tapms service
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.11
+    version: 0.0.13
     namespace: tapms-operator


### PR DESCRIPTION
### Summary and Scope

Use standard port, get path and dns name working so services can hit api like: 

http://cray-tapms/v1/tenants

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6433

### Testing

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
