### PR TITLE
CASMPET-6479: Update cilium images to 1.13.2 and add Hubble images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cilium images to 1.13.2 and add Hubble images (CASMPET-6479)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121)
 - Update cray-nls and cray-iuf charts to 3.1.0 (CASMPET-6235)
 - Update iuf-cli from iuf-cli-1.5.0-1 to iuf-cli-1.5.0~alpha.1-1

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -160,9 +160,17 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Cilium images required by platform
     quay.io/cilium/cilium:
-      - v1.12.4
+      - v1.13.2
     quay.io/cilium/operator-generic:
-      - v1.12.4
+      - v1.13.2
+
+    # Cilium Hubble images
+    quay.io/cilium/hubble-relay:
+      - v1.13.2
+    quay.io/cilium/hubble-ui:
+      - v0.11.0
+    quay.io/cilium/hubble-ui-backend:
+      - v0.11.0
 
     # Cilium images needed for connectivity testing
     quay.io/cilium/alpine-curl:


### PR DESCRIPTION
## Summary and Scope

This updates the cilium images and adds the hubble images to the tarball.   Cilium is not installed by default at this time.   This makes the images available if we turn on the cilium flag at fresh install or migrate from weave.

Updating the cilium images will also address the CVEs that are currently flagged in cilium 1.12.4 since we will no longer be including 1.12.4 in the tarball.

## Issues and Related PRs

* Resolves [CASMPET-6479](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6479)
* Resolves [CASMPET-6330](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6330)

## Testing

### Tested on:

  * Virtual Shasta - cilium cluster

### Test description:

I have used these images (imported manually) to go through the migration process on the cilium cluster

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

