### PR TITLE
Update hms-hmcollector to version 2.16.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -76,7 +76,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.18.1/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.16.0
+    version: 2.16.1
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update hms-hmcollector to version 2.16.1
hmcollector 2.16.1 automatically removes stale redfish subscriptions. Stale subscriptions happen when the hardware is moved.

CASMHMS-5685

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* https://github.com/Cray-HPE/hms-hmcollector/pull/49

https://github.com/Cray-HPE/hms-hmcollector-charts/pull/22
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

see PRs:
https://github.com/Cray-HPE/hms-hmcollector/pull/49
https://github.com/Cray-HPE/hms-hmcollector-charts/pull/22

### Tested on:

  * docker compose env
  * mug

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

Added config option so that the feature can be turned off.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

