### PR TITLE
Updated sls to 5.1.1 and smd to 7.0.4 for the k8s 1.22 upgrade

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 5.1.0
+    version: 5.1.1
     namespace: services
     swagger:
     - name: sls
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.3
+    version: 7.0.4
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Rebuilt sls and smd to use the latest base-charts. 10.0.2 for cray-service and 1.0.1 for cray-postgres. These new charts don't use any k8s deprecated APIs

## Issues and Related PRs

* Resolves [CASMHMS-5880](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5880)
* Resolves [CASMHMS-5881](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5881)

## Testing

### Tested on:


### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

