### PR TITLE
Fix etcd balance test to allow for stuck/dead pods (CASMPET-6507)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,10 +35,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.30-1.noarch
+    - csm-testing-1.16.31-1.noarch
     - docs-csm-1.5.39-1.noarch
     - hpe-csm-scripts-0.5.4-1.noarch
-    - goss-servers-1.16.30-1.noarch
+    - goss-servers-1.16.31-1.noarch
     - iuf-cli-1.5.0-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Allow for more than the minimum etcd pods, in case we've got one stuck in terminating on a dead worker.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6507

### Testing

```
ncn-m002:/opt/cray/tests/install/ncn/scripts # ./etcd_health_check.sh
--- Check that the Correct Number of Pods Running, Check Endpoint Health, Check if Any Alarms are Set ---
### 5 etcd cluster(s) being checked
PASS                cray-bos: Expected 3 etcd members, got 3 members. Endpoint health check passed. No alarms set.
PASS                cray-bss: Expected 3 etcd members, got 3 members. Endpoint health check passed. No alarms set.
PASS                cray-fas: Expected 3 etcd members, got 3 members. Endpoint health check passed. No alarms set.
PASS              cray-hmnfd: Expected 3 etcd members, got 3 members. Endpoint health check passed. No alarms set.
PASS      cray-power-control: Expected 3 etcd members, got 3 members. Endpoint health check passed. No alarms set.
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
