### PR TITLE
CASMPET-6606: cray-etcd-operator cannot be installed as-is on 1.22 at…

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -210,10 +210,6 @@ spec:
     - name: sts
       version: v1
       url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.7.0/api/openapi.yaml
-  - name: cray-etcd-operator
-    source: csm-algol60
-    version: 0.17.3
-    namespace: operators
   - name: cray-etcd-defrag
     source: csm-algol60
     version: 0.4.0


### PR DESCRIPTION
… all, remove it

## Summary and Scope

Not backwards compatible at all. But this operator does not work on 1.22 so its a non-issue it can't install anyway.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6606
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Vshasta v2

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

This was from a run in yasha and fearne, our default platform.yaml file can't install with this present as it uses api's removed in k8s 1.22.

Since a new install shouldn't use this at all anymore remove it from the platform yaml.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

