### PR TITLE
CASM-4261: iuf-cli Version Bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update iuf-cli from iuf-cli-1.5.0~alpha.1-1 to iuf-cli-1.5.1
 - Update cilium images to 1.13.2 and add Hubble images (CASMPET-6479)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121)
 - Update cray-nls and cray-iuf charts to 3.1.0 (CASMPET-6235)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.32-1.noarch
     - hpe-csm-scripts-0.5.5-1.noarch
     - goss-servers-1.16.32-1.noarch
-    - iuf-cli-1.5.0~alpha.1-1.x86_64
+    - iuf-cli-1.5.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64
     - metal-ipxe-2.3.0-1.noarch


### PR DESCRIPTION
Bump the version of iuf-cli from iuf-cli-1.5.0~alpha.1-1.x86_64 to iuf-cli-1.5.1-1.x86_64.


