### PR TITLE
casmpet-6502 Update cray-spire to 1.4.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -239,7 +239,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.3.0
+    version: 1.4.0
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
This fixes an issue where NCNs are unable to connect to the spire-server.