### PR TITLE
CASMPET-6659 1.5 : Fix ncnPostgresHealthCheck for version and spire issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update platform-utils RPM to fix ncnPostgresHealthCheck
 - Add csm-node-heartbeat to 2.0-3 (MTL-2019)
 - Add acpid to 2.0.31-2.0 (MTL-2019)
 - Update cray-dhcp-kea to 0.10.24 (CASMNET-2095)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -28,4 +28,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - platform-utils-1.6.0-1.noarch
+    - platform-utils-1.6.1-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.3.0-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
-    - platform-utils-1.6.0-1.noarch
+    - platform-utils-1.6.1-1.noarch
     - spire-agent-1.5.5-1.7.x86_64
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4/:
   rpms:


### PR DESCRIPTION
## Summary and Scope

(1) Remove the patronictl version case and use the code that is currently defined under 1.6.5. The output format for 1.6.5 is the same as that for 2.1.4.  Version 1.6.4 was needed for CSM 1.2.
(2) Also modify the test so that it can distinguish between spire-postgres and cray-spire-postgres – spire-postgres will be removed in the future, but it is possible that both could exist until CSM 1.6.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6659](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6659)
* Change will also be needed in `NA`
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after `NA`

## Testing

### Tested on:

Although the change is not needed for CSM 1.4, tested on CSM 1.4 and CSM 1.5.

  * surtur CSM 1.5
  * wasp CSM 1.4.1

### Test description:

surtur: Note that spire-postgres and cray-spire-postgres are now distinguishable and the 1.6.5 based patronictl version command format also works with 2.1.4

