### PR TITLE
CASMREL-1512

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -40,7 +40,7 @@ KERNEL_VERSION='5.14.21-150400.24.63-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION/-default/}.1.${NCN_ARCH}"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=5.1.0
+KUBERNETES_IMAGE_ID=5.1.1
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -48,14 +48,14 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=5.1.0
+PIT_IMAGE_ID=5.1.1
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/installed.deps-${PIT_IMAGE_ID}-${NCN_ARCH}.packages"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=5.1.0
+STORAGE_CEPH_IMAGE_ID=5.1.1
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=5.1.0
+COMPUTE_IMAGE_ID=5.1.1
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -45,7 +45,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - loftsman-1.2.0-2.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.5-1.x86_64
-    - metal-ipxe-2.3.0-1.noarch
+    - metal-ipxe-2.4.0-1.noarch
     - pit-init-1.3.0-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64


### PR DESCRIPTION
- [CASMINST-6410](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6410) images (the RPMs went in via #2277)
- [MTL-2032](https://jira-pro.it.hpe.com:8443/browse/MTL-2032) (staging items; metal-ipxe, and metal-provision scripts)
- [MTL-2139](https://jira-pro.it.hpe.com:8443/browse/MTL-2139) (metal-ipxe aarm64 support)

***NOTE*** MTL-2032 is *not* linked to CASMREL-1512 because it is incomplete, these image builds and the included metal-ipxe are needed for staging the rest of its changes.

***NOTE*** MTL-2139 is linked post-release meeting because it was automatically included with MTL-2032's staging change, MTL-2139 went in between metal-ipxe-2.3.0 and metal-ipxe-2.4.0.
