### PR TITLE
CASMCMS-7594: Update gitea to add CMN gateway

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.6.1
+    version: 2.6.2
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

Updates the gitea chart for a change that adds the CMN/customer-admin-gateway to the gateways for the external ui and git endpoints. 

## Issues and Related PRs

* Resolves CASMCMS-7594

## Testing

### Tested on:

  * Mug

### Test description:

Deployed and validated access via endpoints

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

