### PR TITLE
CASMNET-2122 - cray-externaldns-manager crashes when used with external-dns 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-powerdns-manager to 0.8.1 (CASMNET-2122)
 - Update cray-dns-unbound to 0.7.22 (CASMNET-2139)
 - Update platform-utils to 1.6.0 (CASMPET-6643)
 - Update cray-istio to 2.9.1 (CASMPET-5797)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -69,5 +69,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.8.0 # update platform.yaml cray-precache-images with this
+    version: 0.8.1 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -70,7 +70,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.22
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.0
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.1
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

External DNS changed the format of their TXT records in version 0.12. The TXT record now contains a prefix indicating the record type e.g. a-foo.example.com which means it no longer directly matches the corresponding A record.

A second bug was also identified where the `allZones` slice was being sorted while being iterated over which messed up zone processing and caused some zones to get processed twice and others not at all.

## Issues and Related PRs

* Resolves [CASMNET-2122](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2122)

## Testing

### Tested on:

  * Local development environment
  * Ashton
     * Tested using the following
        * Helm chart: cray-externaldns 1.5.0-20230511191813+6f5436c
        * Image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns  0.13.4-debian-11-r14

### Test description:

* Verified externaldns-manager no longer crashes when a new format external-dns record is encountered.
   ```
    {"level":"debug","ts":1687252356.671869,"msg":"Found new format registry record","rrSet":{"name":"a-capsules.chn.surtur.hpc.amslabs.hpecorp.net.","type":"TXT","ttl":300,"records":[{"content":"\"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/services/cray-oauth2-proxies-customer-high-speed-ingress\"","disabled":false}]}}
    {"level":"debug","ts":1687252356.6718771,"msg":"Found corresponding A record","name":"capsules.chn.surtur.hpc.amslabs.hpecorp.net.","ip":"10.102.67.225"}
    {"level":"debug","ts":1687252356.6719182,"msg":"Generating PTR record","ipaddr":"225.67.102.10.in-addr.arpa"}
    {"level":"debug","ts":1687252356.6719282,"msg":"Record already exits, nothing to do","rrSetReverse":{"name":"225.67.102.10.in-addr.arpa.","type":"PTR","ttl":3600,"changetype":"REPLACE","records":[{"content":"capsules.chn.surtur.hpc.amslabs.hpecorp.net.","disabled":false}]}}
   ```

* Verified each zone is processed and is only processed once
   ```
   {"level":"debug","ts":1687252491.455631,"msg":"Processing zone","zone":"hmnlb.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.455915,"msg":"Processing zone","zone":"nmnlb.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.4560719,"msg":"Processing zone","zone":"hsn.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.45608,"msg":"Processing zone","zone":"cmn.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.456852,"msg":"Processing zone","zone":"nmn.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.456855,"msg":"Processing zone","zone":"mtl.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.456897,"msg":"Processing zone","zone":"chn.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.457124,"msg":"Processing zone","zone":"hmn.surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.4571269,"msg":"Processing zone","zone":"surtur.hpc.amslabs.hpecorp.net."}
   {"level":"debug","ts":1687252491.457129,"msg":"Processing zone","zone":"100.92.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457132,"msg":"Processing zone","zone":"67.102.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457251,"msg":"Processing zone","zone":"100.94.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.4572532,"msg":"Processing zone","zone":"107.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457255,"msg":"Processing zone","zone":"106.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457257,"msg":"Processing zone","zone":"252.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457259,"msg":"Processing zone","zone":"254.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457261,"msg":"Processing zone","zone":"253.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457263,"msg":"Processing zone","zone":"1.10.in-addr.arpa."}
   {"level":"debug","ts":1687252491.457265,"msg":"Processing zone","zone":"hmnlb."}
   {"level":"debug","ts":1687252491.457267,"msg":"Processing zone","zone":"nmnlb."}
   {"level":"debug","ts":1687252491.457269,"msg":"Processing zone","zone":"cmn."}
   {"level":"debug","ts":1687252491.457271,"msg":"Processing zone","zone":"nmn."}
   {"level":"debug","ts":1687252491.457273,"msg":"Processing zone","zone":"mtl."}
   {"level":"debug","ts":1687252491.457275,"msg":"Processing zone","zone":"hmn."}
   {"level":"debug","ts":1687252491.4572759,"msg":"Processing zone","zone":"chn."}
   {"level":"debug","ts":1687252491.457278,"msg":"Processing zone","zone":"hsn."}
   ```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

