### PR TITLE
CASMTRIAGE-5475: Release csm-testing v1.16.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update csm-testing to 1.16.35 (CASMTRIAGE-5475)
 - Update iuf-cli from 1.5.2 to 1.5.3 and cray-nls and cray-iuf from 3.1.1 to 3.1.2 (CASMINST-6208)
 - Update cray-vault-operator to 1.3.0 (CASMPET-6591)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.2-1.noarch
     - csm-ssh-keys-roles-1.5.2-1.noarch
-    - csm-testing-1.16.34-1.noarch
-    - goss-servers-1.16.34-1.noarch
+    - csm-testing-1.16.35-1.noarch
+    - goss-servers-1.16.35-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Discovered that we have two different master taint tests in goss.   One of them I added to 1.6 about 5 months ago.   Then a couple of months later when we were still hitting the master taint issue in 1.4, I looked for the test and didn't find it.   Therefore, I added the test to both 1.4 and main.    This resulted in the two different tests in main.

I am removing the one I added originally because the new test handles the case where ncn-m001 is not deployed yet.

I also added goss-check-taints.yaml to the ncn-kubernetes-tests-master suite.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5475](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5475)

## Testing

### Tested on:

  * `surtur`

### Test description:

I ran `csm pit validate --k8s` after removing `goss-k8s-nodes-master-taint.yaml` from the `ncn-kubernetes-tests-master-single` suite.  I verified in the full output that the taint test ran on both m002 and m003.   All tests passed.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


