### PR TITLE
CASMPET-6664: Update oauth2-proxies to use cmn gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update cray-oauth2-proxies to 0.3.1 (CASMPET-6664)
 - Add csm-node-heartbeat to 2.0-3 (MTL-2019)
 - Add acpid to 2.0.31-2.0 (MTL-2019)
 - Update cray-dhcp-kea to 0.10.24 (CASMNET-2095)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -236,7 +236,7 @@ spec:
     namespace: services
   - name: cray-oauth2-proxies
     source: csm-algol60
-    version: 0.3.0
+    version: 0.3.1
     namespace: services
   - name: cray-iuf
     source: csm-algol60

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -349,6 +349,7 @@ spec:
             - api-gw-service.local
             - api-gw-service-nmn.local
             - istio-ingressgateway.istio-system.svc.cluster.local
+            - istio-ingressgateway-cmn.istio-system.svc.cluster.local
             - '*.cmn.{{ network.dns.external }}'
             - '*.can.{{ network.dns.external }}'
             - '*.chn.{{ network.dns.external }}'


### PR DESCRIPTION
## Summary and Scope

This update the upstream url for the customer management proxy to allow for a disconnection from the nmn gateway for all cmn traffic.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6664](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6664)
* Additional changes needed in [CASMPET-6664](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6664)

## Testing

### Tested on:

  * drax
  
### Test description:

Tested by manually updating the URL and discovered there was also a need for a customization change to allow for a different upstream url with a updated certificate

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Risk in depending on what is installed on system and where in the upgrade process the install is in to allow for updated certificates and updated istio


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

