### PR TITLE
Update UAS to 1.23.0 for etcd bitnami

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -220,12 +220,12 @@ spec:
   # Cray UAS Manager service
   - name: cray-uas-mgr
     source: csm-algol60
-    version: 1.22.1
+    version: 1.23.0
     namespace: services
     swagger:
     - name: uas-mgr
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/uas-mgr/v1.22.1/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/uas-mgr/v1.23.0/api/swagger.yaml
 
   - name: update-uas
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update UAS to use the new bitnami etcd chart.
Update python requirements for a clean build (and address dependabot security alerts)

## Issues and Related PRs

* Resolves [CASMUSER-3148](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3148)

## Testing

  * `ashton`

### Test description:


```
cray-uas-mgr-556d5f5f88-gn2hd                                     2/2     Running            0          19m
cray-uas-mgr-556d5f5f88-pfmgv                                     2/2     Running            0          18m
cray-uas-mgr-bitnami-etcd-0                                       2/2     Running            0          29m
cray-uas-mgr-bitnami-etcd-1                                       2/2     Running            0          30m
cray-uas-mgr-bitnami-etcd-2                                       2/2     Running            0          31m
cray-uas-mgr-bitnami-etcd-snapshotter-28083720-bbjl8              0/2     Completed          0          26m
cray-uas-mgr-etcd-post-install-6k4l2                              0/1     Completed          0          33m
cray-uas-mgr-pre-upgrade-etcd-backup-xk4ws                        0/1     Completed          0          33m
cray-uas-mgr-wait-for-etcd-2-sp8fx                                0/1     Completed          0          33m
```

Basic CRUD test using the new etcd backend
```
pit:~ # cray uas admin config images create --imagename foo
{
  "default": false,
  "image_id": "a465cb81-f43a-4282-bdf6-f6963832686f",
  "imagename": "foo"
}
pit:~ # cray uas admin config images update a465cb81-f43a-4282-bdf6-f6963832686f --imagename bar
{
  "default": false,
  "image_id": "a465cb81-f43a-4282-bdf6-f6963832686f",
  "imagename": "bar"
}
pit:~ # cray uas admin config images describe a465cb81-f43a-4282-bdf6-f6963832686f
{
  "default": false,
  "image_id": "a465cb81-f43a-4282-bdf6-f6963832686f",
  "imagename": "bar"
}
pit:~ # cray uas admin config images delete a465cb81-f43a-4282-bdf6-f6963832686f
{
  "default": false,
  "image_id": "a465cb81-f43a-4282-bdf6-f6963832686f",
  "imagename": "bar"
}
pit:~ # cray uas admin config images describe a465cb81-f43a-4282-bdf6-f6963832686f
Usage: cray uas admin config images describe [OPTIONS] IMAGE_ID
Try 'cray uas admin config images describe --help' for help.

Error: Not Found: image 'a465cb81-f43a-4282-bdf6-f6963832686f' does not exist
```

```
ncn-m002:~/alanm # loftsman ship --manifest-path ./manifest.yaml --charts-path ./helm/
2023-05-25T13:53:21Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-05-25T13:53:21Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-05-25T13:53:21Z INF Ensuring that the loftsman namespace exists command=ship
2023-05-25T13:53:21Z INF Loftsman will use the packaged charts at ./helm/ as the Helm install source command=ship
2023-05-25T13:53:21Z INF Running a release for the provided manifest at ./manifest.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-uas-mgr v1.23.0-20230524182857+671a88c
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-05-25T13:53:22Z INF Running helm install/upgrade with arguments: upgrade --install cray-uas-mgr helm/cray-uas-mgr-1.23.0-20230524182857+671a88c.tgz --namespace services --create-namespace --set global.chart.name=cray-uas-mgr --set global.chart.version=1.23.0-20230524182857+671a88c chart=cray-uas-mgr command=ship namespace=services version=1.23.0-20230524182857+671a88c
2023-05-25T13:54:42Z INF W0525 13:53:33.827558 2894404 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0525 13:53:33.831455 2894404 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0525 13:53:33.838326 2894404 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "cray-uas-mgr" has been upgraded. Happy Helming!
NAME: cray-uas-mgr
LAST DEPLOYED: Thu May 25 13:53:27 2023
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Installation info for chart cray-uas-mgr:
 chart=cray-uas-mgr command=ship namespace=services version=1.23.0-20230524182857+671a88c
2023-05-25T13:54:42Z INF Ship status: success. Recording status, manifest to configmap loftsman-alanm in namespace loftsman command=ship
2023-05-25T13:54:42Z INF Recording log data to configmap loftsman-alanm-ship-log in namespace loftsman command=ship
```

## Risks and Mitigations

Needs wider testing with a metal system when available


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

