### PR TITLE
CASM-4085: Bump csm-config version to 1.16.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -195,7 +195,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.3
+    version: 1.16.5
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Bumps version of csm-config to 1.16.5 for csm.ncn.sysctl role 

## Issues and Related PRs

* Resolves [CASM-4085](https://jira-pro.it.hpe.com:8443/browse/CASM-4085)

