### PR TITLE
[Backport stable/1.5] CASMPET-6659 1.5 : Fix ncnPostgresHealthCheck for version and spire issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update platform-utils RPM to fix ncnPostgresHealthCheck
 - Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Add csm-node-heartbeat to 2.0-3 (MTL-2019)
 - Add acpid to 2.0.31-2.0 (MTL-2019)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -28,13 +28,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
+    - platform-utils-1.6.1-1.noarch
     - metal-ipxe-2.4.4-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - pit-nexus-1.2.2-1.x86_64
     - pit-observability-1.0.7-1.x86_64
-    - platform-utils-1.6.0-1.noarch
 https://artifactory.algol60.net/artifactory/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/noos/:
   rpms:
     - cm-cli-1.5.0-1.x86_64
     - cvt-1.5.1-20230623121517_c8c3bc0b7d74.x86_64
-

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -46,5 +46,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - loftsman-1.2.0-2.x86_64
     - manifestgen-1.3.9-1.x86_64
     - pit-init-1.3.0-1.noarch
-    - platform-utils-1.6.0-1.noarch
+    - pit-nexus-1.2.1-1.x86_64
+    - pit-observability-1.0.6-1.x86_64
+    - platform-utils-1.6.1-1.noarch
     - spire-agent-1.5.5-1.7.x86_64


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2425. Cherry-picked from  for branch stable/1.5.