### PR TITLE
FAS Chart to 2.1.7 - CASMTRIAGE-5322

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -48,7 +48,7 @@ spec:
     namespace: services
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 2.1.6
+    version: 2.1.7
     namespace: services
   - name: cray-hms-hbtd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updated FAS to chart version 2.1.7 - This was necessary to bring in FAS v1.24.1

The version of FAS should have been updated to v1.24.1 instead of reusing v1.24.0 -- Other than the version, there is no change to the current v1.24.0, but the original v1.24.0 had a issue with the new semver python library.

## Issues and Related PRs

CASMTRIAGE-5322

## Testing

Tested locally

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

