### PR TITLE
Revert "Revert "CASMCMS-8651/CASMCLOUD-1220: Remove ARS from Cray CLI; remove references to ARS from BSS API spec""

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -38,10 +38,13 @@ spec:
     source: csm-algol60
     version: 3.1.2
     namespace: services
+    values:
+        global:
+            appVersion: 1.25.1
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.25.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.25.1/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 4.0.2

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.81.2-1.x86_64
+    - craycli-0.82.0-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.4-1.noarch
     - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
     - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.81.2-1.x86_64
+    - craycli-0.82.0-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.2-1.noarch
     - csm-ssh-keys-roles-1.5.2-1.noarch


### PR DESCRIPTION
This reverts commit 965b1441761cc4eb9a76a1c1431ecada5feb188a.

Restore the contents of this PR:
https://github.com/Cray-HPE/csm/pull/2346