### PR TITLE
Add management switches to HSM/PCS for status tracking

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: services
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.1
+    version: 7.0.2
     namespace: services
     values:
       cray-service:
@@ -31,7 +31,7 @@ spec:
     namespace: services
   - name: cray-hms-reds
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -64,11 +64,21 @@ spec:
     namespace: services
   - name: cray-hms-rts
     source: csm-algol60
-    version: 2.0.4
+    version: 3.0.0
     namespace: services
+  - name: cray-hms-rts
+    releaseName: cray-hms-rts-snmp
+    source: csm-algol60
+    version: 3.0.0
+    namespace: services
+    values:
+      rtsDoInit: false
+      environment:
+        cray_hms_rts:
+          backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.0
+    version: 2.0.1
     namespace: services
 
   # CMS


### PR DESCRIPTION
## Summary and Scope

This updates cray-reds, cray-smd, cray-power-control, and cray-hms-rts to provide status tracking for all management switches for CASM-2974 - xtalive equivalent API in PCS.

cray-reds - Adds default SNMP credentials to vault for management switches
cray-hms-rts - Stands up a SNMP backed redfish interface for HSM and PCS to talk to
cray-smd - Discovers the management switches via RTS's redfish interface
cray-power-control - Gets availability status of the management switches from RTS's redfish interface.

## Issues and Related PRs

* Resolves [CASMHMS-5950](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5950)

## Testing

For testing, see:
cray-reds - https://github.com/Cray-HPE/hms-reds/pull/37
cray-hms-rts - https://github.com/Cray-HPE/hms-redfish-translation-layer/pull/46
cray-smd - https://github.com/Cray-HPE/hms-smd/pull/113
cray-power-control - https://github.com/Cray-HPE/hms-power-control/pull/33


## Risks and Mitigations

low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

