### PR TITLE
CASMCMS-8602: TESTS: cmsdev: Get values from cray-ipxe-settings configmap instead of using hard-coded defaults

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.11.10-1.x86_64
+    - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
     - cray-site-init-1.31.2-1.x86_64
     - craycli-0.81.0-1.x86_64
     - csm-node-identity-1.0.20-1.noarch


### PR DESCRIPTION
## Summary and Scope

This PR improves the cmsdev iPXE/TFTP test so that it covers all iPXE binaries being generated, and so that it uses the `cray-ipxe-settings` configmap as its source of truth, rather than using hard-coded default values. This makes it a more comprehensive and robust test, and also lays the groundwork for further changes needed as part of the ARM enablement work.

## Issues and Related PRs

- [source PR](https://github.com/Cray-HPE/cms-tools/pull/105)

## Testing

See source PR for details.

## Risks and Mitigations

Low risk. On systems with default configurations, the change is slight. On other systems, without these changes, the existing test would fail.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
