### PR TITLE
CASMHMS-5958: Fix HSM Node Architecture Discovery for ARM

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.2
+    version: 7.0.3
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.8.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.9.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 2.0.3


### PR DESCRIPTION
## Summary and Scope

This updates the cray-smd chart version for CASMHMS-5958 to allow HSM to discover ARM node architecture.

## Issues and Related PRs

* Resolves [CASMHMS-5958](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5958)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/114

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

