### PR TITLE
CRAYSAT-1738: Update cray-sat container version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.23.0
+      - 3.24.0
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.23.0"
+sat_version="3.24.0"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 # Tag iuf-container image as csm-latest


### PR DESCRIPTION


## Summary and Scope

Update the cray-sat container to version 3.24.0, which is the latest version included in the latest SAT 2.6 release.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially resolves [CRAYSAT-1738](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1738)

## Testing

### Tested on:

  * Jenkins

### Test description:

The individual features included in this new version of cray-sat were tested on various development systems during development.

Jenkins should be sufficient to test the build of the CSM product with the changes in this PR.

## Risks and Mitigations

No.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable