### PR TITLE
CASMPET-6173: Prepopulate ALL cert-manager images to ensure they are …

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -77,6 +77,16 @@ artifactory.algol60.net/csm-docker/stable:
       - v16.2.9
       - v17.2.6
 
+    # The auto imports seem to miss the cert-manager images
+    quay.io/jetstack/cert-manager-cainjector:
+      - v1.5.5
+    quay.io/jetstack/cert-manager-controller:
+      - v1.5.5
+    quay.io/jetstack/cert-manager-ctl:
+      - v1.5.5
+    quay.io/jetstack/cert-manager-webhook:
+      - v1.5.5
+
     # XXX See also k8s.gcr.io/coredns:1.7.0 below
     docker.io/coredns/coredns:
       - 1.6.2


### PR DESCRIPTION
…present pre pit nexus

## Summary and Scope

Found that the cert-manager-webhook image isn't cached before pit nexus bringup. Which is a problem in general.

So to avoid whatever is not importing that one image, specify all 4 needed for cert-manager manually.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

grog

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

