### PR TITLE
CASM-3868: Improve existing image check logic for ims-python-helper

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.2.1
+      - 2.3.0
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,13 +126,13 @@ spec:
     namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.8.0
+    version: 1.9.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.8.0
+            tag: 1.9.0
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3


### PR DESCRIPTION
## Summary and Scope

[main branch manifest PR](https://github.com/Cray-HPE/csm/pull/2132)

Update `ims-load-artifacts` image to 2.3.0 to pull in changes to check if recipes and images are already updated based on their artifact checksums, instead of just on their names.

## Issues and Related PRs
* Resolves [CASM-3868](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3868)
* Also resolves [CASMINST-6081](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6081)

## Testing

This was tested manually against the `ims-python-helper` library with a test harness script by uploading the same recipe multiple times, and then checking with recipes with different contents, and with recipes with the same name but empty links.

See testing here: https://gist.github.com/jack-stanek-hpe/e8f01617d29a6a588156a2e2cca49b35

## Risks and Mitigations
N/A

## Pull Request Checklist

- [x] Testing is appropriate and complete, if applicable

