### PR TITLE
Stop using hudson.model.Item getFullName, which requires approval

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,6 +40,7 @@ pipeline {
     environment {
         DOCS_CSM_BRANCH = "main"
         CSM_VSHASTA_DEPLOY_BRANCH = "main"
+        CSM_VSHASTA_DEPLOY_ENVIRONMENT = "yasha"
     }
 
     stages {
@@ -222,13 +223,13 @@ pipeline {
                         env.SNYK_RESULTS_SHEET = "${env.RELEASE_NAME}-${env.RELEASE_VERSION}-snyk-results.xlsx"
                         env.SNYK_RESULTS_SHEET_URL = "${env.RELEASE_BASEURL}/${env.SNYK_RESULTS_SHEET}"
                         slackSend(channel: env.SLACK_CHANNEL_NOTIFY, color: "good", message: "<${env.BUILD_URL}|CSM ${env.RELEASE_VERSION}> - :white_check_mark: Success!\n- Release distribution: <${env.RELEASE_URL}|${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz>\n- Snyk results: <${env.SNYK_RESULTS_SHEET_URL}|${env.SNYK_RESULTS_SHEET}> (raw scan results: <${env.SNYK_RESULTS_URL}|${env.SNYK_RESULTS_FILENAME}>)")
-                        build(job: jenkinsUtils.findJob("Cray-HPE", "csm-release-internal-upload", env.CSM_VSHASTA_DEPLOY_BRANCH).getFullName(), wait: false, parameters: [
+                        build(job: "Cray-HPE/csm-release-internal-upload/main", wait: false, parameters: [
                             string(name: "CSM_TARBALL", value: "${env.WORKSPACE}/dist/${env.RELEASE_NAME}-${env.RELEASE_VERSION}.tar.gz"),
                             string(name: "POSTUPLOAD_REPORT", value: "always")
                         ])
-                        build(job: jenkinsUtils.findJob("Cray-HPE", "csm-vshasta-deploy", env.CSM_VSHASTA_DEPLOY_BRANCH).getFullName(), wait: false, parameters: [
+                        build(job: "Cray-HPE/csm-vshasta-deploy/${env.CSM_VSHASTA_DEPLOY_BRANCH}", wait: false, parameters: [
                             string(name: "CSM_RELEASE", value: env.RELEASE_VERSION),
-                            string(name: "ENVIRONMENT", value: "yasha")
+                            string(name: "ENVIRONMENT", value: env.CSM_VSHASTA_DEPLOY_ENVIRONMENT)
                         ])
                     }
                 }


### PR DESCRIPTION
## Summary and Scope

Latest 1.4.0 build failed with the error:

    Error when executing success post condition:
    org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method hudson.model.Item getFullName
	    at org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist.rejectMethod(StaticWhitelist.java:229)

This happened, because there was an explicit override placed for `hudson.model.Item getFullName` in Jenkins settings before, and it was accidentally cleared. Generally, we should not rely on such overrides in jenkins settings. In this particular case, we just don't need to use this method.
