### PR TITLE
CASMINST-6450 - pin ims dependencies for csm-1.3.4 release.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -99,7 +99,7 @@ spec:
   # CMS
   - name: cray-ims
     source: csm-algol60
-    version: 3.7.1
+    version: 3.7.2
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The nightly rebuilds were picking up a version of ims-python-helper that was too new to use with this release. I pinned the version of the python module to what was needed for this release, so it will not pick up the newer versions.

Code PR's:
https://github.com/Cray-HPE/ims-utils/pull/57
https://github.com/Cray-HPE/ims-kiwi-ng-opensuse-x86_64-builder/pull/51

## Issues and Related PRs

* Resolves [CASMINST-6450](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6450)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I duplicated the problem that NERSC was seeing with the install, then tested the new versions of the dependent images and observed them work correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - this uses the version of the underlying dependency (ims-python-helper) that was originally shipping with the 1.3.x releases.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

