### PR TITLE
CASMPET-4948: Update cray-kiali for cmn separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-kiali to 0.5.1 (CASMPET-4948)
 - Update cf-gitea-import to 1.9.4 (CASMCMS-8531)
 - update cms-ipxe to 1.11.2 for vShasta support
 - update cray-console-data, node and operator for stability improvements
@@ -79,18 +80,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Released cray-keycloak 3.6.1 to fix postgres database restore issue (CASMPET-5936)
 - Update csm-config, cray-crus and console-node for to use sp4 base images (CASMCMS-8076)
 - Update craycli to 0.63.0 to fix python 3.6 deprecation warning
-- Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils 
-- Released cray-nls-charts 1.4.0 to add new mount for storage workflows 
+- Release platform-utils v1.4.0, removes duplicate copy of ceph-service-status.sh from utils
+- Released cray-nls-charts 1.4.0 to add new mount for storage workflows
 - Update cfs api, operator and trust for pod priority escalation
 - Released goss-servers/csm-testing v1.14.47 for ceph goss test failure output change
-- Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix 
+- Released goss-servers/csm-testing v1.14.46 for goss_check_static_routes fix
 - Released spire 2.10.0 and cray-nls 1.3.8 for security fixes (CASMPET-5873)
 - Added all istio images to Nexus precache (CASMPET-5888)
 - Released cfs-operator 1.16.0 to fix issues with additional inventory
 - Released cray-keycloak-users-localize v1.11.2 to fix keycloak localize not copying all users to /etc/passwd (CASMPET-5743)
 - Released csm-utils v1.3.5 for recent ncnHealthChecks etcd fixes
 - Released goss-servers/csm-testing v1.14.36 for goss etcd fixes
-- Update update-uas to v1.7.4 - Update gateways tests to include HMN gateway (CASMNET-1741) 
+- Update update-uas to v1.7.4 - Update gateways tests to include HMN gateway (CASMNET-1741)
 - Released cray-opa 1.22.0 to whitelist keycloak for hmn (CASMPET-5860)
 - Released csm-utils v1.3.4 for recent changes
 - Released new cray-istio, cray-istio-deploy, cray-istio-operator, and cray-kiali charts to support istio 1.10.6 (CASMPET-5796)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -156,7 +156,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.5.0
+    version: 0.5.1
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update the virtual service to use the new custoomer-admin-gateway that will be required in 1.5 for all customer accessible services

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-4948](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-4948)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

