### PR TITLE
CASMPET-6330: Removes Cilium container images to remove CVEs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Remove cilium container images to remove CVEs (CASMPET-6330)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121)
 - Update cray-nls and cray-iuf charts to 2.0.1 (CASMPET-6235, CASMPET-6563)
 - Update cf-gitea-import to 1.9.4 (CASMCMS-8531/CASMCMS-8540)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -159,19 +159,6 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/argoproj/argoexec:
       - v3.3.6
 
-    # Cilium images required by platform
-    quay.io/cilium/cilium:
-      - v1.12.4
-    quay.io/cilium/operator-generic:
-      - v1.12.4
-
-    # Cilium images needed for connectivity testing
-    quay.io/cilium/alpine-curl:
-      - v1.6.0
-    # Not pulling in json-mock until there is update to address some CVEs
-    # quay.io/cilium/json-mock:
-    #    - v1.3.3
-
     # Images needed by IUF and possibly non-CSM products
     cray-product-catalog-update:
       - 1.3.1


### PR DESCRIPTION
## Summary and Scope

Snyk found 1 High vulnerability in the cilium v1.12.4 container image.   We are not using cilium yet in 1.4 so I am removing those container images.   These images will be upgraded in 1.5.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6330](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6330)

## Testing

### Test description:

This is just removing unused container images.   The builds for this PR will be the test.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

