### PR TITLE
CASMPET-6651, CASMMON-321, 323 & 327 - main

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.1
+    version: 0.28.4
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

cray-sysmgmt-health grok-exporter node affinity is wrong for mercury. It is using ncn-m001, ncn-m002 and ncn-m003 by default. But mercury has no NCNs and it will fail.
_This change is a backward-compatible bugfix_

## Issues and Related PRs

* Resolves [CASMPET-6651](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6651)
* https://jira-pro.it.hpe.com:8443/browse/CASMMON-323
https://jira-pro.it.hpe.com:8443/browse/CASMMON-321
https://jira-pro.it.hpe.com:8443/browse/CASMMON-327

## Testing
### Tested on:

  * `<frigg>`
  * `<Mug>`
  * `<Starlord>`
  * Local development environment
  * Virtual Shasta - Ashton
  * Mercury

### Test description:

_The changes tested and success verified._

```
sysmgmt-health   cray-sysmgmt-health-grok-exporter-6dfd6c455b-9r7xn                1/1     Running                      0              3m20s   10.32.128.5     k8s-master-sigma7-3    <none>           <none>
sysmgmt-health   cray-sysmgmt-health-grok-exporter-6dfd6c455b-grbq6                1/1     Running                      0              3m21s   10.32.64.4      k8s-master-sigma7-2    <none>           <none>
sysmgmt-health   cray-sysmgmt-health-grok-exporter-6dfd6c455b-z572c                1/1     Running                      0              3m20s   10.32.0.8       k8s-master-sigma7-1    <none>           <none>
```
```
kubectl get pods -n sysmgmt-health -o wide |grep grok
cray-sysmgmt-health-grok-exporter-6dfd6c455b-c4s67              1/1     Running     0              2m36s   10.38.0.2     ncn-m003   <none>           <none>
cray-sysmgmt-health-grok-exporter-6dfd6c455b-vnv5q              0/1     Pending     0              2m36s   <none>        <none>     <none>           <none>
cray-sysmgmt-health-grok-exporter-6dfd6c455b-wq7h8              1/1     Running     0              2m36s   10.32.0.3     ncn-m002   <none>           <none>
```
```
kubectl describe pod -n sysmgmt-health cray-sysmgmt-health-grok-exporter-6dfd6c455b-vnv5q
Name:           cray-sysmgmt-health-grok-exporter-6dfd6c455b-vnv5q
Namespace:      sysmgmt-health
Priority:       0
Node:           <none>
Labels:         app=grok-exporter
                pod-template-hash=6dfd6c455b
Annotations:    kubernetes.io/limit-ranger:
                  LimitRanger plugin set: cpu, memory request for container grok-exporter; cpu, memory limit for container grok-exporter
                kubernetes.io/psp: restricted-transition
Status:         Pending
IP:
IPs:            <none>
Controlled By:  ReplicaSet/cray-sysmgmt-health-grok-exporter-6dfd6c455b
Containers:
  grok-exporter:
    Image:      artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest
    Port:       9144/TCP
    Host Port:  0/TCP
    Limits:
      cpu:     2
      memory:  2Gi
    Requests:
      cpu:        10m
      memory:     64Mi
    Environment:  <none>
    Mounts:
      /etc/grok_exporter from grok-config-volume (rw)
      /logs/goss_tests from logs (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-6zsv6 (ro)
Conditions:
  Type           Status
  PodScheduled   False
Volumes:
  grok-config-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      cray-sysmgmt-health-grok-exporter
    Optional:  false
  logs:
    Type:          HostPath (bare host directory volume)
    Path:          /opt/cray/tests/install/logs/grok_exporter
    HostPathType:  DirectoryOrCreate
  kube-api-access-6zsv6:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node-role.kubernetes.io/master:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason            Age    From                  Message
  ----     ------            ----   ----                  -------
  Warning  FailedScheduling  5m10s  default-scheduler     0/5 nodes are available: 2 node(s) didn't match pod anti-affinity rules, 3 node(s) didn't match Pod's node affinity/selector.
  Warning  FailedScheduling  4m11s  default-scheduler     0/5 nodes are available: 2 node(s) didn't match pod anti-affinity rules, 3 node(s) didn't match Pod's node affinity/selector.
  Warning  PolicyViolation   5m11s  admission-controller  Rule(s) 'host-path' of policy 'disallow-host-path' failed to apply on the resource
```

