### PR TITLE
CASMCMS-8686/8687 - ims fixes for dkms and job records.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -179,7 +179,7 @@ spec:
             tag: 2.1.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.9.5
+    version: 3.9.6
     namespace: services
     swagger:
     - name: ims


### PR DESCRIPTION
## Summary and Scope

There are 2 issues wrapped together in this hotfix:
CASMCMS-8686 - fix jobs record scheme change on helm update.
CASMCMS-8687 - fix global require-dkms setting usage.

Both were found when doing more extensive testing of the csm-1.5 release version of IMS.

Code PR: https://github.com/Cray-HPE/ims/pull/87

## Issues and Related PRs
* Resolves [CASMCMS-8686](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8686)
* Resolves [CASMCMS-8687](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8687)

## Testing
### Tested on:
  * `Mug`

### Test description:

I did a clean install of the csm-1.4 version of IMS on Mug, then did helm upgrade/downgrade testing to insure the schema of the jobs records is correctly updated, and the global require-dkms flag is being used as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

The bigger risk here is not including this fix and possibly getting corrupt job data entries.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

