### PR TITLE
CASMMON-299 Grok-exporter issue with running on ncn-m001

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.27.5
+    version: 0.27.8
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

_Grok-exporter is not running on ncn-m001 as it comes up last when nodes are installed on pit. The other master nodes of m002 or m003 is taking ownership of the m001 instance before it is up._

_This fix will resolve the issue and wait for m001 to take the ownership of the pod._

_Minor fix with canu-test dashboard filename as it is conflicting with the config-map of the same name and causing issues._

## Issues and Related PRs

* Resolves [CASMMON-299](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-299)
* Resolves [CASMTRIAGE-5335](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5335)

## Testing

### Tested on:

  * `<mug>`
  * `<hela>`
  * Local development environment
  * Virtual Shasta

### Test description:

_Tested and success verified._
ncn-m001:/mnt/developer/sum # kubectl get all -n sysmgmt-health | grep grok
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-2cc8z              1/1     Running            0          3m34s
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-htsps              1/1     Running            0          3m35s
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-khrhs              1/1     Running            0          3m35s
service/cray-sysmgmt-health-grok-exporter              ClusterIP   10.18.245.121   <none>        9144/TCP                     2d17h
deployment.apps/cray-sysmgmt-health-grok-exporter              3/3     3            3           2d17h
replicaset.apps/cray-sysmgmt-health-grok-exporter-6b64849ff5              3         3         3       3m35s
replicaset.apps/cray-sysmgmt-health-grok-exporter-d68865c8                0         0         0       2d17h

ncn-m001:/mnt/developer/sum # kubectl get pod -n sysmgmt-health -o wide | grep grok-exporter
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-2cc8z              1/1     Running            0          4m3s    10.32.0.5     ncn-m003   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-htsps              1/1     Running            0          4m4s    10.33.128.0   ncn-m001   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-khrhs              1/1     Running            0          4m4s    10.35.0.0     ncn-m002   <none>           <none>

ncn-m001:/mnt/developer/sum # kubectl get all -n sysmgmt-health | grep canu-test
pod/cray-sysmgmt-health-canu-test-7b5fc744dd-vrb8z                  2/2     Running            0          2d17h
service/cray-sysmgmt-health-canu-test                  ClusterIP   10.24.234.135   <none>        9144/TCP                     2d17h
deployment.apps/cray-sysmgmt-health-canu-test                  1/1     1            1           2d17h
replicaset.apps/cray-sysmgmt-health-canu-test-7b5fc744dd                  1         1         1       2d17h

![image](https://user-images.githubusercontent.com/110656037/236754471-4d4bc1b5-14f5-4913-8f95-7d3cbf79315b.png)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
