### PR TITLE
CRAYSAT-1742: Update cray-sat version from 3.21.5 to 3.21.6

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.5
+      - 3.21.6
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.5"
+sat_version="3.21.6"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 # Tag iuf-container image as csm-latest


### PR DESCRIPTION

## Summary and Scope

This resolves 6 vulnerabilities detected by Snyk scanning.

## Issues and Related PRs

* Resolves [CRAYSAT-1742](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1742)
* Corresponding update to the SAT 2.5 product release distribution is here: https://github.com/Cray-HPE/sat-product-stream/pull/53

## Testing

### Tested on:

  * Jenkins

### Test description:

Jenkins build will test that the cray-sat container image version specified can be pulled.

Performed a quick smoke test of the cray-sat:3.21.6 container image by downloading it on mug and running `sat status` and `sat showrev` which exercised access to CSM APIs, K8s API, and S3 API.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

