### PR TITLE
CASMPET-6590 Update cray-drydock

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.15.1
+    version: 2.15.2
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
The previous network policy was not correctly implemented. This will allow dvs mqtt client to talk to the dvs activemq artemis server on clusters that have working NetworkPolicies