### PR TITLE
MTL-2167 Fix goss test for ipxe files

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.2-1.noarch
     - csm-ssh-keys-roles-1.5.2-1.noarch
-    - csm-testing-1.16.35-1.noarch
-    - goss-servers-1.16.35-1.noarch
+    - csm-testing-1.16.36-1.noarch
+    - goss-servers-1.16.36-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
Addresses a failed goss test that broke from MTL-2139.

