### PR TITLE
[Backport stable/1.5] CASM-4351 Fixes wrong entries are added for helm chart in cray-produc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Add csm-node-heartbeat to 2.0-3 (MTL-2019)
 - Add acpid to 2.0.31-2.0 (MTL-2019)
 - Update cray-dhcp-kea to 0.10.24 (CASMNET-2095)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -187,4 +187,4 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.3.2
       - 1.8.8
     cray-nexus-setup:
-      - 0.10.0
+      - 0.10.1


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2400. Cherry-picked from  for branch stable/1.5.