### PR TITLE
[Backport stable/1.5] CASMNET-2095, MTL-2018, MTL-2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add csm-node-heartbeat to 2.0-3 (MTL-2019)
+- Add acpid to 2.0.31-2.0 (MTL-2019)
+- Update cray-dhcp-kea to 0.10.24 (CASMNET-2095)
 - Update cray-keycloak to 5.0.3 (CASMTRIAGE-5527)
 - cray-nls and cray-iuf to 3.1.6 (CASMTRIAGE-5568)
 - Update iuf to 0.1.10; cray-nls and cray-iuf to 3.1.5; downgrade argoexec to v3.3.6 (CASM-4352)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -49,7 +49,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.23 # update platform.yaml cray-precache-images with this
+    version: 0.10.24 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.23
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.24
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.22
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.1

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -23,8 +23,9 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
-    - acpid-2.0.31-2.1.x86_64
+    - acpid-2.0.31-2.0.x86_64.rpm
     - csm-auth-utils-1.0.0-1.noarch
+    - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
     - metal-ipxe-2.4.4-1.noarch


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2399. Cherry-picked from  for branch stable/1.5.