### PR TITLE
Revert "CASM-3868: Improve existing image check logic for ims-python-helper"

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.3.0
+      - 2.2.1
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,13 +126,13 @@ spec:
     namespace: services
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 1.9.0
+    version: 1.8.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 1.9.0
+            tag: 1.8.0
   - name: cray-ims
     source: csm-algol60
     version: 3.8.3


### PR DESCRIPTION
Reverts Cray-HPE/csm#2133