### PR TITLE
MTL-2171 No-op Builds

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
-    - acpid-2.0.31-2.0.x86_64.rpm
+    - acpid-2.0.31-2.1.x86_64.rpm
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -28,4 +28,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
+    - metal-ipxe-2.4.4-1.noarch
+    - metal-basecamp-1.2.6-1.x86_64
+    - pit-nexus-1.2.2-1.x86_64
+    - pit-observability-1.0.7-1.x86_64
     - platform-utils-1.6.0-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -45,11 +45,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64
     - manifestgen-1.3.9-1.x86_64
-    - metal-basecamp-1.2.5-1.x86_64
-    - metal-ipxe-2.4.3-1.noarch
     - pit-init-1.3.0-1.noarch
-    - pit-nexus-1.2.1-1.x86_64
-    - pit-observability-1.0.6-1.x86_64
     - platform-utils-1.6.0-1.noarch
     - spire-agent-1.5.5-1.7.x86_64
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/:


### PR DESCRIPTION
These version bumps include some build pipeline (CI) related fixes, and change our manifests to including them via the `noos` repo.
