### PR TITLE
CASMINST-6336 Package latest versioned docs-csm with csm build [main]

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -36,7 +36,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.16.32-1.noarch
-    - docs-csm-1.5.45-1.noarch
     - hpe-csm-scripts-0.5.5-1.noarch
     - goss-servers-1.16.32-1.noarch
     - iuf-cli-1.5.0~alpha.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Currently, we package `docs-csm` by referring it in `rpm/cray/csm/sle-15sp4/index.yaml` file. This approach has some issues:
1. Version of docs-csm must be updated manually before each build - a lot of redundant builds and some manual work
2. We can't implement [CASMINST-6284](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6284) (auto-tag docs-csm during csm build)
3. Even though we refer to specific version in `rpm/cray/csm/sle-15sp4/index.yaml` file, the file packaged with csm tarball is actually `docs-csm-latest.noarch.rpm`. This happens to a bug in packaging tools (`nevra` field for docs-csm-latest still contains version of original package, so it overrides original package):
https://jenkins.algol60.net/job/Cray-HPE/job/csm/job/v1.5.0-alpha.39/2/consoleText

        ...
        [2023-05-09T22:52:10.993Z] 2023-05-09 22:52:10,756	INFO	[200 OK] https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/1.5/noarch/docs-csm-latest.noarch.rpm
        ...
        [2023-05-09T23:04:31.863Z] 23:04:31: Adding pkg: /data/noarch/docs-csm-latest.noarch.rpm
        ...

Therefore, I think we need to apply special handling to docs-csm: identify real version from docs-csm-latest in right folder, then download actual `docs-csm-X.Y.X-1.noarch.rpm` file and check signature.## Issues and Related PRs

## Testing
### Tested on:

  * Jenkins

### Test description:

Temporarily modified Jenkinsfile to run release.sh script. The versioned `docs-csm` was successfully retrieved, signature presence verified and package included into csm build:
https://jenkins.algol60.net/job/Cray-HPE/job/csm/job/feature%252Fdocs-csm-latest/4/consoleFull
    
    00:14:00.407  + DOCS_CSM_VERSION=1.5.45
    00:14:00.407  + mkdir -p /home/jenkins/workspace/_HPE_csm_feature_docs-csm-latest/dist/csm-1.5.0-alpha.38-3-gfc60a4a1/rpm/cray/csm/sle-15sp4/noarch
    00:14:00.407  + curl -sSL -u jenkins-readonly:**** -o /home/jenkins/workspace/_HPE_csm_feature_docs-csm-latest/dist/csm-1.5.0-alpha.38-3-gfc60a4a1/rpm/cray/csm/sle-15sp4/noarch/docs-csm-1.5.45-1.noarch.rpm https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/1.5/noarch/docs-csm-1.5.45-1.noarch.rpm
    00:14:01.347  + rpm -qpi /home/jenkins/workspace/_HPE_csm_feature_docs-csm-latest/dist/csm-1.5.0-alpha.38-3-gfc60a4a1/rpm/cray/csm/sle-15sp4/noarch/docs-csm-1.5.45-1.noarch.rpm
    00:14:01.347  + grep -q -E 'Signature\s*:\s*\(none\)'
    00:14:01.607  warning: /home/jenkins/workspace/_HPE_csm_feature_docs-csm-latest/dist/csm-1.5.0-alpha.38-3-gfc60a4a1/rpm/cray/csm/sle-15sp4/noarch/docs-csm-1.5.45-1.noarch.rpm: Header V4 RSA/SHA256 Signature, key ID 9da39f44: NOKEY
    ...
    00:14:04.261  06:43:25: Adding pkg: /data/noarch/docs-csm-1.5.45-1.noarch.rpm


## Risks and Mitigations

Low risk - build time change, easy to rollback.