### PR TITLE
CASMTRIAGE-5222/CASMNET-2110 - restarting kea on large systems wipe DNS records from configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121 CASMTRIAGE-5155)
 - Update cray-opa to v1.25.8 (CASMPET-6510)
 - Release csm-testing v1.14.62 (CASMPET-6420)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -44,7 +44,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.21 # update platform.yaml cray-precache-images with this
+    version: 0.10.22 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.21
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.22
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.21
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.8
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.6


### PR DESCRIPTION
## Summary and Scope

This PR addresses the following issues

#### CASMTRIAGE-5222 - do not start kea until config has been generated

The Kea API returns a HTTP response code 200 before dhcp-helper has run and generated the Kea configuration and populated the lease database.

This in turn can cause cray-dns-unbound-manager to delete records when it receives a 200 response from Kea but no leases.

#### CASMNET-1752 - validate generated kea config abort if invalid config

The existing implementation also does not validate the generated Kea configuration before loading it which can leave the pod in a bad state, this PR now uses Kea to test the generated configuration before loading it ensuring the configuration is always valid.

#### CASMNET-2108 - add kea config backup and load from backup functionality to cray-dhcp-kea

cray-dhcp-kea now backup the generated configuration to the `cray-dhcp-kea-backup` ConfigMap. If the pod is restarted this configuration is used rather than rebuilding it from scratch.

#### CASMNET-2109 - add per node pxe options

Provide the option for a node to boot a manually specified ipxe binary by providing an `ipxe=<artifact>` KV pair in the SMD ethernetInterfaces description field.

#### CASMNET-1525 - Control dhcp-helper.py log levels via an environment variable

Quality of life improvement, logging level can now be changed by editing an environment variable in the deployment rather than having to edit the `dhcp-helper.py` script.

## Issues and Related PRs

* Resolves 
  * [CASMNET-2110](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2110) 
  * [CASMNET-1752](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1752) 
  * [CASMNET-2108](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2108) 
  * [CASMNET-2109](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2109)
  * [CASMNET-1525](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1525)

## Testing

### Tested on:

  * `mug`
  * `surtur`

### Test description:

#### CASMNET-2110

The Kea API container does not reach a Ready state until Kea has loaded a valid configuration. This prevents `cray-dns-unbound-manager` from querying Kea, obtaining no records, and deleting entries from DNS.

#### CASMNET-1752