```
ncn-m001:/tmp # ./ncnPostgresHealthChecks.sh
             +++++ NCN Postgres Health Checks +++++
=== Can Be Executed on any ncn worker or master node. ===
=== Executing on ncn-m001, Fri 23 Jun 2023 07:00:41 PM UTC ===

=== Postgresql Operator Version ===
artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.8.2

=== List of Postgresql Clusters Using Operator ===
NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
argo        cray-nls-postgres            cray-nls            11        3      1Gi                                     18d   Running
services    cfs-ara-postgres             cfs-ara             14        3      50Gi                                    18d   Running
services    cray-console-data-postgres   cray-console-data   14        3      2Gi                                     18d   Running
services    cray-dns-powerdns-postgres   cray-dns-powerdns   14        3      10Gi                                    18d   Running
services    cray-sls-postgres            cray-sls            14        3      1Gi                                     18d   Running
services    cray-smd-postgres            cray-smd            14        3      100Gi    4             8Gi              18d   Running
services    gitea-vcs-postgres           gitea-vcs           14        3      50Gi                                    18d   Running
services    keycloak-postgres            keycloak            14        3      10Gi                                    18d   Running
spire       cray-spire-postgres          cray-spire          14        3      60Gi     4             4Gi              17d   Running
spire       spire-postgres               spire               14        3      60Gi     1             4Gi              18d   Running

=== Look at patronictl list info for each cluster, determine and attach to leader of each cluster ===
=== Report status of postgres pods in cluster ===
-----------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-nls-postgres cluster with leader pod: cray-nls-postgres-0 ===

--- patronictl, version , list for argo leader pod cray-nls-postgres-0 ---
+ Cluster: cray-nls-postgres (7241155837241774154) ----+----+-----------+
| Member              | Host       | Role    | State   | TL | Lag in MB |
+---------------------+------------+---------+---------+----+-----------+
| cray-nls-postgres-0 | 10.33.0.29 | Leader  | running |  7 |           |
| cray-nls-postgres-1 | 10.40.0.40 | Replica | running |  7 |         0 |
| cray-nls-postgres-2 | 10.38.0.12 | Replica | running |  7 |         0 |
+---------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
argo             cray-nls-postgres-0                                                      3/3     Running            0          24h     10.33.0.29    ncn-w002   <none>           <none>
argo             cray-nls-postgres-1                                                      3/3     Running            0          24h     10.40.0.40    ncn-w004   <none>           <none>
argo             cray-nls-postgres-2                                                      3/3     Running            0          24h     10.38.0.12    ncn-w003   <none>           <none>
argo             cray-nls-postgresql-db-backup-28124590-c968c                             0/1     Completed          0          19h     10.33.0.28    ncn-w002   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cfs-ara-postgres cluster with leader pod: cfs-ara-postgres-2 ===

--- patronictl, version , list for services leader pod cfs-ara-postgres-2 ---
+ Cluster: cfs-ara-postgres (7241158520058687565) ----+----+-----------+
| Member             | Host       | Role    | State   | TL | Lag in MB |
+--------------------+------------+---------+---------+----+-----------+
| cfs-ara-postgres-0 | 10.38.0.72 | Replica | running |  7 |         0 |
| cfs-ara-postgres-1 | 10.32.0.88 | Replica | running |  7 |         0 |
| cfs-ara-postgres-2 | 10.40.0.21 | Leader  | running |  7 |           |
+--------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         cfs-ara-postgres-0                                                       3/3     Running            3          15d     10.38.0.72    ncn-w003   <none>           <none>
services         cfs-ara-postgres-1                                                       3/3     Running            3          15d     10.32.0.88    ncn-w001   <none>           <none>
services         cfs-ara-postgres-2                                                       3/3     Running            5          15d     10.40.0.21    ncn-w004   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-console-data-postgres cluster with leader pod: cray-console-data-postgres-0 ===

--- patronictl, version , list for services leader pod cray-console-data-postgres-0 ---
+ Cluster: cray-console-data-postgres (7241158547660943437) ----+----+-----------+
| Member                       | Host       | Role    | State   | TL | Lag in MB |
+------------------------------+------------+---------+---------+----+-----------+
| cray-console-data-postgres-0 | 10.40.0.27 | Leader  | running |  5 |           |
| cray-console-data-postgres-1 | 10.32.0.71 | Replica | running |  5 |         0 |
| cray-console-data-postgres-2 | 10.38.0.44 | Replica | running |  5 |         0 |
+------------------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         cray-console-data-postgres-0                                             3/3     Running            4          15d     10.40.0.27    ncn-w004   <none>           <none>
services         cray-console-data-postgres-1                                             3/3     Running            3          15d     10.32.0.71    ncn-w001   <none>           <none>
services         cray-console-data-postgres-2                                             3/3     Running            3          15d     10.38.0.44    ncn-w003   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-dns-powerdns-postgres cluster with leader pod: cray-dns-powerdns-postgres-0 ===

--- patronictl, version , list for services leader pod cray-dns-powerdns-postgres-0 ---
+ Cluster: cray-dns-powerdns-postgres (7241155947592331341) -----+----+-----------+
| Member                       | Host        | Role    | State   | TL | Lag in MB |
+------------------------------+-------------+---------+---------+----+-----------+
| cray-dns-powerdns-postgres-0 | 10.40.0.23  | Leader  | running |  5 |           |
| cray-dns-powerdns-postgres-1 | 10.32.0.86  | Replica | running |  5 |         0 |
| cray-dns-powerdns-postgres-2 | 10.38.0.102 | Replica | running |  5 |         0 |
+------------------------------+-------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         cray-dns-powerdns-postgres-0                                             3/3     Running            5          15d     10.40.0.23    ncn-w004   <none>           <none>
services         cray-dns-powerdns-postgres-1                                             3/3     Running            3          15d     10.32.0.86    ncn-w001   <none>           <none>
services         cray-dns-powerdns-postgres-2                                             3/3     Running            3          15d     10.38.0.102   ncn-w003   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-sls-postgres cluster with leader pod: cray-sls-postgres-0 ===

--- patronictl, version , list for services leader pod cray-sls-postgres-0 ---
+ Cluster: cray-sls-postgres (7241155706967109709) -----+----+-----------+
| Member              | Host        | Role    | State   | TL | Lag in MB |
+---------------------+-------------+---------+---------+----+-----------+
| cray-sls-postgres-0 | 10.40.0.43  | Leader  | running |  5 |           |
| cray-sls-postgres-1 | 10.32.0.90  | Replica | running |  5 |         0 |
| cray-sls-postgres-2 | 10.38.0.107 | Replica | running |  5 |         0 |
+---------------------+-------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         cray-sls-postgres-0                                                      3/3     Running            5          15d     10.40.0.43    ncn-w004   <none>           <none>
services         cray-sls-postgres-1                                                      3/3     Running            3          15d     10.32.0.90    ncn-w001   <none>           <none>
services         cray-sls-postgres-2                                                      3/3     Running            3          15d     10.38.0.107   ncn-w003   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-smd-postgres cluster with leader pod: cray-smd-postgres-2 ===

--- patronictl, version , list for services leader pod cray-smd-postgres-2 ---
+ Cluster: cray-smd-postgres (7241155994554597454) ----+----+-----------+
| Member              | Host       | Role    | State   | TL | Lag in MB |
+---------------------+------------+---------+---------+----+-----------+
| cray-smd-postgres-0 | 10.32.0.69 | Replica | running |  8 |         0 |
| cray-smd-postgres-1 | 10.38.0.32 | Replica | running |  8 |         0 |
| cray-smd-postgres-2 | 10.40.0.39 | Leader  | running |  8 |           |
+---------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         cray-smd-postgres-0                                                      3/3     Running            3          15d     10.32.0.69    ncn-w001   <none>           <none>
services         cray-smd-postgres-1                                                      3/3     Running            4          15d     10.38.0.32    ncn-w003   <none>           <none>
services         cray-smd-postgres-2                                                      3/3     Running            5          15d     10.40.0.39    ncn-w004   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the gitea-vcs-postgres cluster with leader pod: gitea-vcs-postgres-0 ===

--- patronictl, version , list for services leader pod gitea-vcs-postgres-0 ---
+ Cluster: gitea-vcs-postgres (7241159106879881293) ----+----+-----------+
| Member               | Host       | Role    | State   | TL | Lag in MB |
+----------------------+------------+---------+---------+----+-----------+
| gitea-vcs-postgres-0 | 10.40.0.48 | Leader  | running |  5 |           |
| gitea-vcs-postgres-1 | 10.32.0.83 | Replica | running |  5 |         0 |
| gitea-vcs-postgres-2 | 10.38.0.76 | Replica | running |  5 |         0 |
+----------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         gitea-vcs-postgres-0                                                     3/3     Running            5          15d     10.40.0.48    ncn-w004   <none>           <none>
services         gitea-vcs-postgres-1                                                     3/3     Running            3          15d     10.32.0.83    ncn-w001   <none>           <none>
services         gitea-vcs-postgres-2                                                     3/3     Running            3          15d     10.38.0.76    ncn-w003   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the keycloak-postgres cluster with leader pod: keycloak-postgres-0 ===

--- patronictl, version , list for services leader pod keycloak-postgres-0 ---
+ Cluster: keycloak-postgres (7241155855177723981) ----+----+-----------+
| Member              | Host       | Role    | State   | TL | Lag in MB |
+---------------------+------------+---------+---------+----+-----------+
| keycloak-postgres-0 | 10.40.0.20 | Leader  | running |  5 |           |
| keycloak-postgres-1 | 10.38.0.37 | Replica | running |  5 |         0 |
| keycloak-postgres-2 | 10.32.0.68 | Replica | running |  5 |         0 |
+---------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
services         keycloak-postgres-0                                                      3/3     Running            5          15d     10.40.0.20    ncn-w004   <none>           <none>
services         keycloak-postgres-1                                                      3/3     Running            4          15d     10.38.0.37    ncn-w003   <none>           <none>
services         keycloak-postgres-2                                                      3/3     Running            3          15d     10.32.0.68    ncn-w001   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-spire-postgres cluster with leader pod: cray-spire-postgres-0 ===

--- patronictl, version , list for spire leader pod cray-spire-postgres-0 ---
+ Cluster: cray-spire-postgres (7241324464387387465) ----+----+-----------+
| Member                | Host       | Role    | State   | TL | Lag in MB |
+-----------------------+------------+---------+---------+----+-----------+
| cray-spire-postgres-0 | 10.40.0.47 | Leader  | running |  3 |           |
| cray-spire-postgres-1 | 10.38.0.23 | Replica | running |  3 |         0 |
| cray-spire-postgres-2 | 10.32.0.84 | Replica | running |  3 |         0 |
+-----------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
spire            cray-spire-postgres-0                                                    3/3     Running            5          15d     10.40.0.47    ncn-w004   <none>           <none>
spire            cray-spire-postgres-1                                                    3/3     Running            4          15d     10.38.0.23    ncn-w003   <none>           <none>
spire            cray-spire-postgres-2                                                    3/3     Running            3          15d     10.32.0.84    ncn-w001   <none>           <none>
spire            cray-spire-postgres-pooler-5657f8774-bglw5                               2/2     Running            3          15d     10.32.0.4     ncn-w001   <none>           <none>
spire            cray-spire-postgres-pooler-5657f8774-nflks                               2/2     Running            3          15d     10.38.0.58    ncn-w003   <none>           <none>
spire            cray-spire-postgres-pooler-5657f8774-twgrv                               2/2     Running            4          15d     10.40.0.41    ncn-w004   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the spire-postgres cluster with leader pod: spire-postgres-0 ===

--- patronictl, version , list for spire leader pod spire-postgres-0 ---
+ Cluster: spire-postgres (7241159087958188109) ----+----+-----------+
| Member           | Host       | Role    | State   | TL | Lag in MB |
+------------------+------------+---------+---------+----+-----------+
| spire-postgres-0 | 10.40.0.45 | Leader  | running |  8 |           |
| spire-postgres-1 | 10.38.0.2  | Replica | running |  8 |         0 |
| spire-postgres-2 | 10.32.0.70 | Replica | running |  8 |         0 |
+------------------+------------+---------+---------+----+-----------+
NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
spire            spire-postgres-0                                                         3/3     Running            5          15d     10.40.0.45    ncn-w004   <none>           <none>
spire            spire-postgres-1                                                         3/3     Running            4          15d     10.38.0.2     ncn-w003   <none>           <none>
spire            spire-postgres-2                                                         3/3     Running            3          15d     10.32.0.70    ncn-w001   <none>           <none>
spire            spire-postgres-pooler-75688648f5-9njfm                                   2/2     Running            4          15d     10.40.0.3     ncn-w004   <none>           <none>
spire            spire-postgres-pooler-75688648f5-k9767                                   2/2     Running            2          15d     10.32.0.55    ncn-w001   <none>           <none>
spire            spire-postgres-pooler-75688648f5-p6djk                                   2/2     Running            3          15d     10.38.0.25    ncn-w003   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------

=== kubectl get pods -A -o wide | grep "NAME\|postgres-" | grep -v "operator\|Completed\|pooler" ===

NAMESPACE        NAME                                                                     READY   STATUS             RESTARTS   AGE     IP            NODE       NOMINATED NODE   READINESS GATES
argo             cray-nls-postgres-0                                                      3/3     Running            0          24h     10.33.0.29    ncn-w002   <none>           <none>
argo             cray-nls-postgres-1                                                      3/3     Running            0          24h     10.40.0.40    ncn-w004   <none>           <none>
argo             cray-nls-postgres-2                                                      3/3     Running            0          24h     10.38.0.12    ncn-w003   <none>           <none>
services         cfs-ara-postgres-0                                                       3/3     Running            3          15d     10.38.0.72    ncn-w003   <none>           <none>
services         cfs-ara-postgres-1                                                       3/3     Running            3          15d     10.32.0.88    ncn-w001   <none>           <none>
services         cfs-ara-postgres-2                                                       3/3     Running            5          15d     10.40.0.21    ncn-w004   <none>           <none>
services         cray-console-data-postgres-0                                             3/3     Running            4          15d     10.40.0.27    ncn-w004   <none>           <none>
services         cray-console-data-postgres-1                                             3/3     Running            3          15d     10.32.0.71    ncn-w001   <none>           <none>
services         cray-console-data-postgres-2                                             3/3     Running            3          15d     10.38.0.44    ncn-w003   <none>           <none>
services         cray-dns-powerdns-postgres-0                                             3/3     Running            5          15d     10.40.0.23    ncn-w004   <none>           <none>
services         cray-dns-powerdns-postgres-1                                             3/3     Running            3          15d     10.32.0.86    ncn-w001   <none>           <none>
services         cray-dns-powerdns-postgres-2                                             3/3     Running            3          15d     10.38.0.102   ncn-w003   <none>           <none>
services         cray-sls-postgres-0                                                      3/3     Running            5          15d     10.40.0.43    ncn-w004   <none>           <none>
services         cray-sls-postgres-1                                                      3/3     Running            3          15d     10.32.0.90    ncn-w001   <none>           <none>
services         cray-sls-postgres-2                                                      3/3     Running            3          15d     10.38.0.107   ncn-w003   <none>           <none>
services         cray-smd-postgres-0                                                      3/3     Running            3          15d     10.32.0.69    ncn-w001   <none>           <none>
services         cray-smd-postgres-1                                                      3/3     Running            4          15d     10.38.0.32    ncn-w003   <none>           <none>
services         cray-smd-postgres-2                                                      3/3     Running            5          15d     10.40.0.39    ncn-w004   <none>           <none>
services         gitea-vcs-postgres-0                                                     3/3     Running            5          15d     10.40.0.48    ncn-w004   <none>           <none>
services         gitea-vcs-postgres-1                                                     3/3     Running            3          15d     10.32.0.83    ncn-w001   <none>           <none>
services         gitea-vcs-postgres-2                                                     3/3     Running            3          15d     10.38.0.76    ncn-w003   <none>           <none>
services         keycloak-postgres-0                                                      3/3     Running            5          15d     10.40.0.20    ncn-w004   <none>           <none>
services         keycloak-postgres-1                                                      3/3     Running            4          15d     10.38.0.37    ncn-w003   <none>           <none>
services         keycloak-postgres-2                                                      3/3     Running            3          15d     10.32.0.68    ncn-w001   <none>           <none>
spire            cray-spire-postgres-0                                                    3/3     Running            5          15d     10.40.0.47    ncn-w004   <none>           <none>
spire            cray-spire-postgres-1                                                    3/3     Running            4          15d     10.38.0.23    ncn-w003   <none>           <none>
spire            cray-spire-postgres-2                                                    3/3     Running            3          15d     10.32.0.84    ncn-w001   <none>           <none>
spire            spire-postgres-0                                                         3/3     Running            5          15d     10.40.0.45    ncn-w004   <none>           <none>
spire            spire-postgres-1                                                         3/3     Running            4          15d     10.38.0.2     ncn-w003   <none>           <none>
spire            spire-postgres-2                                                         3/3     Running            3          15d     10.32.0.70    ncn-w001   <none>           <none>

PASSED. All postgresql checks passed.

ncn-m001:~ # kubectl exec cray-sls-postgres-1 -n services -c postgres -- patronictl version
patronictl version 2.1.4
ncn-m001:~ #

```
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable