### PR TITLE
CASM-3946: Logging improvements for IUF

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,7 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.2.0
 
     iuf:
-    - v0.1.3
+    - v0.1.6
 
     # Rebuilt third-party images below
 
@@ -187,4 +187,4 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.3.2
       - 1.8.8
     cray-nexus-setup:
-      - 0.9.3
+      - 0.10.0

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.5.0
+      - 2.5.2
     cray-grafterm:
       - 1.0.2
     # XXX Are these HMS images missing from a chart or are they used to
@@ -52,10 +52,10 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.8.0
 
     cf-gitea-update:
-      - 1.0.4
+      - 1.0.6
 
     cf-gitea-import:
-      - 1.9.4
+      - 1.9.5
 
     cray-capmc:
       - 2.7.0
@@ -185,7 +185,6 @@ artifactory.algol60.net/csm-docker/stable:
     cray-product-catalog-update:
       - 1.3.1
       - 1.3.2
-      - 1.8.2
-      - 1.8.3
+      - 1.8.8
     cray-nexus-setup:
       - 0.9.3

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: argo
     swagger:
     - name: nls

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -198,7 +198,7 @@ spec:
       cray-import-config:
         catalog:
           image:
-            tag: 1.8.3
+            tag: 1.8.8
   - name: csm-ssh-keys
     source: csm-algol60
     version: 1.5.2
@@ -214,7 +214,7 @@ spec:
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version: 1.8.3
+    version: 1.8.8
     namespace: services
 
   # Cray UAS Manager service


### PR DESCRIPTION
## Summary and Scope

As part of the initiative CASM-3946 for enhancing IUF logging, modified various repo whose PR's are listed below. Updating CSM with the latest image versions of all the products. 

## Issues and Related PRs

https://github.com/Cray-HPE/cray-nls/pull/179                               - CASM-4314
https://github.com/Cray-HPE/cray-product-catalog/pull/228         - CASM-4224
https://github.com/Cray-HPE/iuf-containers/pull/16                       - CASM-4225/CASM-4226
https://github.com/Cray-HPE/nexus-setup/pull/25                          - CASM-4227/CASM-4228/CASM-4229/CASM-4230
https://github.com/Cray-HPE/cf-gitea-import/pull/84                     - CASM-4231
https://github.com/Cray-HPE/ims-load-artifacts/pull/62                 - CASM-4232
https://github.com/Cray-HPE/ims-python-helper/pull/41               - CASM-4232 
https://github.com/Cray-HPE/cf-gitea-update/pull/20                    - CASM-4233
