### PR TITLE
CASMCMS-8532: Update BOS for actual state cleanup operator fix (1.4)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.18
+    version: 2.0.20
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Updates BOS to pull in a fix for the actual state cleanup operator, which was trying a PATCH operation with an invalid field.

## Issues and Related PRs

* Resolves CASMCMS-8532

## Testing

### Tested on:

  * Mug

### Test description:

Validated the operator was correctly patching state.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

