### PR TITLE
casmpet-6615 Bump cray-spire to 1.4.2

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -239,7 +239,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.4.1
+    version: 1.4.2
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
The hostPath has changed for this chart. However, the PSP was not updated along with this path change, causing the spire-jwks service to fail to start. This fixes the permission issue.