### PR TITLE
CASMINST-6336 Package latest versioned docs-csm with csm build [release/1.4]

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -170,6 +170,15 @@ rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute/index.yaml" "${BUILDDIR}/rpm
 #rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp4" 
 #rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp4-compute" 
 
+# Special processing for docs-csm, as we don't know exact version before build starts, so can't include it into rpm indexes.
+# Can't include docs-csm-latest either, because it is not unique. Get version from right docs-csm-latest, then download actual rpm file.
+DOCS_CSM_MAJOR_MINOR="${DOCS_CSM_MAJOR_MINOR:-${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}}"
+DOCS_CSM_VERSION=$(curl -sSL -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/api/storage/csm-rpms/hpe/stable/sle-15sp4/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-latest.noarch.rpm?properties" | jq -r '.properties["rpm.metadata.version"][0]')
+mkdir -p "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch"
+curl -sSL -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" -o "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" \
+    "https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm"
+rpm -qpi "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" | grep -q -E "Signature\s*:\s*\(none\)" && (echo "ERROR: RPM package docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm is not signed"; exit 1)
+
 # Fix-up cray directories by removing misc subdirectories
 {
     find "${BUILDDIR}/rpm/cray" -name '*-team' -type d

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,7 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.15.46-1.noarch
-    - docs-csm-1.4.110-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - goss-servers-1.15.46-1.noarch
     - iuf-cli-1.4.5-1.x86_64


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2179 into `release/1.4`.