### PR TITLE
MTL-2165 New `ilorest`

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,5 +25,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - csm-auth-utils-1.0.0-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
+    - ilorest-4.2.0.0-20.x86_64
     - platform-utils-1.5.2-1.noarch
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,6 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cray-site-init-1.31.3-1.x86_64
     - craycli-0.81.2-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
-    - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -40,6 +40,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64
+    - ilorest-4.2.0.0-20.x86_64
     - iuf-cli-1.5.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64


### PR DESCRIPTION
New `ilorest` 4.2.0.0 provides Gen11 support, and can be pulled from SP4 and noos repos. It'll be mentioned in both sp4 and noos until we're ready to just use the noos copy.
