### PR TITLE
Correct placement of replicaCount settings in site customizations tem…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update customizations.yaml (CASMSMF-7400)
 - Update cray-istio to 2.9.1 (CASMPET-5797)
 - Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-site-init to 1.31.3

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -632,8 +632,8 @@ spec:
         es_disk_lowwater: 90
         es_disk_minimum_indices: 3
       sma-rsyslog-aggregator:
-        replicaCount: 3
         cray-service:
+          replicaCount: 3
           service:
             loadBalancerIP: 10.92.100.72
           volumeClaimTemplate:
@@ -647,8 +647,8 @@ spec:
           service:
             loadBalancerIP: 10.94.100.72
       sma-rsyslog-aggregator-udp:
-        replicaCount: 3
         cray-service:
+          replicaCount: 3
           service:
             loadBalancerIP: 10.92.100.72
           volumeClaimTemplate:


### PR DESCRIPTION
## Summary and Scope

fix a bug in the customizations.yaml template in which the rsyslog-aggregator and rsyslog-aggregator-udp sections include a replicaCount setting, which should be an argument to the the cray-services template, but is not. As written changing this value does not change the number of pods, as intended. Moving it to a argument value of cray-services corrects the problem. The default setting of 3 pods works well for modestly sized systems, but for large customer systems with thousands of compute nodes, having a way to increase the number of pods is required. 


_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [casmsmf-7400](https://jira-pro.it.hpe.com:8443/browse/CASMSMF-7400)
* Change may also be needed in `CSM-1.4` - Not clear how badly the customer needs this fixed in the template, and can just update the site-local copy. 

## Testing
### Tested on:
Tested initially on Alvarez (Nersc TDS system), then on rocket. 

### Test description:
Set the corrected syntax in the customizations.yaml file, then ran the SMA installer, observing that the number of pods had been updated to the intended value. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NO 
- Were continuous integration tests run? If not, why? - YES
- Was upgrade tested? If not, why?  - NO, only the template changes, so would do nothing. 
- Was downgrade tested? If not, why? - NO, only the template changes, so would do nothing. 
- Were new tests (or test issues/Jiras) created for this change? - NO

## Risks and Mitigations
No known risks. 

## Pull Request Checklist

- [n/a] Version number(s) incremented, if applicable
- [n/a] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [n/a] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

