### PR TITLE
Change craycli to use shasta keycloak client instead of deprecated cray client (CASMPET-6640)

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.31.2-1.x86_64
-    - craycli-0.81.2-1.x86_64
+    - craycli-0.82.1-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.4-1.noarch
     - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
     - cray-site-init-1.31.2-1.x86_64
-    - craycli-0.81.2-1.x86_64
+    - craycli-0.82.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.2-1.noarch
     - csm-ssh-keys-roles-1.5.2-1.noarch


### PR DESCRIPTION
### Summary and Scope

Switch craycli from deprecated keycloak client

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6640

### Testing

Tested on ashton during MT OPA demo

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
