### PR TITLE
CASM-4351 Fixes wrong entries are added for helm chart in cray-produc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Update cray-keycloak to 5.0.3 (CASMTRIAGE-5527)
 - Update iuf to 0.1.10; cray-nls and cray-iuf to 4.0.0; downgrade argoexec to v3.3.6 (CASM-4352)
 - Update cray-powerdns-manager to 0.8.1 (CASMNET-2122)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -190,4 +190,4 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.3.2
       - 1.8.8
     cray-nexus-setup:
-      - 0.10.0
+      - 0.10.1


### PR DESCRIPTION
…t-catalog

## Summary and Scope

As part of [CASM-4351](https://jira-pro.it.hpe.com:8443/browse/CASM-4351), modified nexus-setup which created latest version of 0.10.1. Corresponding docs-csm PR  - https://github.com/Cray-HPE/docs-csm/pull/3902

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4351](https://jira-pro.it.hpe.com:8443/browse/CASM-4351)
* Change will also be needed in `stable/1.5`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge before https://github.com/Cray-HPE/docs-csm/pull/3902

### Tested on:

  * `MUG`
  * Local development environment
  * Virtual Shasta


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

