### PR TITLE
CASMINST-3421 CASMINST-6410 Add `noos` repo

### DIFF
--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -65,13 +65,14 @@ skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 
 # Upload repository contents
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/noos"              "csm-${RELEASE_VERSION}"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2"         "csm-${RELEASE_VERSION}-sle-15sp2"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2-compute" "csm-${RELEASE_VERSION}-sle-15sp2-compute"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERSION}-sle-15sp3"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3-compute" "csm-${RELEASE_VERSION}-sle-15sp3-compute"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4"         "csm-${RELEASE_VERSION}-sle-15sp4"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute" "csm-${RELEASE_VERSION}-sle-15sp4-compute"
-nexus-upload raw "${ROOTDIR}/rpm/embedded" "csm-${RELEASE_VERSION}-embedded"
+nexus-upload raw "${ROOTDIR}/rpm/embedded"                   "csm-${RELEASE_VERSION}-embedded"
 
 clean-install-deps
 

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,12 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
-    - cray-switchboard-2.1.0-1.x86_64
-    - cray-uai-util-2.1.0-1.x86_64
-    - csm-install-workarounds-1.12.1-1.noarch
-    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
-    - shasta-authorization-module-1.6.2-1.noarch
-    - yapl-0.1.1-1.x86_64
+    - platform-utils-1.5.2-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -23,4 +23,5 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
+    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - platform-utils-1.5.2-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -27,6 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -40,6 +40,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64
     - iuf-cli-1.5.2-1.x86_64
+    - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64
@@ -47,7 +48,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.3.0-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
-    - libcsm-0.0.4-1.noarch
+    - platform-utils-1.5.2-1.noarch
     - spire-agent-1.5.5-1.7.x86_64
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/:
   rpms:

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -37,6 +37,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.16.34-1.noarch
     - goss-servers-1.16.34-1.noarch
+    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64
     - iuf-cli-1.5.2-1.x86_64


### PR DESCRIPTION
This adds the `noos` repo, and moves one of the first packages to publish there into it (`platform-utils`).
