### PR TITLE
Hms etcd rc updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: services
     values:
         global:
@@ -55,7 +55,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.3.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.0.2
+    version: 3.0.3
     namespace: services
     swagger:
     - name: firmware-action
@@ -63,7 +63,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.28.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.0.1
+    version: 3.0.2
     namespace: services
     swagger:
     - name: hbtd
@@ -71,7 +71,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.19.1/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 3.0.1
+    version: 3.0.2
     namespace: services
     swagger:
     - name: hmnfd
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.3
+    version: 2.0.4
     namespace: services
     swagger:
     - name: power-control


### PR DESCRIPTION
## Summary and Scope

Update to ETCD portion of chart due to release critical issue in the old ETCD chart.

## Issues and Related PRs

* Resolves [CASMHMS-6047](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6047)
* Resolves [CASMHMS-6048](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6048)
* Resolves [CASMHMS-6049](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6049)
* Resolves [CASMHMS-6050](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6050)
* Resolves [CASMHMS-6051](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6051)

## Testing

Tested on:

  * `ashton`

Test description:

Validate I can deploy the new chart and the proper version of ETCD was included.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable