### PR TITLE
CASMTRIAGE-5527: Update keycloak to address upstream bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update cray-keycloak to 5.0.3 (CASMTRIAGE-5527)
 - Update cray-powerdns-manager to 0.8.1 (CASMNET-2122)
 - update cray-ims to 3.9.3 (CASMCMS-8624)
 - Update craycli to 0.82.2 (CASMCMS-8624)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -188,7 +188,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.0.2
+    version: 5.0.3
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates Keycloak image to latest to fix bug in upstream affecting UAS authentication with Keycloak. A Null Pointer exception in the Keycloak upstream code. Fixes a bug where a user can not get user info due to missing scope on all Keycloak clients.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5527](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5527)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Dorian

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

No known risks or bugs with upgraded version

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

