### PR TITLE
CASMINST-6333 Bump CSI to 1.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update cray-site-init to 1.31.3
 - Update iuf-cli from 1.5.2 to 1.5.3 and cray-nls and cray-iuf from 3.1.1 to 3.1.2 (CASMINST-6208)
 - Update cray-vault-operator to 1.3.0 (CASMPET-6591)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cray-site-init-1.31.2-1.x86_64
+    - cray-site-init-1.31.3-1.x86_64
     - craycli-0.81.2-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-3.5.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-state-reporter-1.9.2-1.noarch
     - cfs-trust-1.6.3-1.x86_64
     - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
-    - cray-site-init-1.31.2-1.x86_64
+    - cray-site-init-1.31.3-1.x86_64
     - craycli-0.81.2-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.2-1.noarch
@@ -54,4 +54,3 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/:
   rpms:
     - cvt-1.4.22-20230519111329_785fd5fe00f2.x86_64
-


### PR DESCRIPTION
## Summary and Scope

Move cray-site-init RPM to 1.31.2 which makes the `bond0` interface on NCNs optional to permit vShasta to populate BSS, and adds public key authentication to the SSH invocations used when populating BSS. The SSH authentication will try to use public key authentication first, then fall back to password based authentication. In the case of a fallback, it will prompt for the password once. That password will then be used for any NCN that fails public key authentication. If any NCN fails both, SSH will retry password based authentication prompting for a new password (and tell the user which NCN it is trying to reach). Rinse and repeat.

In addition to this, if `bond0` cannot be found on an NCN, the code will now issue a warning and continue. This allows vShasta to work without having `bond0` interfaces which will not work on vShasta nodes.

This is a backward compatible bug-fix.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6333](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6333)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

This was tested extensively on vShasta as part of the testing of the procedure to prepare nodes to boot from BSS.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? n
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

There are no known issues or risks introduced by this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

