### PR TITLE
CASMCMS-8290: Update platform.yaml for gitea vcs policy addition

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.4.2
+    version: 1.4.3
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bumping up the kyverno-policy chart version as we have submitted 2 new policies for gitea through PR https://github.com/Cray-HPE/cray-kyverno-policies/pull/11

## Testing

ncn-m001:/tmp/pradeep # kubectl get pol -A | grep -i gitea
ncn-m001:/tmp/pradeep # cd ../kyverno/
ncn-m001:/tmp/kyverno # ls -ltr
total 112
-rw-r--r-- 1 root root 51772 Jun 23 14:22 cray-kyverno-1.5.3.tgz
-rw-r--r-- 1 root root 51772 Jun 23 14:23 cray-kyverno-1.4.3.tgz
-rw-r--r-- 1 root root  6283 Jun 23 14:46 kyverno-policy-1.4.3.tgz
ncn-m001:/tmp/kyverno # helm upgrade -n kyverno kyverno-policy /tmp/kyverno/kyverno-policy-1.4.3.tgz^C
ncn-m001:/tmp/kyverno # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         192             2023-06-23 14:38:57.477461568 +0000 UTC deployed        cray-kyverno-1.4.0                      v1.6.2
cray-kyverno-policies-upstream  kyverno         3               2023-03-02 16:37:53.003221264 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-03-02 16:37:48.274514882 +0000 UTC deployed        kyverno-policy-1.2.0                    v1.6.0
ncn-m001:/tmp/kyverno #  helm upgrade -n kyverno kyverno-policy /tmp/kyverno/kyverno-policy-1.4.3.tgz
Release "kyverno-policy" has been upgraded. Happy Helming!
NAME: kyverno-policy
LAST DEPLOYED: Fri Jun 23 14:48:44 2023
NAMESPACE: kyverno
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
Thank you for installing kyverno-policy 1.4.3 😀

We have installed the collection of policies that implement the various levels of Kubernetes Pod Security Standards.

Visit https://kyverno.io/policies/ to find more sample policies.
ncn-m001:/tmp/kyverno # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         192             2023-06-23 14:38:57.477461568 +0000 UTC deployed        cray-kyverno-1.4.0                      v1.6.2
cray-kyverno-policies-upstream  kyverno         3               2023-03-02 16:37:53.003221264 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         4               2023-06-23 14:48:44.947139039 +0000 UTC deployed        kyverno-policy-1.4.3                    v1.6.0
ncn-m001:/tmp/kyverno # kubectl get pol -A | grep -i gitea
services    pod-sec-ctxt-gitea                                  true         audit    true
services    validate-pod-sec-ctxt-gitea                         true         audit    true
ncn-m001:/tmp/kyverno #

### Tested on:

MUG

