### PR TITLE
CASMINST-6383: Sync up csm-testing rpms in sle-15sp3 and sle-15-sp4

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.72.0-1.x86_64
-    - csm-testing-1.15.46-1.noarch
-    - goss-servers-1.15.46-1.noarch
+    - csm-testing-1.15.47-1.noarch
+    - goss-servers-1.15.47-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 


### PR DESCRIPTION
## Summary and Scope

Update csm-testing and goss-servers rpms in sle15-sp3 manifest since that is the one that gets installed in the 1.4 CI pipeline.

## Issues and Related PRs

* Resolves [CASMINST-6383](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6383)
* Related to [CASMTRIAGE-5354](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5354)

## Testing

### Tested on:

  * Virtual Shasta - grog

### Test description:

Verified that the correct rpm gets selected for installation.

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

