### PR TITLE
CASMCMS-8516: cfs-reporter rpm noarch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cfs-state-reporter to use noarch rpms (CASMCMS-8516)
 - Update cilium images to 1.13.2 and add Hubble images (CASMPET-6479)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121)
 - Update cray-nls and cray-iuf charts to 3.1.0 (CASMPET-6235)

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - cfs-state-reporter-1.9.0-1.x86_64
+    - cfs-state-reporter-1.9.2-1.noarch
     - cfs-trust-1.6.0-1.x86_64
     - bos-reporter-2.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - canu-1.7.1-1.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64
-    - cfs-state-reporter-1.9.1-1.x86_64
+    - cfs-state-reporter-1.9.2-1.noarch
     - cfs-trust-1.6.3-1.x86_64
     - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
     - cray-site-init-1.31.2-1.x86_64


### PR DESCRIPTION
## Summary and Scope

ARM work requires to change some x86 rpms to build as noarch instead. Currently cfs state reporter has released and is
now publishing noarch rpms.

## Issues and Related PRs

Resolves - https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8603

