### PR TITLE
CASMCMS-8609: Update bos for power-on status fix (1.3)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.7
+    version: 2.0.12
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys


### PR DESCRIPTION
## Summary and Scope

Pulls in a fix for BOS that was slowing down power-on operations on large systems.  

Also pulls in some build fixes and corrections to the api spec.  (No changes to the api behavior)

## Issues and Related PRs

* Resolves CASMCMS-8609

## Testing

### Tested on:

  * crossroads

### Test description:

Tested shutdown, boot and reboot sessions for all compute nodes.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

