### PR TITLE
Set skopeo creds only if pulling from artifactory

### DIFF
--- a/build/images/inspect.sh
+++ b/build/images/inspect.sh
@@ -12,6 +12,8 @@ function usage() {
 
 function skopeo-inspect() {
     local img="docker://$1"
+    local creds=""
+    [[ "${1}" == artifactory.algol60.net/* ]] && creds="${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}"
     # echo >&2 "+ skopeo inspect $img"
     docker run --rm "$SKOPEO_IMAGE" \
         --command-timeout 60s \
@@ -19,7 +21,7 @@ function skopeo-inspect() {
         --override-arch amd64 \
         inspect \
         --retry-times 5 \
-        --creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" \
+        ${creds:+--creds "${creds}"} \
         --format "{{.Name}}@{{.Digest}}" \
         "$img"
 }

--- a/build/images/sync.sh
+++ b/build/images/sync.sh
@@ -26,6 +26,9 @@ if [ -z "${ARTIFACTORY_USER}" -o -z "${ARTIFACTORY_TOKEN}" ]; then
     exit 1
 fi
 
+creds=""
+[[ "${image}" == artifactory.algol60.net/* ]] && creds="${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}"
+
 docker run --rm \
     -u "$(id -u):$(id -g)" \
     --mount "type=bind,source=$(realpath "$workdir"),destination=/data" \
@@ -35,7 +38,7 @@ docker run --rm \
     --override-arch amd64 \
     copy \
     --retry-times 5 \
-    --src-creds "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" \
+    ${creds:+--src-creds "${creds}"} \
     "docker://$image" \
     dir:/data \
     >&2 || exit 255


### PR DESCRIPTION
## Summary and Scope

Skopeo operations (`skopeo inspect` and `skopeo copy`) were updated to always use Artifactory credentials.However, if source container image is not in Artifactory and getting pulled directly from `docker.io` or `quay.io`, this causes HTTP 401 errors. We do allow direct pulls `docker.io` or `quay.io` as fail safe mechanism.

## Testing
### Tested on:

  * Jenkins

### Test description:

Ran build with `cray-certmanager` chart temporarily downgraded to version `0.7.0`:
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm/detail/feature%2Fskopeo-auth/7/pipeline

This version of `cray-certmanager` chart pulls one image directly from `quay.io`:

    $ helm template csm-algol60/cray-certmanager --version 0.7.0 | grep image:
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-webhook:v1.5.5"
              image: "quay.io/jetstack/cert-manager-ctl:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0"

Note that current version `0.7.2` pulls everything from artifactory:

    $ helm template csm-algol60/cray-certmanager --version 0.7.2 | grep image:
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-webhook:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-ctl:v1.5.5"
              image: "artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0"