### PR TITLE
CASMCMS-8581: Update csm-ssh-keys Ansible to restrict file permissions

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -201,7 +201,7 @@ spec:
             tag: 1.8.3
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.5.1
+    version: 1.5.2
     namespace: services
   - name: gitea
     source: csm-algol60

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -33,8 +33,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cray-site-init-1.31.2-1.x86_64
     - craycli-0.81.2-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
-    - csm-ssh-keys-1.5.1-1.noarch
-    - csm-ssh-keys-roles-1.5.1-1.noarch
+    - csm-ssh-keys-1.5.2-1.noarch
+    - csm-ssh-keys-roles-1.5.2-1.noarch
     - csm-testing-1.16.34-1.noarch
     - goss-servers-1.16.34-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64


### PR DESCRIPTION
## Summary and Scope

Updates the csm-ssh-keys Ansible content to pull in a change that will create a file with more restricted permissions to address a security concern.

## Issues and Related PRs

* Resolves CASMCMS-8581

## Testing

Tested by LANL

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