Introduced an error into SLS (for uai_macvlan the attributes should be ReservationStart and ReservationEnd

```
ncn-m001:~ # cray sls dumpstate list --format json | jq '.Networks.NMN.ExtraProperties.Subnets[] | select(.Name=="uai_macvlan") | {Name,DHCPEnd,DHCPStart}'
{
  "Name": "uai_macvlan",
  "DHCPEnd": "10.252.3.254",
  "DHCPStart": "10.252.2.10"
}
```
dhcp-helper now validates the config and aborts rather than replacing the existing configuration (the Kea messages are from the server in test mode, not the running server)
```
/ $ /srv/kea/dhcp-helper.py
2023-05-19 10:55:28,572 - __main__ - ERROR - Error with Kea Config Validation.2023-05-19 10:55:28.559 INFO  [kea-dhcp4.hosts/72250.139940411438208] HOSTS_BACKENDS_REGISTERED the following host backend types are available: postgresql
2023-05-19 10:55:28.559 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_SOCKET_TYPE_SELECT using socket type udp
2023-05-19 10:55:28.559 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_ADD_IFACE listening on interface eth0
2023-05-19 10:55:28.560 INFO  [kea-dhcp4.hooks/72250.139940411438208] HOOKS_LIBRARY_CLOSED hooks library /usr/local/lib/kea/hooks/libdhcp_lease_cmds.so successfully closed
2023-05-19 10:55:28.560 INFO  [kea-dhcp4.hooks/72250.139940411438208] HOOKS_LIBRARY_CLOSED hooks library /usr/local/lib/kea/hooks/libdhcp_stat_cmds.so successfully closed
2023-05-19 10:55:28.568 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_NEW_SUBNET4 a new subnet has been added to configuration: 10.102.67.192/26 with params: valid-lifetime=3600
2023-05-19 10:55:28.568 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_NEW_SUBNET4 a new subnet has been added to configuration: 10.254.1.0/17 with params: valid-lifetime=3600
2023-05-19 10:55:28.569 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_NEW_SUBNET4 a new subnet has been added to configuration: 10.1.1.0/16 with params: valid-lifetime=3600
2023-05-19 10:55:28.569 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_NEW_SUBNET4 a new subnet has been added to configuration: 10.107.0.0/22 with params: valid-lifetime=3600
2023-05-19 10:55:28.569 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_NEW_SUBNET4 a new subnet has been added to configuration: 10.252.1.0/17 with params: valid-lifetime=3600
2023-05-19 10:55:28.570 INFO  [kea-dhcp4.dhcpsrv/72250.139940411438208] DHCPSRV_CFGMGR_NEW_SUBNET4 a new subnet has been added to configuration: 10.252.2.0/23 with params: valid-lifetime=3600
2023-05-19 10:55:28.570 ERROR [kea-dhcp4.dhcp4/72250.139940411438208] DHCP4_PARSER_FAIL failed to create or run parser for configuration element subnet4: ID of the new IPv4 subnet '2' is already in use (/tmp/cray-dhcp-kea-dhcp4.conf:1:13746)
Error encountered: ID of the new IPv4 subnet '2' is already in use (/tmp/cray-dhcp-kea-dhcp4.conf:1:13746)
Exiting and no update(s) to Kea configs
```
The loaded Kea config is untouched.

#### CASMNET-2108

After a successful dhcp-helper run the configuration has been backed up to a configmap

```
ncn-m001:~ # kubectl -n services get cm cray-dhcp-kea-backup -o jsonpath='{.binaryData.keaBackup\.conf\.gz}' | base64 -d | gzip -dc | jq | head{
  "Dhcp4": {
    "decline-probation-period": 3,
    "sanity-checks": {
      "lease-checks": "fix-del"
    },
    "expired-leases-processing": {
      "reclaim-timer-wait-time": 6000,
      "hold-reclaimed-time": 86400,
      "flush-reclaimed-timer-wait-time": 100
```

If this backup exists when cray-dhcp-kea starts then it is used instead of creating the config from scratch.

```
ncn-m001:~ # kubectl -n services logs cray-dhcp-kea-76f65d986b-bfv25 -c cray-dhcp-kea | head -20
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
HTTP/1.1 200 OK
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
content-type: text/html; charset=UTF-8
cache-control: no-cache, max-age=0
x-content-type-options: nosniff
date: Thu, 18 May 2023 14:31:16 GMT
server: envoy
transfer-encoding: chunked

Sidecar available
INFO: Configuration backup exists, checking for validity.
INFO: Configuration backup validated, copying into place
INFO: Using existing configuration.
2023-05-18 14:31:16.305 INFO  [kea-dhcp4.dhcp4/16.139838455571584] DHCP4_STARTING Kea DHCPv4 server version 2.3.1 (development) starting
```

#### CASMNET-2109

Specified a non-default ipxe binary in the ethernetInterfaces record for a compute node.
```
ncn-m001:~/cspiller/kea # cray hsm inventory ethernetInterfaces update b42e99dfec47 --description "ipxe=test.efi"
ID = "b42e99dfec47"
Description = "ipxe=test.efi"
MACAddress = "b4:2e:99:df:ec:47"
LastUpdate = "2023-05-03T15:31:18.150531Z"
ComponentID = "x3000c0s17b4n0"
Type = "Node"
[[IPAddresses]]
IPAddress = "10.252.1.15"
```
Verified the node boots looking for this new binary name.
```
2023-05-18 16:10:10 >>Media Present......
2023-05-18 16:10:10 >>Start PXE over IPv4 on MAC: B4-2E-99-DF-EC-47. Press ESC key to abort PXE boot.
2023-05-18 16:10:18   Station IP address is 10.252.1.15
2023-05-18 16:10:18
2023-05-18 16:10:18   Server IP address is 10.92.100.60
2023-05-18 16:10:18   NBP filename is test.efi
2023-05-18 16:10:18   NBP filesize is 0 Bytes
2023-05-18 16:10:18   PXE-E23: Client received TFTP error from server.
```
#### CASMNET-1525

Default LOG_LEVEL is WARN

```
ncn-m001:~ # kubectl -n services get deployment cray-dhcp-kea -o json | jq '.spec.template.spec.containers[0].env[] | select(.name=="LOG_LEVEL")'
{
  "name": "LOG_LEVEL",
  "value": "WARN"
}
```

Increase log level and verified output increases in verbosity as expected

```
/ $ LOG_LEVEL=DEBUG /srv/kea/dhcp-helper.py
2023-05-19 09:02:29,355 - __main__ - DEBUG - POST http://cray-dhcp-kea-api:8000/ with headers:{
    "Content-Type": "application/json"
}and JSON:{
    "command": "lease4-get-all",
    "service": [
        "dhcp4"
    ]
}
2023-05-19 09:02:29,355 - __main__ - DEBUG - Response to POST http://cray-dhcp-kea-api:8000/ => 200 OK
...
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

