### PR TITLE
CASMINST-6275 Publish image digest along with CSM tarball

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -193,6 +193,10 @@ pipeline {
                                     {
                                     "pattern": "dist/*-snyk-results.xlsx",
                                     "target": "csm-releases/${RELEASE_NAME}/${RELEASE_MAJOR_MINOR}/"
+                                    },
+                                    {
+                                    "pattern": "dist/*-images.txt",
+                                    "target": "csm-releases/${RELEASE_NAME}/${RELEASE_MAJOR_MINOR}/"
                                     }
                                 ]
                             }""",

--- a/release.sh
+++ b/release.sh
@@ -324,6 +324,9 @@ rsync -aq "${BUILDDIR}/scans/" "${scandir}/"
 # Save snyk results spreadsheet as a separate asset
 cp "${scandir}/docker/snyk-results.xlsx" "${ROOTDIR}/dist/${RELEASE}-snyk-results.xlsx"
 
+# Save image digest as a separate asset
+cp "${ROOTDIR}/build/images/index.txt" "${ROOTDIR}/dist/${RELEASE}-images.txt"
+
 # Package scans as an independent archive
 tar -C "${scandir}/.." --owner=0 --group=0 -cvzf "${scandir}/../$(basename "$scandir").tar.gz" "$(basename "$scandir")/" --remove-files
 


### PR DESCRIPTION
## Summary and Scope

We need to store `build/images/index.txt` as a separate asset. We will use it later to produce patch builds, perform troubleshooting, re-generate snyk scans (if needed), etc.

## Issues and Related PRs

* Resolves [CASMINST-6275](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6275)
* Part of [CASMINST-6221](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6221) epic

## Testing
### Tested on:

   * not tested
 
### Test description:

Testing this will require full build. We'll do a full build eventually (probably today) and will see if this change cause any trouble. If it is, it will be very easy to rollback.

## Risks and Mitigations

Low - pipeline change only, easy to rollback.
