### PR TITLE
CASMNET-2121 - Upgrading the cray-dns-unbound Helm chart should not wipe the DNS records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cray-dns-unbound to 0.7.21 (CASMNET-2121)
 - Update cray-nls and cray-iuf charts to 3.1.0 (CASMPET-6235)
 - Update iuf-cli from iuf-cli-1.5.0-1 to iuf-cli-1.5.0~alpha.1-1
 - Update cray-keycloak to 5.0.2 (CASMINST-6105)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -55,11 +55,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.20 # update platform.yaml cray-precache-images with this
+    version: 0.7.21 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.20
+        appVersion: 0.7.21
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.48.0-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.21
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.20
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.21
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.0
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

When the `cray-dns-unbound` Helm chart is upgraded it replaces the `binaryData.records.json.gz` portion of the `cray-dns-unbound` ConfigMap with an empty list. This could lead to a DNS outage if pods are restarted before `cray-dns-unbound-manager` has had a chance to run.

This PR changes the install/upgrade behaviour of the chart. If the `cray-dns-unbound` ConfigMap exists and contains `records.json.gz` then that data will be used rather than overwriting the ConfigMap with an empty record set. In the event that the `cray-dns-unbound` ConfigMap doesn't exist or doesn't contain `records.json.gz` the behaviour is as before and the ConfigMap will be created with the empty record set.

This PR also contains a minor change to `manager.py` as a rebuild of the image pulls in requests v2.30.0 and urllib 2 which removes the deprecated `method_whitelist` Retry option.

## Issues and Related PRs

