### PR TITLE
BOS API spec fixes & one small BOS code fix

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/hack/list-pit-iso-rpms.sh
+++ b/hack/list-pit-iso-rpms.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 SQUASHFS_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/squashfs-tools:0.2.2"
 

--- a/hack/list-squashfs-rpms.sh
+++ b/hack/list-squashfs-rpms.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 SQUASHFS_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/squashfs-tools:0.2.2"
 

--- a/hack/load-container-image.sh
+++ b/hack/load-container-image.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/hack/snyk-scan.sh
+++ b/hack/snyk-scan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 set -euo pipefail
 

--- a/hack/verify-helm-index.sh
+++ b/hack/verify-helm-index.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.5"
 

--- a/hack/verify-rpm-index.sh
+++ b/hack/verify-rpm-index.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.5"
 

--- a/lib/install-goss-tests.sh
+++ b/lib/install-goss-tests.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,13 +133,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.14
+    version: 2.0.15
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.14/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.15/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.2

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,13 +133,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.13
+    version: 2.0.14
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.13/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.14/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.2

--- a/manifests/velero-1.7-upgrade.yaml
+++ b/manifests/velero-1.7-upgrade.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.72.0-1.x86_64
-    - bos-reporter-2.0.14-1.x86_64
+    - bos-reporter-2.0.15-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.72.0-1.x86_64
-    - bos-reporter-2.0.13-1.x86_64
+    - bos-reporter-2.0.14-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.13-1.x86_64
+    - bos-reporter-2.0.14-1.x86_64

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.14-1.x86_64
+    - bos-reporter-2.0.15-1.x86_64

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - bos-reporter-2.0.13-1.x86_64
+    - bos-reporter-2.0.14-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - bos-reporter-2.0.14-1.x86_64
+    - bos-reporter-2.0.15-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.0.13-1.x86_64
+    - bos-reporter-2.0.14-1.x86_64
     - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.0.14-1.x86_64
+    - bos-reporter-2.0.15-1.x86_64
     - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64

--- a/security/snyk-aggregate-results/snyk-aggregate-results.py
+++ b/security/snyk-aggregate-results/snyk-aggregate-results.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 


### PR DESCRIPTION
## Summary and Scope

This PR contains several fixes to the BOS API spec (including one that fixes a customer-reporter problem):

* [CASMCMS-8447](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8447): Update API spec to show that GET of session templates can return v1 or v2 templates
* [CASMCMS-8572](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8572): Update API spec to reflect that creating a BOS v1 session requires operation AND templateName/templateUuid
* [CASMCMS-8576](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8576): Update API spec to reflect that GET /v1/session returns list of IDs not sessions
* [CASMCMS-8577](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8577): Update the spec to accurately reflect what is returned when creating or getting a BOS v1 session
* [CASMCMS-8626](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8626): API spec linting to correct minor errors, omissions, and inconsistencies
* [CASMTRIAGE-5367](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5367): Update API spec to use valid ECMA 262 regular expressions

It also contains one minor fix to BOS itself, so that it returns a valid BOSv2 session template when an example v2 template is requested:

* [CASMCMS-8585](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8585): Return valid BOS v2 session template on GET request to /v2/sessiontemplatetemplate

It also pins the Alpine version in the BOS Dockerfile and specifies the updated Python version in the BOS module setup file, to avoid future surprise changes in the case of CVE rebuilds or similar. ([CASMCMS-8628](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8628)/[CASMCMS-8631](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8631))

There will be a PR for main that includes these as well, but it isn't ready yet. There are additional changes going into it that aren't being backported, so we're waiting for those to be ready before we pull it all into a single manifest PR. @rbak-hpe  plans to create that later today or tomorrow.

I also noticed in the git log that some files had been updated this year but not had their copyright headers updated, so I made a commit to do that as well.

## Issues and Related PRs

Source PRs:

* [CASMCMS-8447](https://github.com/Cray-HPE/bos/pull/130)
* [CASMCMS-8572](https://github.com/Cray-HPE/bos/pull/127)
* [CASMCMS-8576](https://github.com/Cray-HPE/bos/pull/126)
* [CASMCMS-8577](https://github.com/Cray-HPE/bos/pull/128)
* [CASMCMS-8585](https://github.com/Cray-HPE/bos/pull/129)
* [CASMCMS-8626](https://github.com/Cray-HPE/bos/pull/133)
* [CASMTRIAGE-5367](https://github.com/Cray-HPE/bos/pull/134)

## Testing

* The updated API spec was run through an OpenAPI Swagger validation tool.
* The updated regular expressions were run through a regular expression tester with various good and bad path inputs.
* @jsollom-hpe  deployed the BOS image on a system and tested that it fixed the customer problem being reported.

## Risks and Mitigations

Very low risk. Almost all changes are to the spec itself, and are just making the spec match how BOS actually behaves. The one fix to BOS code itself also wasn't even really a code logic change -- it was removing a leftover v1 field from an object definition.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
