### PR TITLE
Update precache images for K8S 1.22 (CASMPET-6586)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -51,12 +51,12 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:v1.8.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.21.12
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.21.12
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.21.12
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.21.12
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.5
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless


### PR DESCRIPTION
### Summary and Scope

Update precache images for K8S 1.22 

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6586

### Testing

Verified image list on redbull with NCN image change.

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
