### PR TITLE
CASMPET-6517 Override cray-spire server.fqdn

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -753,6 +753,10 @@ spec:
         trustDomain: shasta
         server:
           fqdn: spire.local
+      cray-spire:
+        trustDomain: shasta
+        server:
+          fqdn: spire.nmnlb.{{ network.dns.external }}
       cray-keycloak-users-localize:
         sealedSecrets:
           - '{{ kubernetes.sealed_secrets.keycloak_users_localize | toYaml }}'


### PR DESCRIPTION
This allows the fqdn to be registered via externaldns.