### PR TITLE
CASMTRIAGE-5317: Restore CRUS subcommands to Cray CLI

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,6 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - craycli-0.71.0-1.x86_64
+    - craycli-0.72.0-1.x86_64
     - bos-reporter-2.0.0-beta.3.x86_64
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
-    - craycli-0.71.0-1.x86_64
+    - craycli-0.72.0-1.x86_64
     - csm-testing-1.15.44-1.noarch
     - goss-servers-1.15.44-1.noarch
     - ilorest-3.5.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Restore CRUS subcommands to Cray CLI.

## Issues and Related PRs

- Corresponding docs PR to document known issue in 1.4.0: https://github.com/Cray-HPE/docs-csm/pull/3759
