### PR TITLE
CRAYSAT-1719: Bump cray-sat image version to 3.21.5

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.4
+      - 3.21.5
 
 artifactory.algol60.net/csm-docker/stable:
   images:
@@ -164,7 +164,7 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.12.4
     quay.io/cilium/operator-generic:
       - v1.12.4
-    
+
     # Cilium images needed for connectivity testing
     quay.io/cilium/alpine-curl:
       - v1.6.0

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.4"
+sat_version="3.21.5"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope
Address critical CVE-2023-27536 in the cray-sat docker image.


## Issues and Related PRs

* Resolves [CRAYSAT-1719](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1719)

## Testing

Tested in corresponding SAT change.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

