### PR TITLE
CASMCMS-8610: Bring BOS API spec in line with actual API

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -91,7 +91,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.10
+    version: 2.0.11
     namespace: services
     timeout: 10m
   - name: cray-cfs-api

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.72.0-1.x86_64
-    - bos-reporter-2.0.0-beta.3.x86_64
+    - bos-reporter-2.0.11-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.7-1.x86_64
+    - bos-reporter-2.0.11-1.x86_64

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - bos-reporter-2.0.9-1.x86_64
+    - bos-reporter-2.0.11-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.0.7-1.x86_64
+    - bos-reporter-2.0.11-1.x86_64
     - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Once CASMINST-6284 is completed, we'll be auto-generating docs for our APIs. Because of that, we want to backport these minor BOS changes to CSM 1.4.1 in order to bring the published spec and actual behavior more closely in alignment. Almost all of the changes here are to the spec, with just one minor (and well-tested) bug fix in the service itself.

## Issues and Related PRs
## Testing

See [source PR](https://github.com/Cray-HPE/bos/pull/119) for details.

## Risks and Mitigations

Without this, there is a much greater risk of customer problems if they try to use BOS via the published API spec.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
