### PR TITLE
CASM-3884: Upgrade Grafterm version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -45,7 +45,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-ims-load-artifacts:
       - 2.3.0
     cray-grafterm:
-      - 1.0.2
+      - 1.0.3
     # XXX Are these HMS images missing from a chart or are they used to
     # XXX facilitate install/upgrade?
     hms-shcd-parser:


### PR DESCRIPTION
## Summary and Scope

Our team as missed updating the grafterm version in index.yaml for the CASM-3884: Upgrade Prometheus Operator to latest version.

This PR includes index.yaml file change for same.

Upgrade script changes with respect to Prometheus-operator upgrade from 9.3.1 to 45.1.1 (latest) version is moved to docs-csm as suggested by Dennis walker - https://github.com/Cray-HPE/docs-csm/tree/main/upgrade/scripts

PR for docs-csm: [https://github.com/Cray-HPE/docs-csm/pull/3487](url)

## Issues and Related PRs

* Resolves 
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-282
https://jira-pro.its.hpecorp.net:8443/browse/CASM-3884

## Testing

_List the environments in which these changes were tested._

### Tested on:

Wasp & Gamora

### Test description: (LOGS)

ncn-m001:/mnt/developer/shreni/migration # ./upgrade.sh
Checking for chart version of cray-sysmgmt-health
Get PV for both prometheus and Alertmanager
Prometheus PV: pvc-5311abcd-18da-484a-ba3b-363e11b75986
Alertmanager PV: pvc-5f237239-7bfc-4abd-836e-0586622fb53f
persistentvolume/pvc-5311abcd-18da-484a-ba3b-363e11b75986 patched
persistentvolume/pvc-5f237239-7bfc-4abd-836e-0586622fb53f patched
W0321 10:02:31.950164  259623 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
W0321 10:02:31.954006  259623 warnings.go:70] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
W0321 10:02:31.959220  259623 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0321 10:02:31.964999  259623 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0321 10:02:31.993981  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:31.994470  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:31.994514  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:31.995282  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:31.995292  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:31.995338  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:31.995706  259623 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0321 10:02:32.083201  259623 warnings.go:70] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
W0321 10:02:32.220833  259623 warnings.go:70] admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
release "cray-sysmgmt-health" uninstalled
persistentvolumeclaim "prometheus-cray-sysmgmt-health-promet-prometheus-db-prometheus-cray-sysmgmt-health-promet-prometheus-0" deleted
persistentvolumeclaim "alertmanager-cray-sysmgmt-health-promet-alertmanager-db-alertmanager-cray-sysmgmt-health-promet-alertmanager-0" deleted
Verifying whether PVs became Released or not.
Both Prometheus and Alertmanager PVs are Released
Deleting cray-sysmgmt-health-promet-kubelet service in kube-system namespace.
service "cray-sysmgmt-health-promet-kubelet" deleted
Deleting sysmgmt-health existing CRDs
customresourcedefinition.apiextensions.k8s.io "alertmanagers.monitoring.coreos.com" deleted
customresourcedefinition.apiextensions.k8s.io "podmonitors.monitoring.coreos.com" deleted
customresourcedefinition.apiextensions.k8s.io "prometheuses.monitoring.coreos.com" deleted
customresourcedefinition.apiextensions.k8s.io "prometheusrules.monitoring.coreos.com" deleted
customresourcedefinition.apiextensions.k8s.io "servicemonitors.monitoring.coreos.com" deleted
customresourcedefinition.apiextensions.k8s.io "thanosrulers.monitoring.coreos.com" deleted
persistentvolume/pvc-5311abcd-18da-484a-ba3b-363e11b75986 patched
persistentvolume/pvc-5f237239-7bfc-4abd-836e-0586622fb53f patched
Verifying whether PV became Available or not.
Both Prometheus and Alertmanager PVs are Available. Ready to deploy the latest cray-sysmgmt-chart now.

### K8s 1.22 deprecation:

Tested on - Pluto

ncn-m001:/mnt/developer/shreni/dep # ./pluto detect-helm | awk '/NAME|sysmgmt-health/'
NAME                                                                       KIND                             VERSION                                REPLACEMENT                       REMOVED   DEPRECATED   REPL AVAIL
cray-sysmgmt-health/cray-sysmgmt-health-prometheus-node-exporter           PodSecurityPolicy                policy/v1beta1                                                           false     true         true
cray-sysmgmt-health/cray-sysmgmt-health-kube-p-alertmanager                PodSecurityPolicy                policy/v1beta1                                                           false     true         true
cray-sysmgmt-health/cray-sysmgmt-health-kube-p-operator                    PodSecurityPolicy                policy/v1beta1                                                           false     true         true
cray-sysmgmt-health/cray-sysmgmt-health-kube-p-prometheus                  PodSecurityPolicy                policy/v1beta1                                                           false     true         true