### PR TITLE
CASMINST-6471 Download and stash docs-csm in gen-push-swagger script

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -87,7 +87,9 @@ pipeline {
                 stage("Charts and Images") {
                     steps {
                         withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                            // sleep for 1 minute to avoid 'context deadline exceeded' cuased by API documentation
                             sh """
+                                sleep 60
                                 . build/.env/bin/activate && make images -j8
                             """
                         }
@@ -115,9 +117,6 @@ pipeline {
                         GIT_COMMITTER_NAME = "Jenkins"
                         GIT_COMMITTER_EMAIL = "jenkins@algol60.net"
                         EMAIL = "jenkins@algol60.net"
-                    }
-                    agent {
-                        label "metal-gcp-builder"
                     }
                     steps {
                         withCredentials(

--- a/release.sh
+++ b/release.sh
@@ -174,14 +174,10 @@ rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp3/index.yaml" "${BUILDDIR}/rpm/cray/cs
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp4" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/noos/index.yaml" "${BUILDDIR}/rpm/cray/csm/noos" -s
 
-# Special processing for docs-csm, as we don't know exact version before build starts, so can't include it into rpm indexes.
-# Can't include docs-csm-latest either, because it is not unique. Get version from right docs-csm-latest, then download actual rpm file.
-DOCS_CSM_MAJOR_MINOR="${DOCS_CSM_MAJOR_MINOR:-${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}}"
-DOCS_CSM_VERSION=$(curl -sSL -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/api/storage/csm-rpms/hpe/stable/sle-15sp4/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-latest.noarch.rpm?properties" | jq -r '.properties["rpm.metadata.version"][0]')
-mkdir -p "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch"
-curl -sSL -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" -o "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" \
-    "https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm"
-rpm -qpi "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" | grep -q -E "Signature\s*:\s*\(none\)" && (echo "ERROR: RPM package docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm is not signed"; exit 1)
+# Special processing for docs-csm. We don't know exact version before build starts, so can't include it into rpm indexes.
+# Instead, docs-csm-<tag>.noarch.rpm file is supposed to be downloaded by hack/gen-push-swagger-markdown.sh script into
+# dist/docs-csm/ folder, prior to running release.sh.
+mv "${ROOTDIR}/dist/docs-csm/docs-csm-*.noarch.rpm" "${BUILDDIR}/rpm/cray/csm/sle-15sp4/noarch/"
 
 # Fix-up cray directories by removing misc subdirectories
 {


### PR DESCRIPTION
## Summary and Scope

Previously, we've been observing errors in a module, which identifies version of `docs-csm` package and downloads it. This module was relying on Artifactory to disclose version as property of `docs-csm-latest.rpm` file. However, this call often returned `null` failing the build.

The change is to download `docs-csm-*.rpm` in the same script, which actually checked docs-csm repo tagging, generates API docs and tags the docs-csm repo if needed. As additional step, it would download docs-csm RPM file into predefined directory. Main csm build is expected to pick this file up and include in the build.


## Issues and Related PRs

* Resolves [CASMINST-6471](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6471)

## Testing
### Tested on:

  * Jenkins

### Test description:

Tested both scenarios (docs-csm is tagged and downloaded, docs-csm is untagged and not downloaded).