### PR TITLE
CASMPET-6571: Update gitea for fixed postgres host

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.6.2
+    version: 2.6.3
     namespace: services
     values:
       keycloakImage:


### PR DESCRIPTION
## Summary and Scope

This updates gitea to fix the POSTGRES_HOST value in the chart.

This does not fix the whole upgrade issue with VCS postgres, but the remaining portion is a upgrade process issue.

## Issues and Related PRs

* Partially Resolves CASMPET-6571

## Testing

### Tested on:

  * Drax

### Test description:

Deployed successfully.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

