### PR TITLE
CASMTRIAGE-5494 - csm-1.3.4 upgrade failure pulling image: connection refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121 CASMTRIAGE-5155)
 - Update cray-opa to v1.25.8 (CASMPET-6510)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.22
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.21
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.8
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.6


### PR DESCRIPTION
## Summary and Scope

Fix manifest error, cray-precache-images was not configured to cache the version of cray-dhcp-kea that was shipped.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5494](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5494)

## Testing

### Tested on:

  * `fanta`

### Test description:

Re-deployed cray-precache-images with new values, the correct version of cray-dhcp-kea is now cached.
```
ncn-m002:~ # kubectl -n nexus logs cray-precache-images-8kgm8 | grep -A1 cray-dhcp-kea
Caching image: artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.23
  Image is up to date for sha256:8ba80b66441bf09e4929927e2764c49d89ad0fc93859afd605b37ade4d5aeea8
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

