### PR TITLE
MTL-2016 New CFS play for `csm-auth-utils`

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.2
+    version: 1.16.3
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Includes `csm-auth-utils` in the CFS `csm_packages` variable file.

CASMINST-3431 - includes the `noos` repo in the CFS `csm_repos` variable file.
