### PR TITLE
CASMTRIAGE-5525: Fixes BOS v1 error from multi-tenancy changes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -131,7 +131,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.4.1
+    version: 2.4.2
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION


## Summary and Scope

Fixes an issue where a wrapper used to handle multi-tenancy on the v1 endpoints was changing the signature of the function.

Also updates the tapms endpoint used by BOS.

## Issues and Related PRs

* Resolves CASMTRIAGE-5525
* Resolves CASMCMS-8665

## Testing

See individual tickets

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