```
ncn-m001:/mnt/developer/sum/shreni/cray-sysmgmt-health/templates/canu-test # kubectl get pods -n sysmgmt-health                                                  NAME                                                            READY   STATUS      RESTARTS   AGE
alertmanager-cray-sysmgmt-health-kube-p-alertmanager-0          2/2     Running     1          23m
cray-sysmgmt-health-canu-test-7c7468b479-7rzls                  2/2     Running     0          8m54s
cray-sysmgmt-health-grafana-768766bb95-nz8sc                    3/3     Running     0          23m
cray-sysmgmt-health-grafterm-555dcffcd4-rhpbw                   1/1     Running     0          23m
cray-sysmgmt-health-grok-exporter-7569b88b85-m7wg5              1/1     Running     0          23m
cray-sysmgmt-health-grok-exporter-7569b88b85-mxgrm              1/1     Running     0          23m
cray-sysmgmt-health-grok-exporter-7569b88b85-qxglz              1/1     Running     0          23m
cray-sysmgmt-health-kube-p-admission-patch-pdlbs                0/1     Completed   0          2m12s
cray-sysmgmt-health-kube-p-operator-ffcbf9569-qcn6l             1/1     Running     0          23m
cray-sysmgmt-health-kube-state-metrics-9ccffd45f-rzd69          1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-hook-hbf7q                    0/1     Completed   0          2m8s
cray-sysmgmt-health-node-exporter-smartmon-6lt82                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-7lnpm                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-9m64d                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-bpmhx                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-fpxrw                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-hjv5x                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-jqvf5                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-kkh7h                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-l2l2q                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-lwhfb                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-nfw9d                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-rct94                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-v7kzf                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-vhqxf                1/1     Running     0          23m
cray-sysmgmt-health-node-exporter-smartmon-whtwr                1/1     Running     0          23m
cray-sysmgmt-health-patch-nodeexporter-alerts-1-ffrmm           0/1     Completed   0          23m
cray-sysmgmt-health-patch-nodeexporter-alerts-10-4p4t5          0/1     Completed   0          10d
cray-sysmgmt-health-patch-nodeexporter-alerts-2-nmx8g           1/1     Running     0          105s
cray-sysmgmt-health-patch-nodeexporter-alerts-3-zc4wz           0/1     Completed   0          14d
cray-sysmgmt-health-patch-nodeexporter-alerts-5-k9nhn           0/1     Completed   0          14d
cray-sysmgmt-health-patch-nodeexporter-alerts-6-qh7dh           0/1     Completed   0          11d
cray-sysmgmt-health-patch-nodeexporter-alerts-7-sdsql           0/1     Completed   0          11d
cray-sysmgmt-health-patch-nodeexporter-alerts-8-b6d9w           0/1     Completed   0          11d
cray-sysmgmt-health-patch-service-monitors-2-bc5kr              1/1     Running     0          2m29s
cray-sysmgmt-health-patch-thanos-secret-ncmk5                   0/1     Completed   0          2m40s
cray-sysmgmt-health-prometheus-node-exporter-56tdv              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-789tn              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-8z8bf              1/1     Running     0          21m
cray-sysmgmt-health-prometheus-node-exporter-dbmvj              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-dh6jj              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-fm2t5              1/1     Running     0          23m
cray-sysmgmt-health-prometheus-node-exporter-h6kzp              1/1     Running     0          21m
cray-sysmgmt-health-prometheus-node-exporter-mbhvk              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-mcnn8              1/1     Running     0          21m
cray-sysmgmt-health-prometheus-node-exporter-pf2c5              1/1     Running     0          21m
cray-sysmgmt-health-prometheus-node-exporter-q648s              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-tdg8m              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-tq5qs              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-node-exporter-tvnf2              1/1     Running     0          21m
cray-sysmgmt-health-prometheus-node-exporter-z8rps              1/1     Running     0          22m
cray-sysmgmt-health-prometheus-snmp-exporter-7d96ff9ccd-2klhg   1/1     Running     0          23m
cray-sysmgmt-health-thanos-compactor-0                          1/1     Running     0          58s
cray-sysmgmt-health-thanos-query-0                              1/1     Running     0          8s
cray-sysmgmt-health-thanos-store-0                              1/1     Running     0          9s
prometheus-cray-sysmgmt-health-kube-p-prom-0                    3/3     Running     0          23m
prometheus-cray-sysmgmt-health-kube-p-prom-1                    3/3     Running     0          23m
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-0            3/3     Running     0          23m
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-1            3/3     Running     0          23m
thanos-ruler-kube-prometheus-stack-thanos-ruler-0               2/2     Running     0          23m
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
