### PR TITLE
CASM-4352 Remove installation of dependencies using zypper entirely to rely upon the host for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-- Update iuf to 0.1.8; cray-nls and cray-iuf to 3.1.5 (CASM-4352)
+
+- Update iuf to 0.1.10; cray-nls and cray-iuf to 4.0.0 (CASM-4352)
 - Update cray-dns-unbound to 0.7.22 (CASMNET-2139)
 - Update platform-utils to 1.6.0 (CASMPET-6643)
 - Update cray-istio to 2.9.1 (CASMPET-5797)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update iuf to 0.1.7 (CASM-4352)
 - Update cray-dns-unbound to 0.7.22 (CASMNET-2139)
 - Update platform-utils to 1.6.0 (CASMPET-6643)
 - Update cray-istio to 2.9.1 (CASMPET-5797)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-- Update iuf to 0.1.7 (CASM-4352)
+- Update iuf to 0.1.8; cray-nls and cray-iuf to 3.1.5 (CASM-4352)
 - Update cray-dns-unbound to 0.7.22 (CASMNET-2139)
 - Update platform-utils to 1.6.0 (CASMPET-6643)
 - Update cray-istio to 2.9.1 (CASMPET-5797)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Update iuf to 0.1.10; cray-nls and cray-iuf to 4.0.0 (CASM-4352)
+- Update iuf to 0.1.10; cray-nls and cray-iuf to 4.0.0; downgrade argoexec to v3.3.6 (CASM-4352)
 - Update cray-powerdns-manager to 0.8.1 (CASMNET-2122)
 - update cray-ims to 3.9.3 (CASMCMS-8624)
 - Update craycli to 0.82.2 (CASMCMS-8624)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,7 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.2.0
 
     iuf:
-    - v0.1.6
+    - v0.1.7
 
     # Rebuilt third-party images below
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -160,7 +160,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Argo images
     quay.io/argoproj/argoexec:
-      - v3.4.5
+      - v3.3.6
 
     # Cilium images required by platform
     quay.io/cilium/cilium:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,7 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.2.0
 
     iuf:
-    - v0.1.8
+    - v0.1.10
 
     # Rebuilt third-party images below
 

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,7 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.2.0
 
     iuf:
-    - v0.1.7
+    - v0.1.8
 
     # Rebuilt third-party images below
 

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -57,10 +57,17 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 
 # Upload assets to existing repositories
 skopeo-sync "${ROOTDIR}/docker"
+
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
 sat_version="3.23.0"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
+
+# Tag iuf-container image as csm-latest
+iuf_image="artifactory.algol60.net/csm-docker/stable/iuf"
+# this comes from `iuf-containers/.github/workflows/iuf-container.yaml`
+iuf_version="v0.1.10"
+skopeo-copy "${iuf_image}:${iuf_version}" "${iuf_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.5
+    version: 4.0.0
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.1.5
+    version: 4.0.0
     namespace: argo
     swagger:
     - name: nls

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.3
+    version: 3.1.5
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.1.3
+    version: 3.1.5
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
# PLEASE MERGE CORRESPONDING DOCS-CSM PR AFTER MERGING THIS PR
Corresponding docs-csm PR: https://github.com/Cray-HPE/docs-csm/pull/3891
Do not merge docs-csm PR before merging this PR.

## Summary and Scope

Remove installation of dependencies using zypper entirely to rely upon the host for dependencies.

We are removing these because the dependencies in the host are more up-to-date, as opposed to the embedding them within this container which doesn't get updated often.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4352](https://jira-pro.it.hpe.com:8443/browse/CASM-4352)
* Merged code PR: https://github.com/Cray-HPE/iuf-containers/pull/18

## Testing

### Tested on:

Drax

### Test description:

Removed internally embedded dependencies from the image, volume mounted the host /usr/bin directory, appended the $PATH inside the container, and checked if the dependencies are accessible.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

