### PR TITLE
CASMPET-6580 Disable spire postgres backups

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -235,11 +235,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.13.1
+    version: 2.14.2
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.4.0
+    version: 1.4.1
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
spire-server needs to be reinstalled if there's a problems. Backups will restore old authentication data that will cause unexpected issues.