### PR TITLE
CASMHMS-5995: Utilize HSM PowerMaps in PCS CSM 1.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -106,12 +106,12 @@ spec:
     namespace: services
     values:
       global:
-        appVersion: 1.4.1
-        testVersion: 1.4.1
+        appVersion: 1.4.2
+        testVersion: 1.4.2
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.4.1/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.4.2/api/swagger.yaml
 
   # CMS
   # These are (mostly) alphabetized; please keep them so (when possible).


### PR DESCRIPTION
## Summary and Scope

This updates the helm chart version for:

CASMHMS-5995 - Changes PCS to utilize PowerMaps from HSM when available to honor power hierarchy failures when PDU outlets are involved.

CASMHMS-5998 - Fixes a memory leak in the transition and power-cap domain functions.

## Issues and Related PRs

* Resolves [CASMHMS-5995](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5995)
* Resolves [CASMHMS-5998](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5998)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/34

## Risks and Mitigations

low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

