### PR TITLE
[Backport stable/1.5] CASMPET-6664: Update oauth2-proxies to use cmn gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-oauth2-proxies to 0.3.1 (CASMPET-6664)
 - Update platform-utils RPM to fix ncnPostgresHealthCheck
 - Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Add csm-node-heartbeat to 2.0-3 (MTL-2019)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,7 +240,7 @@ spec:
     namespace: services
   - name: cray-oauth2-proxies
     source: csm-algol60
-    version: 0.3.0
+    version: 0.3.1
     namespace: services
   - name: cray-iuf
     source: csm-algol60

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -349,6 +349,7 @@ spec:
             - api-gw-service.local
             - api-gw-service-nmn.local
             - istio-ingressgateway.istio-system.svc.cluster.local
+            - istio-ingressgateway-cmn.istio-system.svc.cluster.local
             - '*.cmn.{{ network.dns.external }}'
             - '*.can.{{ network.dns.external }}'
             - '*.chn.{{ network.dns.external }}'


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2432. Cherry-picked from  for branch stable/1.5.