### PR TITLE
CASMPET-6604: Update sealed-secrets to 0.4.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -104,7 +104,7 @@ spec:
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60
-    version: 0.3.0
+    version: 0.4.1
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates sealed secrets to latest release for 1.22 compatibility.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6604]
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

fearne/grog

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

I've got an update to the sealed-secrets readme but I ran through creating a new secret, updating it, deleting it after upgrading to this new version on 1.22 (fearne) and grog (when it was 1.21) this version of sealed secrets should still run on any 1.16+ cluster but for now lets constrain it to 1.22 only.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

no known issues (I hope)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

