### PR TITLE
CASMCMS-8623: Updating latest ims-load-artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+
+- Update cray-ims-load-artifacts to 2.6.0 (CASMCMS-8623)
 - Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Update cray-oauth2-proxies to 0.3.1 (CASMPET-6664)
 - Update platform-utils RPM to fix ncnPostgresHealthCheck

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -43,7 +43,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.5.2
+      - 2.6.0
     cray-grafterm:
       - 1.0.3
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
Latest version 2.6.0 of `ims-load-artifacts` is required for arch IUF manifest changes to process correctly.

Must merge with:
https://github.com/Cray-HPE/cray-nls/pull/181 - [CASMCMS-8623](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8623)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

