### PR TITLE
Add disasterRecovery to hms charts that use ETCD

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: services
     swagger:
     - name: bss
@@ -52,7 +52,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.3.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
     swagger:
     - name: firmware-action
@@ -60,7 +60,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.27.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
     swagger:
     - name: hbtd
@@ -68,7 +68,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.19.1/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
     swagger:
     - name: hmnfd
@@ -102,7 +102,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.1
+    version: 2.0.2
     namespace: services
     swagger:
     - name: power-control


### PR DESCRIPTION
## Summary and Scope

Add required disasterRecovery chart section to allow for ETCD backups.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5390](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5390)
* Resolves [CASMTRIAGE-5391](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5391)
* Resolves [CASMTRIAGE-5392](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5392)
* Resolves [CASMTRIAGE-5393](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5393)
* Resolves [CASMTRIAGE-5394](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5394)

## Testing

### Tested on:

  * `drax`

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

