### PR TITLE
CASMPET-6638: Add k8s 1.22.13 images, remove duplicate key

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -77,10 +77,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v16.2.9
       - v17.2.6
 
-    # XXX See also k8s.gcr.io/coredns:1.7.0 below
-    docker.io/coredns/coredns:
-      - 1.6.2
-
     docker.io/portainer/kubectl-shell:
       - latest-v1.21.1-amd64
 
@@ -122,27 +118,34 @@ artifactory.algol60.net/csm-docker/stable:
       - v3.9.3
 
     # CoreDNS required by platform
-    # XXX See also docker.io/coredns/coredns:1.6.2 above
+    # XXX Note this is different from any docker.io/coredns/coredns images
     k8s.gcr.io/coredns:
       - v1.8.0
 
+    # Note this is the new layout for k8s 1.22 for coredns upstream the above
+    # will go away for k8s 1.23+
+    k8s.gcr.io/coredns/coredns:
+      - v1.8.0
+      - v1.8.4
+
     # Kube images required by platform
     k8s.gcr.io/kube-apiserver:
-      - v1.20.13
       - v1.21.12
+      - v1.22.13
     k8s.gcr.io/kube-controller-manager:
-      - v1.20.13
       - v1.21.12
+      - v1.22.13
     k8s.gcr.io/kube-proxy:
-      - v1.20.13
       - v1.21.12
+      - v1.22.13
     k8s.gcr.io/kube-scheduler:
-      - v1.20.13
       - v1.21.12
-    quay.io/galexrt/node-exporter-smartmon:
-      - v0.1.1
+      - v1.22.13
     k8s.gcr.io/pause:
       - 3.4.1
+      - 3.5
+    quay.io/galexrt/node-exporter-smartmon:
+      - v0.1.1
 
     # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
     # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L43


### PR DESCRIPTION
## Summary and Scope

Adds k8s 1.22.13 images for precaching support. While here remove a duplicate key for docker.io/coredns/coredns:1.6.2 that appears to be overridden later and not in use. A similar action was done for 1.4 but never brought into main.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6638
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

