### PR TITLE
CASMPET-6177: Bump cray-metrics-server to 0.4.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -33,7 +33,7 @@ spec:
   charts:
   - name: cray-metrics-server
     source: csm-algol60
-    version: 0.4.0
+    version: 0.4.1
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bump for cray-metrics-server to use 1.22 compatible api's.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6177
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

vshasta though we'll need to install 1.22 to know for sure all is ok.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

