### PR TITLE
CASMTRIAGE-5371

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -163,7 +163,7 @@ spec:
     version: 0.27.8
     namespace: sysmgmt-health
     values:
-      prometheus-operator:
+      kube-prometheus-stack:
         prometheus:
           prometheusSpec:
             resources:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Prometheus resources were not updating due to old name (prometheus-operator) in csm/manifest/platform.yaml. 
Changed the name to kube-prometheus-stack to support the latest version of prometheus-operator.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5371
