### PR TITLE
CASMHMS-5995: Utilize HSM PowerMaps in PCS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -102,12 +102,12 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.2
+    version: 2.0.3
     namespace: services
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.9.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.10.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
## Summary and Scope

This updates the helm chart version for:

CASMHMS-5995 - Changes PCS to utilize PowerMaps from HSM when available to honor power hierarchy failures when PDU outlets are involved.

CASMHMS-5998 - Fixes a memory leak in the transition and power-cap domain functions.

CASMHMS-5996 - This fixes a naming inconsistency between snapshots and parsing HSM data inside PCS.

## Issues and Related PRs

* Resolves [CASMHMS-5995](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5995)
* Resolves [CASMHMS-5998](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5998)
* Resolves [CASMHMS-5996](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5996)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/34

## Risks and Mitigations

low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

