### PR TITLE
CASMCMS-8621: Add noarch rpms support for cfs-trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## Unreleased
+- Update cfs-trust to use noarch rpms (CASMCMS-8621)
 - Add arm64 and x86 compute node artifacts (CASM-4066)
 - Update csm-testing to 1.16.34 (CASMINST-6342)
 - Update cray-drydock to 2.18.1 (CASMPET-6583)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.3
+    version: 1.6.4
     namespace: services
   - name: cms-ipxe
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -24,5 +24,5 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.2-1.noarch
-    - cfs-trust-1.6.0-1.x86_64
+    - cfs-trust-1.6.4-1.noarch
     - bos-reporter-2.3.0-1.noarch.rpm

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -28,7 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.2-1.noarch
-    - cfs-trust-1.6.3-1.x86_64
+    - cfs-trust-1.6.4-1.noarch
     - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
     - cray-site-init-1.31.2-1.x86_64
     - craycli-0.81.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

- Updating the `cfs-trust` versions to point to newer `noarch` rpms
