### PR TITLE
CASMCMS-8549: cmsdev: Add list of valid tests to --help output

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.9-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.10-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.80.0-1.x86_64
     - csm-node-identity-1.0.20-1.noarch


### PR DESCRIPTION
## Summary and Scope

When helping NERSC last week, we noticed that the cmsdev test tool doesn't provide a list of valid tests to run when you ask it to show its usage message -- it is only visible when you specify an invalid test or omit the test argument. This changes that, so that you can get the information from the usage message itself.

No changes made to the tests themselves.

## Issues and Related PRs

- [Source PR](https://github.com/Cray-HPE/cms-tools/pull/102)
- [csm-rpms manifest PR]()
- Resolves [CASMCMS-8549](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8549)

## Testing

See source PR.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
