### PR TITLE
CASMINST-6282 Avoid duplicate image list calculation

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -52,6 +52,8 @@ pipeline {
                             echo >&2 "error: parallel: command not found"
                             exit 1
                         }
+                        make clean
+                        rm -fr dist
                         make build/.env
                     """
                 }
@@ -153,8 +155,6 @@ pipeline {
                             withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
                                 sh """
                                     . build/.env/bin/activate
-                                    make clean
-                                    rm -fr dist
                                     ./release.sh
                                 """
                             }


### PR DESCRIPTION
## Summary and Scope

We calculate `build/images/index.txt` twice during CSM build, once during mandatory `Validate Images` stage, second time during `Release` stage (invoked only on tagged builds). Second time, file is not reused, because it gets cleaned up between 1st and 2nd stage. The suggestion is to move cleanup to the beginning  of build. so that file generated at 1st step will be reused at 2nd step.

## Issues and Related PRs

* Resolves [CASMINST-6282](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6282)

## Testing
### Tested on:

   * not tested
 
### Test description:

Testing this will require full build. We'll do a full build eventually (probably today) and will see if this change cause any trouble. If it is, it will be very easy to rollback.

## Risks and Mitigations

Low - pipeline change only, easy to rollback.
