### PR TITLE
Add CMS SLES15SP5 noarch RPMs for Arm computes; add relevant Artifactory repos to relevant scripts

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -102,6 +102,7 @@ pipeline {
                                     rpm/cray/csm/sle-15sp2/index.yaml \
                                     rpm/cray/csm/sle-15sp3/index.yaml \
                                     rpm/cray/csm/sle-15sp4/index.yaml \
+                                    rpm/cray/csm/sle-15sp5/index.yaml \
                                     rpm/cray/csm/noos/index.yaml
                             """
                         }

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -53,6 +53,7 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/int
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                               cray/cos-2.2/sle15_sp3_ncn \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                                cray/cos-2.2/sle15_sp3_cn \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/slingshot-host-software-rpm-stable-local/release/cos-2.2/sle15_sp2_ncn/           cray/cos-2.2/sle15_sp2_ncn \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15_aarch64/standard/                                     suse/Backports-SLE/15/aarch64/standard \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/                  suse/SLE-Module-Basesystem/15-SP2/x86_64/product \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Basesystem/15-SP2/x86_64/product_debug/            suse/SLE-Module-Basesystem/15-SP2/x86_64/product_debug \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/                    suse/SLE-Module-Basesystem/15-SP2/x86_64/update \
@@ -203,6 +204,54 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/int
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-SLES/15-SP4/x86_64/update_debug/                   suse/SLE-Product-SLES/15-SP4/x86_64/update_debug \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-WE/15-SP4/x86_64/product/                         suse/SLE-Product-WE/15-SP4/x86_64/product \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-WE/15-SP4/x86_64/product_debug/                   suse/SLE-Product-WE/15-SP4/x86_64/product_debug \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP4_x86_64/standard/                                  suse/Backports-SLE/15-SP4/x86_64/standard \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP4_x86_64/standard_debug/                            suse/Backports-SLE/15-SP4/x86_64/standard_debug \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Basesystem/15-SP5/x86_64/product/                  suse/SLE-Module-Basesystem/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Basesystem/15-SP5/aarch64/product/                 suse/SLE-Module-Basesystem/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP5/x86_64/update/                    suse/SLE-Module-Basesystem/15-SP5/x86_64/update \   
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP5/aarch64/update/                   suse/SLE-Module-Basesystem/15-SP5/aarch64/update \   
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Containers/15-SP5/x86_64/product/                  suse/SLE-Module-Containers/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Containers/15-SP5/aarch64/product/                 suse/SLE-Module-Containers/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Containers/15-SP5/x86_64/update/                    suse/SLE-Module-Containers/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Containers/15-SP5/aarch64/update/                   suse/SLE-Module-Containers/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Desktop-Applications/15-SP5/x86_64/product/        suse/SLE-Module-Desktop-Applications/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Desktop-Applications/15-SP5/aarch64/product/       suse/SLE-Module-Desktop-Applications/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Desktop-Applications/15-SP5/x86_64/update/          suse/SLE-Module-Desktop-Applications/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Desktop-Applications/15-SP5/aarch64/update/         suse/SLE-Module-Desktop-Applications/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Development-Tools/15-SP5/x86_64/product/           suse/SLE-Module-Development-Tools/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Development-Tools/15-SP5/aarch64/product/          suse/SLE-Module-Development-Tools/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Development-Tools/15-SP5/x86_64/update/             suse/SLE-Module-Development-Tools/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Development-Tools/15-SP5/aarch64/update/            suse/SLE-Module-Development-Tools/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-HPC/15-SP5/x86_64/product/                         suse/SLE-Module-HPC/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-HPC/15-SP5/aarch64/product/                        suse/SLE-Module-HPC/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-HPC/15-SP5/x86_64/update/                           suse/SLE-Module-HPC/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-HPC/15-SP5/aarch64/update/                          suse/SLE-Module-HPC/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Legacy/15-SP5/x86_64/product/                      suse/SLE-Module-Legacy/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Legacy/15-SP5/aarch64/product/                     suse/SLE-Module-Legacy/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Legacy/15-SP5/x86_64/update/                        suse/SLE-Module-Legacy/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Legacy/15-SP5/aarch64/update/                       suse/SLE-Module-Legacy/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Public-Cloud/15-SP5/x86_64/product/                suse/SLE-Module-Public-Cloud/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Public-Cloud/15-SP5/aarch64/product/               suse/SLE-Module-Public-Cloud/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Public-Cloud/15-SP5/x86_64/update/                  suse/SLE-Module-Public-Cloud/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Public-Cloud/15-SP5/aarch64/update/                 suse/SLE-Module-Public-Cloud/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Server-Applications/15-SP5/x86_64/product/         suse/SLE-Module-Server-Applications/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Server-Applications/15-SP5/aarch64/product/        suse/SLE-Module-Server-Applications/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Server-Applications/15-SP5/x86_64/update/           suse/SLE-Module-Server-Applications/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Server-Applications/15-SP5/aarch64/update/          suse/SLE-Module-Server-Applications/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Web-Scripting/15-SP5/x86_64/product/               suse/SLE-Module-Web-Scripting/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Module-Web-Scripting/15-SP5/aarch64/product/              suse/SLE-Module-Web-Scripting/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Web-Scripting/15-SP5/x86_64/update/                 suse/SLE-Module-Web-Scripting/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Web-Scripting/15-SP5/aarch64/update/                suse/SLE-Module-Web-Scripting/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-HPC/15-SP5/x86_64/product/                        suse/SLE-Product-HPC/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-HPC/15-SP5/aarch64/product/                       suse/SLE-Product-HPC/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-HPC/15-SP5/x86_64/update/                          suse/SLE-Product-HPC/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-HPC/15-SP5/aarch64/update/                         suse/SLE-Product-HPC/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-SLES/15-SP5/x86_64/product/                       suse/SLE-Product-SLES/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-SLES/15-SP5/aarch64/product/                      suse/SLE-Product-SLES/15-SP5/aarch64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-SLES/15-SP5/x86_64/update/                         suse/SLE-Product-SLES/15-SP5/x86_64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Product-SLES/15-SP5/aarch64/update/                        suse/SLE-Product-SLES/15-SP5/aarch64/update \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-WE/15-SP5/x86_64/product/                         suse/SLE-Product-WE/15-SP5/x86_64/product \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/SLE-Product-WE/15-SP5/aarch64/product/                        suse/SLE-Product-WE/15-SP5/aarch64/product \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/7/x86_64/product/                                     suse/Storage/7/x86_64/product \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/7/x86_64/product_debug/                               suse/Storage/7/x86_64/product_debug \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/7/x86_64/update/                                       suse/Storage/7/x86_64/update \
@@ -211,8 +260,8 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/int
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/6/x86_64/product_debug/                               suse/Storage/6/x86_64/product_debug \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/6/x86_64/update/                                       suse/Storage/6/x86_64/update \
     -d https://artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/6/x86_64/update_debug/                                 suse/Storage/6/x86_64/update_debug \
-    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP4_x86_64/standard/                                  suse/Backports-SLE/15-SP4/x86_64/standard \
-    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP4_x86_64/standard_debug/                            suse/Backports-SLE/15-SP4/x86_64/standard_debug \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP5_x86_64/standard/                                  suse/Backports-SLE/15-SP5/x86_64/standard \
+    -d https://artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP5_aarch64/standard/                                 suse/Backports-SLE/15-SP5/aarch64/standard \
     -d  https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64                                        kubernetes/el7/x86_64 \
     -d  https://artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP3/x86_64/5.4-1.0.3.0/      hpe/mlnx_ofed_cx4plus/5.4 \
     -d  https://artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP3/x86_64/5.6-1.0.3.3/      hpe/mlnx_ofed_cx4plus/5.6 \
@@ -222,6 +271,7 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/int
     -d  https://artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph:quincy:upstream/openSUSE_Leap_15.4/   opensuse_leap/15.4 \
     -d  https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Python3/15-SP4/x86_64/update/  suse/SLE-Module-Python3/15-SP4/x86_64/update \
     -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/  cray/csm/sle-15sp4 \
+    -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/  cray/csm/sle-15sp5 \
     -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/  cray/csm/noos \
     -d  https://artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP4/x86_64/5.7-1.0.2.0/  hpe/mlnx_ofed_cx4plus/5.7 \
     -d  https://artifactory.algol60.net/artifactory/suse-external/PTF/15-SP4/SLE-Module-Basesystem/  suse-external/SLE-Module-Basesystem \

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -76,6 +76,7 @@ nexus-upload raw "${ROOTDIR}/rpm/cray/csm/noos"              "csm-${RELEASE_VERS
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2"         "csm-${RELEASE_VERSION}-sle-15sp2"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERSION}-sle-15sp3"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4"         "csm-${RELEASE_VERSION}-sle-15sp4"
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp5"         "csm-${RELEASE_VERSION}-sle-15sp5"
 nexus-upload raw "${ROOTDIR}/rpm/embedded"                   "csm-${RELEASE_VERSION}-embedded"
 
 clean-install-deps

--- a/nexus-repositories.yaml
+++ b/nexus-repositories.yaml
@@ -62,6 +62,21 @@ group:
   - csm-0.0.0-sle-15sp4
 
 ---
+name: csm-0.0.0-sle-15sp5
+format: raw
+storage:
+  blobStoreName: csm
+---
+name: csm-sle-15sp5
+format: raw
+storage:
+  blobStoreName: csm
+type: group
+group:
+  memberNames:
+  - csm-0.0.0-sle-15sp5
+
+---
 name: csm-0.0.0-noos
 format: raw
 storage:

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -172,6 +172,7 @@ export RPM_SYNC_NUM_CONCURRENT_DOWNLOADS=1
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp2/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp2" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp3/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp3" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp4" -s
+rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp5/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp5" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/noos/index.yaml" "${BUILDDIR}/rpm/cray/csm/noos" -s
 
 # Special processing for docs-csm, as we don't know exact version before build starts, so can't include it into rpm indexes.
@@ -199,6 +200,7 @@ find "${BUILDDIR}/rpm/cray" -empty -type d -delete
 createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp2"
 createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp3"
 createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp4"
+createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp5"
 createrepo "${BUILDDIR}/rpm/cray/csm/noos"
 
 # Extract docs RPM into release

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,38 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
     - bos-reporter-2.5.0-1.noarch
-    - canu-1.7.1-1.x86_64
     - cf-ca-cert-config-framework-2.6.0-1.noarch
     - cfs-debugger-1.4.0-1.noarch
     - cfs-state-reporter-1.9.3-1.noarch
     - cfs-trust-1.6.5-1.noarch
-    - cray-cmstools-crayctldeploy-1.11.11-1.x86_64
-    - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.82.4-1.x86_64
-    - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.38-1.noarch
-    - goss-servers-1.16.38-1.noarch
-    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
-    - hpe-csm-scripts-0.5.5-1.noarch
-    - hpe-yq-4.33.3-1.x86_64
-    - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.5.3-1.x86_64
-    - libcsm-0.0.4-1.noarch
-    - loftsman-1.2.0-2.x86_64
-    - manifestgen-1.3.9-1.x86_64
-    - metal-basecamp-1.2.5-1.x86_64
-    - metal-ipxe-2.4.3-1.noarch
-    - pit-init-1.3.0-1.noarch
-    - pit-nexus-1.2.1-1.x86_64
-    - pit-observability-1.0.6-1.x86_64
-    - platform-utils-1.6.0-1.noarch
-    - spire-agent-1.5.5-1.7.x86_64
-https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/:
-  rpms:
-    - cm-cli-1.0.5-1.x86_64
-    - cvt-1.4.22-20230519111329_785fd5fe00f2.x86_64

--- a/validate.sh
+++ b/validate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021,2023 Hewlett Packard Enterprise Development LP
 
 declare -A HELM_REPOS
 HELM_REPOS[csm]="https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-helm-stable-local/"
@@ -10,7 +10,7 @@ DEFAULT_HELM_REPO="csm"
 HELM_FILE="./helm/index.yaml"
 CONTAINER_FILE="./docker/index.yaml"
 
-RPM_INDEX_FILES="rpm/cray/csm/sle-15sp2/index.yaml rpm/cray/csm/sle-15sp3/index.yaml rpm/cray/csm/sle-15sp4/index.yaml rpm/cray/csm/noos/index.yaml"
+RPM_INDEX_FILES="rpm/cray/csm/sle-15sp2/index.yaml rpm/cray/csm/sle-15sp3/index.yaml rpm/cray/csm/sle-15sp4/index.yaml rpm/cray/csm/sle-15sp5/index.yaml rpm/cray/csm/noos/index.yaml"
 
 HELM_REPOS_INFO="dist/validate/helm-repos.yaml"
 LOFTSMAN_MANIFESTS="manifests/*"


### PR DESCRIPTION
## Summary and Scope

The main purpose of this PR is just to add the SLES15SP5 noarch RPMs into Nexus, for use on Arm64 computes in CSM 1.5. But I noticed that a bunch of scripts referenced Artifactory RPM repos for SP4 but excluded the SP5 resources on there. I updated them to include the corresponding SP5 repos. Note that some of the repos which exist on artifactory for SP4 do not exist for SP5 -- in those cases, I omitted the nonexistent SP5 versions.

