### PR TITLE
CASMCMS-8613: Update BOS to fix issue with v2 reboots (1.4)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.16
+    version: 2.0.17
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Updates BOS to fix an issue that can occur on large systems when rebooting with v2 but not changing the artifacts being booted.  

## Issues and Related PRs

* Resolves CASMCMS-8613

## Testing

### Tested on:

  * Ashton

### Test description:

Tested new response code

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

