### PR TITLE
CASMPET-6643 Update platform-utils to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update platform-utils to 1.6.0 (CASMPET-6643)
 - Update cray-istio to 2.9.1 (CASMPET-5797)
 - Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-site-init to 1.31.3

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -26,5 +26,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-auth-utils-1.0.0-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - platform-utils-1.5.2-1.noarch
-
+    - platform-utils-1.6.0-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.3.0-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
-    - platform-utils-1.5.2-1.noarch
+    - platform-utils-1.6.0-1.noarch
     - spire-agent-1.5.5-1.7.x86_64
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/:
   rpms:


### PR DESCRIPTION
This updates the fix-spire-on-storage.sh script to use the new spire server, cray-spire-server. This is used as part of the migration from 0.12.2 to 1.5.5