### PR TITLE
CASMCMS-8365 - add arm64 support to barebones image.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -170,13 +170,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.0.0
+    version: 2.1.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.0.0
+            tag: 2.1.0
   - name: cray-ims
     source: csm-algol60
     version: 3.9.2


### PR DESCRIPTION
## Summary and Scope

Add arm64 support to the installed barebones image recipe. There are now 2 recipes installed - one for x86_64 and one for arm64. There is still only one pre-built image installed - the x86 version.

## Issues and Related PRs
* Resolves [CASMCMS-8365](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8365)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new versions via helm deployment, then built both recipes successfully on Mug.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a fairly low risk change. It just adds one more recipe that isn't used in the install or by most users.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
