### PR TITLE
Automated power control on node exit/entry from/to tenant (CASMPET-6317)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -243,11 +243,15 @@ spec:
     namespace: spire
 
   # Tapms service
+  - name: cray-tapms-crd
+    source: csm-algol60
+    version: 0.2.1
+    namespace: tapms-operator
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.1.0
+    version: 0.2.1
     namespace: tapms-operator
     swagger:
     - name: tapms-operator
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.5.4/docs/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.5.6/docs/openapi.yaml


### PR DESCRIPTION
### Summary and Scope

Refactor structure for versioned releases, add power control functionality.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6317

### Testing

Verified image on redbull:

```
{
  "childnamespaces": [
    "vcluster-green-slurm"
  ],
  "tenantresources": [
    {
      "enforceexclusivehsmgroups": true,
      "forcepoweroff": false,
      "hsmgrouplabel": "green",
      "type": "compute",
      "xnames": [
        "x3000c0s19b3n0"
      ]
    },
    {
      "enforceexclusivehsmgroups": true,
      "forcepoweroff": true,
      "hsmgrouplabel": "green",
      "type": "application",
      "xnames": [
        "x3000c0s32b0n0"
      ]
    }
  ],
  "uuid": "7450f2d0-1a7c-4f36-9898-8a73e6c9fc9a"
}
Deployed
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
