### PR TITLE
CASMINST-6382 Increase stability of csm builds

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -64,6 +64,15 @@ pipeline {
         }
 
         stage('Validate') {
+            stage("Charts and Images") {
+                    steps {
+                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                            sh """
+                                . build/.env/bin/activate && make images -j8
+                            """
+                        }
+                    }
+            }
             parallel {
                 stage('Assets') {
                     steps {
@@ -75,15 +84,6 @@ pipeline {
                     }
                 }
 
-                stage("Charts and Images") {
-                    steps {
-                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-                            sh """
-                                . build/.env/bin/activate && make images -j8
-                            """
-                        }
-                    }
-                }
 
                 stage('RPM Index') {
                     steps {
@@ -101,29 +101,30 @@ pipeline {
                     }
                 }
 
-            }
-        }
-        stage("API Documentation") {
-            environment {
-                GIT_AUTHOR_NAME = "Jenkins"
-                GIT_AUTHOR_EMAIL = "jenkins@algol60.net"
-                GIT_COMMITTER_NAME = "Jenkins"
-                GIT_COMMITTER_EMAIL = "jenkins@algol60.net"
-                EMAIL = "jenkins@algol60.net"
-            }
-            steps {
-                withCredentials(
-                    [usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_TOKEN')]
-                ) {
-                    script {
-                        env.GITHUB_APP_INST_TOKEN = getGitHubToken(appId: "330087", installId: "37198173", credentialsId: "github-jenkins-auto-push-bot-key")
-                        sh """
-                            ./hack/gen-push-swagger-markdown.sh ${env.DOCS_CSM_BRANCH} ${env.TAG_NAME ? '--push --wait' : ''}
-                        """
+                stage("API Documentation") {
+                    environment {
+                        GIT_AUTHOR_NAME = "Jenkins"
+                        GIT_AUTHOR_EMAIL = "jenkins@algol60.net"
+                        GIT_COMMITTER_NAME = "Jenkins"
+                        GIT_COMMITTER_EMAIL = "jenkins@algol60.net"
+                        EMAIL = "jenkins@algol60.net"
+                    }
+                    steps {
+                        withCredentials(
+                            [usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_TOKEN')]
+                        ) {
+                            script {
+                                env.GITHUB_APP_INST_TOKEN = getGitHubToken(appId: "330087", installId: "37198173", credentialsId: "github-jenkins-auto-push-bot-key")
+                                sh """
+                                    ./hack/gen-push-swagger-markdown.sh ${env.DOCS_CSM_BRANCH} ${env.TAG_NAME ? '--push --wait' : ''}
+                                """
+                            }
+                        }
                     }
                 }
             }
         }
+
         stage('Release') {
             when { tag "v*" }
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -64,15 +64,6 @@ pipeline {
         }
 
         stage('Validate') {
-            stage("Charts and Images") {
-                    steps {
-                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-                            sh """
-                                . build/.env/bin/activate && make images -j8
-                            """
-                        }
-                    }
-            }
             parallel {
                 stage('Assets') {
                     steps {
@@ -84,6 +75,15 @@ pipeline {
                     }
                 }
 
+                stage("Charts and Images") {
+                    steps {
+                        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                            sh """
+                                . build/.env/bin/activate && make images -j8
+                            """
+                        }
+                    }
+                }
 
                 stage('RPM Index') {
                     steps {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -109,6 +109,9 @@ pipeline {
                         GIT_COMMITTER_EMAIL = "jenkins@algol60.net"
                         EMAIL = "jenkins@algol60.net"
                     }
+                    agent {
+                        label "metal-gcp-builder"
+                    }
                     steps {
                         withCredentials(
                             [usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_TOKEN')]

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -245,6 +245,7 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/int
     -d  https://artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle15_sp4_ncn/  cray/csm/sle-15sp4 \
     -d  https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/  cray/csm/sle-15sp3 \
     -d  https://artifactory.algol60.net/artifactory/dst-rpm-mirror/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/  cray/csm/sle-15sp3 \
+    -d  https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/  cray/csm/sle-15sp4 \
     -d  https://artifactory.algol60.net/artifactory/hpe-mirror-spp-gen10/SUSE/SLES15-SP4/x86_64/current/  cray/csm/sle-15sp4 \
     -d  https://artifactory.algol60.net/artifactory/opensuse-mirror/Cloud:Tools/SLE_15_SP4/   opensuse_leap/15.4 \
     -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Containers/15-SP4/x86_64/update/   suse/SLE-Module-Containers/15-SP4/x86_64/update \

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -39,7 +39,7 @@ if [ ! -z "$REPOCREDSVARNAME" ]; then
     REPO_CREDS_DOCKER_OPTIONS="-e ${REPOCREDSVARNAME}"
     REPO_CREDS_RPMINDEX_OPTIONS="-c ${REPOCREDSVARNAME}"
 fi
-docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
+docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.7 rpm-index ${REPO_CREDS_RPMINDEX_OPTIONS} -v \
 -d  https://download.opensuse.org/repositories/filesystems:/ceph/openSUSE_Leap_15.3/                                        opensuse_leap/15.3 \
 -d  https://artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph/openSUSE_Leap_15.3/                       mirror/opensuse_leap/15.3 \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpm-stable-local/hpe/                                                         cray/csm/sle-15sp3/x86_64 \

--- a/hack/verify-helm-index.sh
+++ b/hack/verify-helm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.7"
 
 set -o errexit
 set -o pipefail

--- a/hack/verify-rpm-index.sh
+++ b/hack/verify-rpm-index.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6"
+PACKAGING_TOOLS_IMAGE="arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.7"
 
 set -o errexit
 set -o pipefail

--- a/hack/verify-rpm-index.sh
+++ b/hack/verify-rpm-index.sh
@@ -23,6 +23,6 @@ if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then
 fi
 
 while [[ $# -gt 0 ]]; do
-    docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i "$PACKAGING_TOOLS_IMAGE" rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -v -n 32 - >/dev/null < "$1"
+    docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i "$PACKAGING_TOOLS_IMAGE" rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -v -n 16 - >/dev/null < "$1"
     shift
 done

--- a/release.sh
+++ b/release.sh
@@ -168,7 +168,7 @@ parallel -j 75% --retries 5 --halt-on-error now,fail=1 -v \
     "${ROOTDIR}/build/images/sync.sh" "docker://{2}" "dir:${BUILDDIR}/docker/{1}"
 
 # Sync RPM manifests
-export RPM_SYNC_NUM_CONCURRENT_DOWNLOADS=32
+export RPM_SYNC_NUM_CONCURRENT_DOWNLOADS=16
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp2/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp2" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp2-compute/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp2-compute" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp3/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp3" -s
@@ -295,7 +295,6 @@ if [[ "${EMBEDDED_REPO_ENABLED:-yes}" = "yes" ]]; then
     > "${ROOTDIR}/rpm/embedded.yaml"
 
     # Sync RPMs from node images
-    RPM_SYNC_NUM_CONCURRENT_DOWNLOADS=1
     rpm-sync "${ROOTDIR}/rpm/embedded.yaml" "${BUILDDIR}/rpm/embedded" -s
 
     # Fix-up embedded/cray directories by removing misc subdirectories

--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 
-: "${PACKAGING_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.6}"
+: "${PACKAGING_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.7}"
 : "${RPM_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/rpm-tools:1.0.0}"
 : "${SKOPEO_IMAGE:=arti.hpc.amslabs.hpecorp.net/quay-remote/skopeo/stable:v1.4.1}"
 : "${CRAY_NEXUS_SETUP_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cray-nexus-setup:0.7.1}"


### PR DESCRIPTION
## Summary and Scope

A few enhancements related to overall stability of CSM build:

1. Run `API Documentation` stage in parallel with other validation stages, but use dedicated VM. Thus it does not affect overall VM utilization and does not cause `context deadline exceeded` errors on main VM.
2. Reduce parallelization for `rpm-sync` operations. With parallel threads set to 32, I've been observing it got stuck for 10 minutes and failing afterwards.
3. Migrate to `packaging-tools` version `0.12.7`, which has a fix for exception handling. It will always print which artifact download stalled, and will also reliably fail the build (in the past, I've observed it just swallowed the failure, delivering unfinished result).

## Issues and Related PRs

* Resolves [CASMINST-6832](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6382)

## Testing
### Tested on:

  * Jenkins

### Test description:

https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm/detail/feature%2Finvestigate-timeouts/5/pipeline

## Risks and Mitigations

Low - build pipeline change only. Individual commits can be reverted if found problematic.
