### PR TITLE
increment ims version to 3.9.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,7 +179,7 @@ spec:
             tag: 2.1.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.9.3
+    version: 3.9.5
     namespace: services
     swagger:
     - name: ims


### PR DESCRIPTION
## Summary and Scope

Added virtiofs daemon configuration annotation to IMS configmaps. This resolves a bug where images built without DKMS  and subsequently customized with DKMS enabled would result in filesystem extended attributes failing to write.
## Issues and Related PRs

* Resolves [CASMCMS-8362](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8362)
## Testing

### Tested on:
This fix was tested on the Mug system.

### Test description:
Added the annotations to IMS configmaps and ran jobs successfully.

## Risks and Mitigations
The bug was the risk. 
No risk that I can foresee for this inclusion.
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

