### PR TITLE
CASMINST-6451: Fix bug creating BOS session templates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,13 +128,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.4.0
+    version: 2.4.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.4.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.4.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.2

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.3.0-1.noarch.rpm
+    - bos-reporter-2.4.1-1.noarch.rpm
     - canu-1.7.1-1.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Fixing a bug with the API spec regular expressions introduced a new bug for creating session templates. This updates to a BOS version with the new bug fixed. See source PR for details.

# Issues and Related PRs

* Resolves [CASMINST-6451](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6451)
* Caused by fix for [CASMTRIAGE-5367](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5367).
* [Source PR](https://github.com/Cray-HPE/bos/pull/146)
* [PR to update 1.3 hotfix](https://github.com/Cray-HPE/csm-hotfixes/pull/20)
* [1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2324)
* [1.3 manifest PR](https://github.com/Cray-HPE/csm/pull/2325)

## Testing

See source PR for details.

## Risks and Mitigations

Low risk. See source PR for details.
