### PR TITLE
CASMPET-6161: Bump cray-certmanager to 0.7.0 rm cray-certmanager-init

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -118,10 +118,10 @@ spec:
     source: csm-algol60
     version: 1.29.0   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
-  - name: cray-certmanager-init
+  - name: cray-certmanager
     source: csm-algol60
-    version: 0.6.0
-    namespace: cert-manager-init
+    version: 0.7.0
+    namespace: cert-manager      
   - name: cray-opa
     source: csm-algol60
     version: 1.32.3
@@ -138,10 +138,6 @@ spec:
     source: csm-algol60
     version: 0.8.0
     namespace: pki-operator
-  - name: cray-certmanager
-    source: csm-algol60
-    version: 0.6.0
-    namespace: cert-manager
   - name: cray-s3
     source: csm-algol60
     version: 1.1.0


### PR DESCRIPTION
## Summary and Scope

As part of cert-manager upgrades, remove cray-certmanager-init, which no longer exists as all it did was install crd's in the past. cray-certmanager is bumped to 0.7.0 to include 1.5.5 with default params to take its place.

This change is not backwards compatible at all due to how cert-manager works.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

betrand

### Tested on:

  * betrand
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

