### PR TITLE
CASMINST-6342: Release csm-testing v1.16.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update csm-testing to 1.16.34 (CASMINST-6342)
 - Add Ceph v17.2.6 to docker index (CASMPET-6585)
 - Update iuf-cli from iuf-cli-1.5.0~alpha.1-1 to iuf-cli-1.5.1
 - Update cfs-state-reporter to use noarch rpms (CASMCMS-8516)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,9 +35,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.16.33-1.noarch
+    - csm-testing-1.16.34-1.noarch
     - hpe-csm-scripts-0.5.5-1.noarch
-    - goss-servers-1.16.33-1.noarch
+    - goss-servers-1.16.34-1.noarch
     - iuf-cli-1.5.1-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64


### PR DESCRIPTION
## Summary and Scope

The goss-rgw-health test fails on vshasta because it doesn't have an HMN network.   Adding the vshasta skip to this test.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6342](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6342)

## Testing

### Tested on:

  * Virtual Shasta - grog

### Test description:

Ran the preflight checks in prerequisites on grog and verified that this test was skipped.

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

