### PR TITLE
CASMTRIAGE-5496 cray-sysmgmt-health fails to install on k8s 1.22 - stable/1.5

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -45,7 +45,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-ims-load-artifacts:
       - 2.5.0
     cray-grafterm:
-      - 1.0.2
+      - 1.0.3
     # XXX Are these HMS images missing from a chart or are they used to
     # XXX facilitate install/upgrade?
     hms-shcd-parser:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.27.8
+    version: 0.27.9
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
Summary and Scope
cray-sysmgmt-health fails to install on k8s 1.22

Issues and Related PRs
[CASMTRIAGE-5496](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5496)
https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-282
https://jira-pro.its.hpecorp.net:8443/browse/CASM-3884

Implementation of the upgraded jettech/kube-webhook-certgen image from 1.2.1 to 1.3.0

Updating the grafterm version in index.yaml for the CASM-3884: Upgrade Prometheus Operator to latest version.

This PR includes index.yaml file change for same.

Tested on Starlord system.

All images and chart gets deployed without issues -
```
ncn-m001:/mnt/developer/sum # kubectl get all -n sysmgmt-health
NAME                                                                READY   STATUS      RESTARTS   AGE
pod/alertmanager-cray-sysmgmt-health-kube-p-alertmanager-0          2/2     Running     1          53m
pod/cray-sysmgmt-health-canu-test-7b5fc744dd-jbjgf                  2/2     Running     0          13s
pod/cray-sysmgmt-health-grafana-768766bb95-qp87c                    3/3     Running     0          53m
pod/cray-sysmgmt-health-grafterm-555dcffcd4-n6wl2                   1/1     Running     0          53m
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-lvlx7              1/1     Running     0          53m
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-rn4m6              1/1     Running     0          53m
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-rn5j5              1/1     Running     0          53m
pod/cray-sysmgmt-health-kube-p-operator-ffcbf9569-x5brl             1/1     Running     0          53m
pod/cray-sysmgmt-health-kube-state-metrics-9ccffd45f-lnjj8          1/1     Running     0          53m
pod/cray-sysmgmt-health-node-exporter-smartmon-dsgpp                1/1     Running     0          53m
pod/cray-sysmgmt-health-node-exporter-smartmon-hn7jx                1/1     Running     0          53m
pod/cray-sysmgmt-health-node-exporter-smartmon-lmxdb                1/1     Running     0          53m
pod/cray-sysmgmt-health-node-exporter-smartmon-lrq27                1/1     Running     0          53m
pod/cray-sysmgmt-health-node-exporter-smartmon-wrcwd                1/1     Running     0          53m
pod/cray-sysmgmt-health-node-exporter-smartmon-xqlnl                1/1     Running     0          53m
pod/cray-sysmgmt-health-patch-nodeexporter-alerts-1-xjbbp           0/1     Completed   0          53m
pod/cray-sysmgmt-health-patch-service-monitors-1-bnssl              0/1     Completed   0          53m
pod/cray-sysmgmt-health-patch-thanos-secret-lz4q9                   0/1     Completed   0          53m
pod/cray-sysmgmt-health-prometheus-node-exporter-45pz4              1/1     Running     0          53m
pod/cray-sysmgmt-health-prometheus-node-exporter-82dkj              1/1     Running     0          52m
pod/cray-sysmgmt-health-prometheus-node-exporter-hnvnx              1/1     Running     0          52m
pod/cray-sysmgmt-health-prometheus-node-exporter-mb6sn              1/1     Running     0          52m
pod/cray-sysmgmt-health-prometheus-node-exporter-sj5cj              1/1     Running     0          52m
pod/cray-sysmgmt-health-prometheus-node-exporter-xqbc9              1/1     Running     0          52m
pod/cray-sysmgmt-health-prometheus-snmp-exporter-7d96ff9ccd-rjzp4   1/1     Running     0          53m
pod/cray-sysmgmt-health-thanos-compactor-0                          1/1     Running     0          53m
pod/cray-sysmgmt-health-thanos-query-0                              1/1     Running     0          53m
pod/cray-sysmgmt-health-thanos-store-0                              1/1     Running     0          53m
pod/prometheus-cray-sysmgmt-health-kube-p-prom-0                    3/3     Running     0          53m
pod/prometheus-cray-sysmgmt-health-kube-p-prom-1                    3/3     Running     0          53m
pod/prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-0            3/3     Running     0          53m
pod/prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-1            3/3     Running     0          53m
pod/thanos-ruler-kube-prometheus-stack-thanos-ruler-0               2/2     Running     0          53m

NAME                                                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
service/alertmanager-operated                          ClusterIP   None            <none>        9093/TCP,9094/TCP,9094/UDP   53m
service/cray-sysmgmt-health-canu-test                  ClusterIP   10.28.194.129   <none>        9144/TCP                     53m
service/cray-sysmgmt-health-ceph-exporter              ClusterIP   None            <none>        9283/TCP                     53m
service/cray-sysmgmt-health-ceph-node-exporter         ClusterIP   None            <none>        9100/TCP                     53m
service/cray-sysmgmt-health-grafana                    ClusterIP   10.18.109.2     <none>        80/TCP                       53m
service/cray-sysmgmt-health-grok-exporter              ClusterIP   10.30.48.177    <none>        9144/TCP                     53m
service/cray-sysmgmt-health-kube-p-alertmanager        ClusterIP   10.26.251.223   <none>        9093/TCP                     53m
service/cray-sysmgmt-health-kube-p-operator            ClusterIP   10.19.61.125    <none>        443/TCP                      53m
service/cray-sysmgmt-health-kube-p-prometheus          ClusterIP   10.23.35.156    <none>        9090/TCP                     53m
service/cray-sysmgmt-health-kube-p-thanos-discovery    ClusterIP   10.16.86.177    <none>        10901/TCP,10902/TCP          53m
service/cray-sysmgmt-health-kube-state-metrics         ClusterIP   10.19.79.150    <none>        8080/TCP                     53m
service/cray-sysmgmt-health-prometheus-node-exporter   ClusterIP   10.29.94.89     <none>        9100/TCP                     53m
service/cray-sysmgmt-health-prometheus-snmp-exporter   ClusterIP   10.31.104.13    <none>        9116/TCP                     53m
service/cray-sysmgmt-health-thanos-compactor           ClusterIP   10.23.200.247   <none>        10902/TCP                    53m
service/cray-sysmgmt-health-thanos-query               ClusterIP   10.24.170.99    <none>        9090/TCP,10901/TCP           53m
service/cray-sysmgmt-health-thanos-store               ClusterIP   None            <none>        10901/TCP,10902/TCP          53m
service/kube-prometheus-stack-thanos-ruler             ClusterIP   10.28.119.48    <none>        10902/TCP,10901/TCP          53m
service/prometheus-operated                            ClusterIP   None            <none>        9090/TCP,10901/TCP           53m
service/thanos-ruler-operated                          ClusterIP   None            <none>        10902/TCP,10901/TCP          53m

NAME                                                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/cray-sysmgmt-health-node-exporter-smartmon     6         6         6       6            6           <none>          53m
daemonset.apps/cray-sysmgmt-health-prometheus-node-exporter   6         6         6       6            6           <none>          53m

NAME                                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cray-sysmgmt-health-canu-test                  1/1     1            1           53m
deployment.apps/cray-sysmgmt-health-grafana                    1/1     1            1           53m
deployment.apps/cray-sysmgmt-health-grafterm                   1/1     1            1           53m
deployment.apps/cray-sysmgmt-health-grok-exporter              3/3     3            3           53m
deployment.apps/cray-sysmgmt-health-kube-p-operator            1/1     1            1           53m
deployment.apps/cray-sysmgmt-health-kube-state-metrics         1/1     1            1           53m
deployment.apps/cray-sysmgmt-health-prometheus-snmp-exporter   1/1     1            1           53m

NAME                                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/cray-sysmgmt-health-canu-test-7b5fc744dd                  1         1         1       53m
replicaset.apps/cray-sysmgmt-health-grafana-768766bb95                    1         1         1       53m
replicaset.apps/cray-sysmgmt-health-grafterm-555dcffcd4                   1         1         1       53m
replicaset.apps/cray-sysmgmt-health-grok-exporter-6b64849ff5              3         3         3       53m
replicaset.apps/cray-sysmgmt-health-kube-p-operator-ffcbf9569             1         1         1       53m
replicaset.apps/cray-sysmgmt-health-kube-state-metrics-9ccffd45f          1         1         1       53m
replicaset.apps/cray-sysmgmt-health-prometheus-snmp-exporter-7d96ff9ccd   1         1         1       53m

NAME                                                                    READY   AGE
statefulset.apps/alertmanager-cray-sysmgmt-health-kube-p-alertmanager   1/1     53m
statefulset.apps/cray-sysmgmt-health-thanos-compactor                   1/1     53m
statefulset.apps/cray-sysmgmt-health-thanos-query                       1/1     53m
statefulset.apps/cray-sysmgmt-health-thanos-store                       1/1     53m
statefulset.apps/prometheus-cray-sysmgmt-health-kube-p-prom             2/2     53m
statefulset.apps/prometheus-cray-sysmgmt-health-kube-p-prom-shard-1     2/2     53m
statefulset.apps/thanos-ruler-kube-prometheus-stack-thanos-ruler        1/1     53m

NAME                                                        COMPLETIONS   DURATION   AGE
job.batch/cray-sysmgmt-health-patch-nodeexporter-alerts-1   1/1           61s        53m
job.batch/cray-sysmgmt-health-patch-service-monitors-1      1/1           3m5s       53m
job.batch/cray-sysmgmt-health-patch-thanos-secret           1/1           6s         53m
```