### PR TITLE
CASMTRIAGE-5598: cmsdev: Compress test artifacts using gzip on failure

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.3.1-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - cray-cmstools-crayctldeploy-1.10.8-1.x86_64
+    - cray-cmstools-crayctldeploy-1.10.9-1.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

The cmsdev test tool failed to compress test artifacts recently when bzip2 was not found on the node where it was running. This modifies cmsdev to use the more widely available gzip for artifact compression. No functional change to the tests, and no change to good path behavior of the tool (artifacts are only collected on failure)

## Testing

Tested on drax -- forced a failure of a test and verified that the gzip compression worked.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
