### PR TITLE
MTL-2000 Add `cloud-init.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cloud-init.json
 /dist
 /env/*
 /venv/*

--- a/release.sh
+++ b/release.sh
@@ -341,6 +341,9 @@ cp "${scandir}/docker/snyk-results.xlsx" "${ROOTDIR}/dist/${RELEASE}-snyk-result
 # Save image digest as a separate asset
 cp "${ROOTDIR}/build/images/index.txt" "${ROOTDIR}/dist/${RELEASE}-images.txt"
 
+# Save the cloud-init package and repository definition file.
+cp "${ROOTDIR}/rpm/cloud-init.yaml" "${BUILDDIR}/rpm/cloud-init.yaml"
+
 # Package scans as an independent archive
 tar -C "${scandir}/.." --owner=0 --group=0 -cvzf "${scandir}/../$(basename "$scandir").tar.gz" "$(basename "$scandir")/" --remove-files
 

--- a/rpm/cloud-init.yaml
+++ b/rpm/cloud-init.yaml
@@ -1,0 +1,32 @@
+# This file is read and used when generating cloud-init user-data, any repository and package listed here will be
+# added to an NCN during cloud-init.
+---
+# All repos need to use a URL that is available during the PIT and after the PIT is gone, but resolves to the correct
+# nexus in either context.
+# The `packages` URL resolves to the PIT nexus and the Kubernetes nexus when in a bootstrap
+# and runtime environment (respectively).
+repos:
+  - id: csm-noos
+    name: csm-noos
+    baseurl: "https://packages/repository/csm-noos?ssl_verify=no"
+    enabled: 1
+    autorefresh: 1
+    gpgcheck: 0
+  # Use Zypper friendly variables so the correct service pack repository is added.
+  # NEVER force add a distro repository, or packages that do care about the distro version can break.
+  - id: csm-sle
+    name: "csm-sle-${releasever_major}sp${releasever_minor}"
+    baseurl: "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no"
+    enabled: 1
+    autorefresh: 1
+    gpgcheck: 0
+# List of packages to install. These do not need version pins, because the latest version in nexus is determined by this
+# tarball. Version pinning here would be redundant, and likely lead to more failures if anyone neglected updating it.
+packages:
+  - canu
+  - cray-cmstools-crayctldeploy
+  - csm-testing
+  - goss-servers
+  - iuf-cli
+  - libcsm
+  - platform-utils

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -24,15 +24,18 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.x86_64.rpm
+    - cray-site-init-1.32.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - platform-utils-1.6.2-1.noarch
     - metal-ipxe-2.4.4-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
+    - metal-ipxe-2.4.4-1.noarch
+    - pit-init-1.4.0-1.noarch
     - pit-nexus-1.2.2-1.x86_64
     - pit-observability-1.0.8-1.x86_64
+    - platform-utils-1.6.2-1.noarch
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/noos/:
   rpms:
     - cm-cli-1.5.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cray-site-init-1.31.3-1.x86_64
+    - cray-site-init-1.32.0-1.x86_64
     - craycli-0.82.6-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-state-reporter-1.9.3-1.noarch
     - cfs-trust-1.6.5-1.noarch
     - cray-cmstools-crayctldeploy-1.12.0-1.x86_64
-    - cray-site-init-1.31.3-1.x86_64
+    - cray-site-init-1.32.0-1.x86_64
     - craycli-0.82.6-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
@@ -45,7 +45,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64
     - manifestgen-1.3.9-1.x86_64
-    - pit-init-1.3.0-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
     - platform-utils-1.6.2-1.noarch


### PR DESCRIPTION
This stages a new manifest for packages to install via cloud-init. The new `cloud-init.yaml` file will be read during fresh installs and upgrades by `pit-init.sh` and `prerequisites.sh` in order to generate cloud-init data.

This is just staging the change, eventually this will replace `lib/install-goss-tests.sh` once the change is made active through a new NCN image once everything is staged.

A new `cray-site-init` and `pit-init` are pulled in that has the ability to read this file, but this is also a staging change.