### PR TITLE
CASMTRIAGE-5352: Fix RTS creating K8s Service Entries with the Incorrect Selector Labels

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -88,12 +88,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.17.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

This updates the RTS chart version for CASMTRIAGE-5352: Fix RTS creating K8s Service Entries with the Incorrect Selector Labels.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5352](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5352)

## Testing

For testing, see https://github.com/Cray-HPE/hms-redfish-translation-layer/pull/47

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

