### PR TITLE
CASMCSM-8517: Updating rpms for bos-reporter

### DIFF
--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
-    - bos-reporter-2.1.1-1.x86_64
+    - bos-reporter-2.3.0-1.noarch.rpm
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.1.1-1.x86_64
+    - bos-reporter-2.3.0-1.noarch.rpm

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,4 +25,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.1.1-1.x86_64
+    - bos-reporter-2.3.0-1.noarch.rpm

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.1.1-1.x86_64
+    - bos-reporter-2.3.0-1.noarch.rpm
     - canu-1.7.1-1.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

ARM work defined in epic - [CASM-4066](https://jira-pro.its.hpecorp.net:8443/browse/CASM-4066) requires that RPMs be built as `noarch` from `x86_64`

- Fixes: [CASMCMS-8604](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8604)