### PR TITLE
CASMTRIAGE-5407: Updates to cert-manager for install/upgrades

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: istio-system
   - name: cray-certmanager
     source: csm-algol60
-    version: 0.7.2
+    version: 0.7.3
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Incorporate fixes tested on grog/cilium for the cray-certmanager chart.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-5407
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

grog/cilium

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta cilium/grog

### Test description:

Used a hacked up 0.7.2 version of the chart with these changes and performed a new csm install and for grog similarly but only for cray-certmanager.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

n/a

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

