### PR TITLE
[Backport stable/1.5] CASMTRIAGE-5527: Update keycloak to address upstream bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-keycloak to 5.0.3 (CASMTRIAGE-5527)
 - cray-nls and cray-iuf to 3.1.6 (CASMTRIAGE-5568)
 - Update iuf to 0.1.10; cray-nls and cray-iuf to 3.1.5; downgrade argoexec to v3.3.6 (CASM-4352)
 - update cray-ims to 3.9.3 (CASMCMS-8624)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -188,7 +188,7 @@ spec:
     namespace: vault
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.0.2
+    version: 5.0.3
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2397. Cherry-picked from  for branch stable/1.5.