### PR TITLE
CASMINST-3421 Fixup

### DIFF
--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -65,7 +65,7 @@ skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 
 # Upload repository contents
-nexus-upload raw "${ROOTDIR}/rpm/cray/csm/noos"              "csm-${RELEASE_VERSION}"
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/noos"              "csm-${RELEASE_VERSION}-noos"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2"         "csm-${RELEASE_VERSION}-sle-15sp2"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2-compute" "csm-${RELEASE_VERSION}-sle-15sp2-compute"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERSION}-sle-15sp3"

--- a/nexus-repositories.yaml
+++ b/nexus-repositories.yaml
@@ -104,7 +104,6 @@ group:
   memberNames:
   - csm-0.0.0-sle-15sp4-compute
 
-
 ---
 name: csm-0.0.0-noos
 format: raw
@@ -119,7 +118,6 @@ type: group
 group:
   memberNames:
   - csm-0.0.0-noos
-
 
 ---
 name: csm-0.0.0-embedded


### PR DESCRIPTION
Fixes failing test in csm-install, which was waiting on `csm-${RELEASE_VERSION}-noos` to exist.
Fallout from #2298.