### PR TITLE
CASMCMS-8537: Include new reference role for introspecting IMS variables

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -195,7 +195,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.3
+    version: 1.16.6
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Included is a new ansible reference role to be used as a method for introspecting specific settings that are set by IMS in the context of image customization, in particular as it pertains to DKMS and IMS image architecture.

## Issues and Related PRs

* Resolves [CASMCMS-8537](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8537)
