### PR TITLE
CASMSEC-400: Update platform.yaml for kyverno upgrade

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -84,7 +84,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.4.1
+    version: 1.4.3
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
Summary and Scope
Chart version is bumped due to changes submitted for Kyverno upgrade from version 1.6.2 to 1.7.5

The changes are submitted through the PR mentioned below,
https://github.com/Cray-HPE/cray-kyverno/pull/17

Testing: Tested on MUG:
[TestLogs14.txt](https://github.com/Cray-HPE/csm/files/11849464/TestLogs14.txt)

