### PR TITLE
Manifest update for BSS change for CASMHMS-6012

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.0.1
+    version: 3.1.0
     namespace: services
     swagger:
     - name: bss


### PR DESCRIPTION
## Summary and Scope

CASMHMS-6012 - Adds definition of SPIRE_TOKEN_URL to over-ride the default to reflect the new spire endpoint.

## Issues and Related PRs

* Resolves [CASMHMS-6012](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-6012)

## Testing



### Tested on:

  * surtur

### Test description:

Verified the changed chart had the SPIRE_TOKEN_URL env variable properly reflected and used in the BSS pod.

## Risks and Mitigations

Requires the spire service endpoint to be updated.

## Pull Request Checklist

- [ x ] Version number(s) incremented, if applicable
- [ x ] Copyrights updated
- [ x ] License file intact
- [ x ] Target branch correct
- [ x ] CHANGELOG.md updated
- [ x ] Testing is appropriate and complete, if applicable


