### PR TITLE
[Backport stable/1.5] CASMPET-5797: Move istio-ingressgateway-cmn to customer-admin

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -148,7 +148,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.9.0
+    version: 2.9.1
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -731,8 +731,6 @@ spec:
         ingresses:
           ingressgateway:
             issuers:
-              shasta-cmn: https://api.cmn.{{ network.dns.external }}/keycloak/realms/shasta
-              keycloak-cmn: https://auth.cmn.{{ network.dns.external }}/keycloak/realms/shasta
               shasta-nmn: https://api.nmnlb.{{ network.dns.external }}/keycloak/realms/shasta
               keycloak-nmn: https://auth.nmnlb.{{ network.dns.external }}/keycloak/realms/shasta
           ingressgateway-customer-admin:


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2329. Cherry-picked from  for branch stable/1.5.