### PR TITLE
CASMNET-2139 - Unbound should not forward .hsn queries to the site DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-dns-unbound to 0.7.22 (CASMNET-2139)
 - Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)
 - Remove cilium container images to remove CVEs (CASMPET-6330)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -58,11 +58,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.21 # update platform.yaml cray-precache-images with this
+    version: 0.7.22 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.21
+        appVersion: 0.7.22
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.23
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.21
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.22
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.8
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.7.6
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

If a client issues a query for a record in the hsn local-zone that Unbound can't answer then the query will be forwarded to the site DNS server which is undesirable.

## Issues and Related PRs

* Resolves [CASMNET-2139](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2139)

## Testing

### Tested on:

  * `mug`

### Test description:

Tested change on mug, verified query for a record that doesn't exist isn't being forwarded to site DNS.

Old behaviour
```
[1686672774] unbound[11:0] info: resolving x3000c0s30b2n0h1.hsn. A IN
[1686672774] unbound[11:0] info: processQueryTargets: x3000c0s30b2n0h1.hsn. A IN
[1686672774] unbound[11:0] info: sending query: x3000c0s30b2n0h1.hsn. A IN
[1686672774] unbound[11:0] debug: sending to target: <.> 16.110.135.51#53
[1686672774] unbound[11:0] debug: cache memory msg=114461 rrset=72829 infra=7451 val=0
[1686672774] unbound[11:0] debug: iterator[module 0] operate: extstate:module_wait_reply event:module_event_reply
[1686672774] unbound[11:0] info: iterator operate: query x3000c0s30b2n0h1.hsn. A IN
[1686672774] unbound[11:0] info: response for x3000c0s30b2n0h1.hsn. A IN
[1686672774] unbound[11:0] info: reply from <.> 16.110.135.51#53
[1686672774] unbound[11:0] info: query response was NXDOMAIN ANSWER
[1686672774] unbound[11:0] info: finishing processing for x3000c0s30b2n0h1.hsn. A IN
```
New behaviour, the query is not forwarded if no answer can be found in static data.
```
[1686673759] unbound[11:0] info: 10.46.0.0 x3000c0s30b2n0h1.hsn. A IN
[1686673759] unbound[11:0] info: hsn. static 10.46.0.0@36713 x3000c0s30b2n0h1.hsn. A IN
[1686673759] unbound[11:0] info: 10.46.0.0 x3000c0s30b2n0h1.hsn. A IN NXDOMAIN 0.000000 1 38
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable