### PR TITLE
CASMPET-6488 Bump spire to 2.10.3

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -201,7 +201,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.10.2
+    version: 2.10.3
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

Fixes an issue where dvs-mqtt workloads were incorrectly created with the wrong SpiffeID.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6488](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6488)

## Testing

### Tested on:

  * Local development environment


### Test description:

Validated correct workloads were created

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, would have no affect
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

