### PR TITLE
Add test to detect etcd clusters not converted to bitnami chart (CASMPET-6608)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.2-1.noarch
     - csm-ssh-keys-roles-1.5.2-1.noarch
-    - csm-testing-1.16.36-1.noarch
-    - goss-servers-1.16.36-1.noarch
+    - csm-testing-1.16.37-1.noarch
+    - goss-servers-1.16.37-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Add test to detect unsupported etcd clusters in CSM 1.5

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6608

### Testing

Success:

```
ncn-m002:/opt/cray/tests/install/ncn/tests # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-non-bitnami-etcd-clusters.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 0.181s
Count: 2, Failed: 0, Skipped: 0
```

Failure:

```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-non-bitnami-etcd-clusters.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
.F

Failures/Skipped:

Title: Verify Etcd Clusters have been migrated to bitmami helm chart
Meta:
    desc: Verifies Etcd clusters have been migrated to a supported version of Kubernetes 1.22. If this test fails, run "kubectl get etcdclusters.etcd.database.coreos.com -A --no-headers" to see which Etcd clusters need conversion.
    sev: 0
Command: non_bitnami_etcd_clusters: stderr: patterns not found: [No resources found]

Total Duration: 0.638s
Count: 2, Failed: 1, Skipped: 0
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