* Resolves [CASMNET-2121](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2121) [CAST-32978](https://jira-pro.its.hpecorp.net:8443/browse/CAST-32978)

## Testing

### Tested on:

  * `surtur`
  * Local development environment

### Test description:

#### Test 1 - Upgrade of old chart

Records exist
```
ncn-m001:~/cspiller/unbound # kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' | base64 -d | gzip -dc | jq -c .[] | head
{"hostname":"api-gw-service","ip-address":"10.92.100.71"}
{"hostname":"api-gw-service-nmn.local","ip-address":"10.92.100.71"}
{"hostname":"api-gw-service.local","ip-address":"10.92.100.81"}
{"hostname":"api_gw_service","ip-address":"10.92.100.71"}
{"hostname":"chn-switch-1.chn","ip-address":"10.102.67.194"}
{"hostname":"chn-switch-2.chn","ip-address":"10.102.67.195"}
{"hostname":"cray-tftp.hmnlb","ip-address":"10.94.100.60"}
{"hostname":"cray-tftp.nmnlb","ip-address":"10.92.100.60"}
{"hostname":"docker-registry.hmnlb","ip-address":"10.94.100.73"}
{"hostname":"docker-registry.nmnlb","ip-address":"10.92.100.73"}
```
Upgrade chart
```
ncn-m001:~/cspiller/unbound # loftsman ship --manifest-path ./deploy.yaml
2023-05-10T09:17:08Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-05-10T09:17:08Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-05-10T09:17:08Z INF Ensuring that the loftsman namespace exists command=ship
2023-05-10T09:17:09Z INF Running a release for the provided manifest at ./deploy.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-dns-unbound v0.7.20
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-05-10T09:17:09Z INF Found value overrides for chart, applying:
domain_name: surtur.hpc.amslabs.hpecorp.net
forwardZones:
- forwardIps:
  - 16.110.135.51
  name: .
 chart=cray-dns-unbound command=ship namespace=services version=0.7.20
2023-05-10T09:17:09Z INF Running helm install/upgrade with arguments: upgrade --install cray-dns-unbound https://packages.local/repository/charts/cray-dns-unbound-0.7.20.tgz --namespace services --create-namespace --set global.chart.name=cray-dns-unbound --set global.chart.version=0.7.20 -f /tmp/loftsman-1683710228/cray-dns-unbound-values.yaml chart=cray-dns-unbound command=ship namespace=services version=0.7.20
2023-05-10T09:17:26Z INF Release "cray-dns-unbound" has been upgraded. Happy Helming!
NAME: cray-dns-unbound
LAST DEPLOYED: Wed May 10 09:17:09 2023
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
 chart=cray-dns-unbound command=ship namespace=services version=0.7.20
2023-05-10T09:17:26Z INF Ship status: success. Recording status, manifest to configmap loftsman-unbound-test in namespace loftsman command=ship
2023-05-10T09:17:26Z INF Recording log data to configmap loftsman-unbound-test-ship-log in namespace loftsman command=ship
```
As expected the ConfigMap is wiped and the records are refreshed by `cray-dns-unbound-manager` next run.
```
ncn-m001:~/cspiller/unbound # kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' | base64 -d | gzip -dc | jq -c .[] | head
ncn-m001:~/cspiller/unbound #
```

#### Test 2 - Upgrade from 0.7.20 to 0.7.21

Records exist
```
ncn-m001:~/cspiller/unbound # kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' | base64 -d | gzip -dc | jq -c .[] | head
{"hostname":"ncn-s003","ip-address":"10.1.1.2"}
{"hostname":"ncn-w002","ip-address":"10.1.1.6"}
{"hostname":"ncn-m003","ip-address":"10.1.1.8"}
{"hostname":"ncn-s002","ip-address":"10.1.1.3"}
{"hostname":"ncn-w001","ip-address":"10.1.1.7"}
{"hostname":"ncn-s001","ip-address":"10.1.1.4"}
{"hostname":"ncn-m002","ip-address":"10.1.1.9"}
{"hostname":"ncn-m001","ip-address":"10.1.1.10"}
{"hostname":"ncn-w003","ip-address":"10.1.1.5"}
{"hostname":"ncn-w004","ip-address":"10.1.1.11"}
```
Upgrade Chart
```
ncn-m001:~/cspiller/unbound # loftsman ship --manifest-path ./deploy.yaml
2023-05-10T09:19:58Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-05-10T09:19:58Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-05-10T09:19:58Z INF Ensuring that the loftsman namespace exists command=ship
2023-05-10T09:19:59Z INF Running a release for the provided manifest at ./deploy.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-dns-unbound v0.7.21-20230509182437+75f737f
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-05-10T09:19:59Z INF Found value overrides for chart, applying:
domain_name: surtur.hpc.amslabs.hpecorp.net
forwardZones:
- forwardIps:
  - 16.110.135.51
  name: .
 chart=cray-dns-unbound command=ship namespace=services version=0.7.21-20230509182437+75f737f
2023-05-10T09:19:59Z INF Running helm install/upgrade with arguments: upgrade --install cray-dns-unbound cray-dns-unbound-0.7.21-20230509182437+75f737f.tgz --namespace services --create-namespace --set global.chart.name=cray-dns-unbound --set global.chart.version=0.7.21-20230509182437+75f737f -f /tmp/loftsman-1683710398/cray-dns-unbound-values.yaml chart=cray-dns-unbound command=ship namespace=services version=0.7.21-20230509182437+75f737f
2023-05-10T09:21:05Z INF Release "cray-dns-unbound" has been upgraded. Happy Helming!
NAME: cray-dns-unbound
LAST DEPLOYED: Wed May 10 09:19:59 2023
NAMESPACE: services
STATUS: deployed
REVISION: 3
TEST SUITE: None
 chart=cray-dns-unbound command=ship namespace=services version=0.7.21-20230509182437+75f737f
2023-05-10T09:21:05Z INF Ship status: success. Recording status, manifest to configmap loftsman-unbound-test in namespace loftsman command=ship
2023-05-10T09:21:05Z INF Recording log data to configmap loftsman-unbound-test-ship-log in namespace loftsman command=ship
```
Verify ConfigMap hasn't been updated with empty record set.
```
ncn-m001:~/cspiller/unbound # kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' | base64 -d | gzip -dc | jq -c .[] | head
{"hostname":"api-gw-service","ip-address":"10.92.100.71"}
{"hostname":"api-gw-service-nmn.local","ip-address":"10.92.100.71"}
{"hostname":"api-gw-service.local","ip-address":"10.92.100.81"}
{"hostname":"api_gw_service","ip-address":"10.92.100.71"}
{"hostname":"chn-switch-1.chn","ip-address":"10.102.67.194"}
{"hostname":"chn-switch-2.chn","ip-address":"10.102.67.195"}
{"hostname":"cray-tftp.hmnlb","ip-address":"10.94.100.60"}
{"hostname":"cray-tftp.nmnlb","ip-address":"10.92.100.60"}
{"hostname":"docker-registry.hmnlb","ip-address":"10.94.100.73"}
{"hostname":"docker-registry.nmnlb","ip-address":"10.92.100.73"}
```

## Risks and Mitigations

A rollback of the chart to the earlier version will cause `binaryData.records.json.gz` to be replaced with the empty record set and `cray-dns-unbound-manager` needs to run to repopulate it.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

