### PR TITLE
CASMPET-6591: Set priorityClassName for cray-vault-operator deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-
 ## Unreleased
+- Update cray-vault-operator to 1.3.0 (CASMPET-6591)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)
 - Update iuf-cli from iuf-cli-1.5.1 to iuf-cli-1.5.2
 - Add arm64 and x86 compute node artifacts (CASM-4066)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.2.0
+    version: 1.3.0
     namespace: vault
   - name: cray-vault
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Adding priorityClassName csm-high-priority-service to the cray-vault-operator for CSM 1.5

## Issues and Related PRs

* Resolves [CASMPET-6591](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6591)
* Change will also be needed in `NA`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

drax (1.5.0-beta.1)

### Test description:

* Pre check using helm template
```
$ helm template .

# Source: cray-vault-operator/charts/vault-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-vault-operator
  labels:
    helm.sh/chart: vault-operator-1.16.1
    app.kubernetes.io/name: vault-operator
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
spec:
  strategy:
    type: Recreate
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: vault-operator
  template:
    metadata:
      labels:
        app.kubernetes.io/name: vault-operator
        app.kubernetes.io/instance: RELEASE-NAME
    spec:
      priorityClassName: csm-high-priority-service  <-------
      containers:
...
```

* Upgrade
```
# helm history cray-vault-operator -n vault
REVISION	UPDATED                 	STATUS    	CHART                                           	APP VERSION	DESCRIPTION
1       	Mon May 29 07:26:51 2023	superseded	cray-vault-operator-1.2.0                       	1.16.0     	Install complete
2       	Mon May 29 16:18:56 2023	superseded	cray-vault-operator-1.2.0                       	1.16.0     	Upgrade complete
3       	Mon May 29 17:06:00 2023	superseded	cray-vault-operator-1.2.0                       	1.16.0     	Upgrade complete
4       	Mon May 29 17:26:15 2023	superseded	cray-vault-operator-1.2.0                       	1.16.0     	Upgrade complete
5       	Tue May 30 13:31:48 2023	superseded	cray-vault-operator-1.2.0                       	1.16.0     	Upgrade complete
6       	Tue May 30 21:00:01 2023	deployed  	cray-vault-operator-1.2.0-20230530202130+b42161e	1.16.0     	Upgrade complete
```

* Check that priorityClassName is set as expected after upgrade 
```
# kubectl get deployment cray-vault-operator -n vault -o json | jq -r '.spec.template.spec.priorityClassName'
csm-high-priority-service
```

* Rollback to 5
```
5       	Tue May 30 13:31:48 2023	superseded	cray-vault-operator-1.2.0                       	1.16.0     	Upgrade complete
6       	Tue May 30 21:00:01 2023	superseded	cray-vault-operator-1.2.0-20230530202130+b42161e	1.16.0     	Upgrade complete
7       	Tue May 30 21:06:45 2023	deployed  	cray-vault-operator-1.2.0                       	1.16.0     	Rollback to 5
```

```
ncn-m001:~ # kubectl get deployment cray-vault-operator -n vault -o json | jq -r '.spec.template.spec.priorityClassName'
null
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

NA

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable