### PR TITLE
CASMTRIAGE-5404: Update BOS to fix v1 session creation regression bug

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.15
+    version: 2.0.16
     namespace: services
     timeout: 10m
   - name: csm-ssh-keys

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.63.0-1.x86_64
-    - bos-reporter-2.0.15-1.x86_64
+    - bos-reporter-2.0.16-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.15-1.x86_64 
+    - bos-reporter-2.0.16-1.x86_64 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -32,6 +32,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.35-1.noarch
     - pit-nexus-1.1.5-1.x86_64
-    - bos-reporter-2.0.15-1.x86_64 
+    - bos-reporter-2.0.16-1.x86_64 
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.0-1.x86_64
     - cfs-trust-1.6.0-1.x86_64
-    - bos-reporter-2.0.15-1.x86_64 
+    - bos-reporter-2.0.16-1.x86_64 
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,5 +29,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.0-1.x86_64
     - csm-ssh-keys-1.5.0-1.noarch  
     - csm-ssh-keys-roles-1.5.0-1.noarch
-    - bos-reporter-2.0.15-1.x86_64 
+    - bos-reporter-2.0.16-1.x86_64 
 


### PR DESCRIPTION
## Summary and Scope

One of the fixes to the API spec caused a regression bug when creating v1 sessions using the deprecated templateUuid parameter. This changes the spec to prevent the bug.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5404](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5404) for the CSM 1.3 and 1.4 backports. (I will make a separate PR to fix this more satisfyingly in the develop branch.)
* [Source PR](https://github.com/Cray-HPE/bos/pull/138)

## Testing

I deployed the updated BOS on Crossroads and verified that the problem no longer occurred, and the BOS regression test suite passed without problems.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
