### PR TITLE
bump version of packaging-tools to v0.12.6 to increase rpm-sync timeo…

### DIFF
--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -39,7 +39,7 @@ if [ ! -z "$REPOCREDSVARNAME" ]; then
     REPO_CREDS_DOCKER_OPTIONS="-e ${REPOCREDSVARNAME}"
     REPO_CREDS_RPMINDEX_OPTIONS="-c ${REPOCREDSVARNAME}"
 fi
-docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.4 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
+docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
 -d  https://download.opensuse.org/repositories/filesystems:/ceph/openSUSE_Leap_15.3/                                        opensuse_leap/15.3 \
 -d  https://artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph/openSUSE_Leap_15.3/                       mirror/opensuse_leap/15.3 \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \

--- a/hack/verify-helm-index.sh
+++ b/hack/verify-helm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.4"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6"
 
 set -o errexit
 set -o pipefail

--- a/hack/verify-rpm-index.sh
+++ b/hack/verify-rpm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.4"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6"
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
## Summary and Scope

bump version of packaging-tools to v0.12.6 to increase rpm-sync timeout to 10 mins

## Issues and Related PRs

* Resolves [issue id](issue link)

## Testing

Tested locally

### Tested on:

  * Local development environment

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
