### PR TITLE
CASMHMS-6018 dmsquash-live pre-signed URL

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,12 +36,12 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.1.1
+    version: 3.1.2
     namespace: services
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.24.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.25.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 4.0.2


### PR DESCRIPTION
Add pre-signed URL support for the dmsquash-live dracut module (`root=live:<url>`).

This will be used for booting CSM application, compute, and hypervisor images built from node-images.
