### PR TITLE
CASMINT-5749: update cray-nls and cray-iuf

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -248,7 +248,7 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.1
+    version: 3.1.0
     namespace: argo
   - name: cray-nls
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -248,17 +248,17 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: argo
     swagger:
     - name: nls
       title: "NCN Lifecycle Service"
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.9/docs/NLS_swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.10/docs/NLS_swagger.yaml
   - name: cray-hnc-manager
     source: csm-algol60
     version: 0.0.6

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -248,7 +248,7 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: argo
   - name: cray-nls
     source: csm-algol60


### PR DESCRIPTION
Bump the version of cray-nls and cray-iuf from 3.1.0 to 3.1.1. 
Update cray-nls image from "https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.9/docs/NLS_swagger.yaml" to "https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.10/docs/NLS_swagger.yaml"