### PR TITLE
Initial support for multi-tenancy in OPA; Restrict Keycloak URIs (port)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -65,7 +65,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.6.2
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.6.2
       # OPA
-      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.48.0-envoy
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.21
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.21
@@ -124,7 +124,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.32.3
+    version: 1.32.5
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Promotes https://github.com/Cray-HPE/cray-opa/releases/tag/v1.32.5. 

### Changes

* Add in logic and tests for multi-tenancy
* Restrict accessible Keycloak URIs via OPA Ingress Policy (forward port)
* Used updated, rootless OPA container image `artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless`

Detailed Changelog: https://github.com/Cray-HPE/cray-opa/compare/v1.32.3...v1.32.5

## Issues and Related PRs

* Resolves [CASMSEC-384](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-384)
* Documentation changes already complete for keycloak URI modifications https://github.com/Cray-HPE/docs-csm/pull/3804

## Testing

See for test details:

https://github.com/Cray-HPE/cray-opa/pull/91
https://github.com/Cray-HPE/cray-opa/pull/92

### Tested on:

  * Local development environment
  * Surtur (1.4)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known issues.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
