### PR TITLE
CASMCMS-8623: Updating cray-nls cray-iuf to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-nls cray-iuf to 4.0.1 (CASMCMS-8623)
 - Update cray-ims-load-artifacts to 2.6.0 (CASMCMS-8623)
 - Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Update cray-oauth2-proxies to 0.3.1 (CASMPET-6664)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.0
+    version: 4.0.1
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.0
+    version: 4.0.1
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

cray-nls and cray-iuf are being updated to `v4.0.1` to account for schema changes recently released regarding `arch` parameter for ARM. 

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Mug`

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

