### PR TITLE
Exclude wait-for jobs from auto three day cleanup (CASMINST-6453)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.4.1
+    version: 1.4.2
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Exclude wait-for jobs from auto three day cleanup


### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6453

### Testing

Drax:

```
cray-bss-567f949774-46q6t                                         2/2     Running            0          3h7m
cray-bss-567f949774-dxbtt                                         2/2     Running            0          32m
cray-bss-567f949774-xvk2t                                         2/2     Running            0          3h20m
```

```
ncn-m001:~ # kubectl get job -n services cray-bss-wait-for-etcd-3 -o yaml | grep ttl
ncn-m001:~ #
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
