### PR TITLE
Add tenant-admin role mapping to tenant keycloak groups (CASMPET-6503)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -190,5 +190,5 @@ spec:
   # Tapms service
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.0.13
+    version: 0.0.14
     namespace: tapms-operator


### PR DESCRIPTION
### Summary and Scope

Assign tenant-admin role to tenant specific keycloak groups.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6503

### Testing

![Screen Shot 2023-04-25 at 1 45 43 PM](https://user-images.githubusercontent.com/7515828/234396807-31efa0a8-4c18-4e40-9952-c10abaf99ee1.png)

```
1.6824523041273134e+09	INFO	controllers.Tenants	Created Keycloak group: vcluster-coke-tenant-admin	{"tenants": "tenants/vcluster-coke"}
1.6824523041273816e+09	INFO	controllers.Tenants	Ensuring Keycloak realm role (tenant-admin) is assigned to Keycloak group: vcluster-coke-tenant-admin	{"tenants": "tenants/vcluster-coke"}
1.68245230897035e+09	INFO	controllers.Tenants	Assigned Keycloak realm role (tenant-admin) to Keycloak group: %!(EXTRA string=vcluster-coke-tenant-admin)	{"tenants": "tenants/vcluster-coke"}
1.6824523089704456e+09	INFO	controllers.Tenants	Updating tenant status	{"tenants": "tenants/vcluster-coke"}
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
