### PR TITLE
Updated cray-rts version to 4.0.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -88,12 +88,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.17.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
-    version: 3.0.1
+    version: 4.0.0
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
-    version: 3.0.1
+    version: 4.0.0
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

In hms-rts-charts updated cert-manager version for the k8s 1.22 upgrade.

## Issues and Related PRs

* Resolves [CASMHMS-5879](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5879)

## Testing

### Tested on:

  * drax

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? Yes

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

