### PR TITLE
CASMCMS-8504: cmsdev: Update test to support iPXE binaries for multiple architectures being built

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.4.0-1.noarch
     - cfs-state-reporter-1.9.3-1.noarch
     - cfs-trust-1.6.5-1.noarch
-    - cray-cmstools-crayctldeploy-1.11.13-1.x86_64
+    - cray-cmstools-crayctldeploy-1.12.0-1.x86_64
     - cray-site-init-1.31.3-1.x86_64
     - craycli-0.82.4-1.x86_64
     - csm-node-identity-1.0.20-1.noarch


### PR DESCRIPTION
## Summary and Scope

When iPXE started building binaries for additional architectures, it ended up creating additional pods, and also changed the behavior of its settings configmap. All of these things resulted in the existing iPXE test failing. This PR updates to a version of the test which has been updated to account for these changes. The updated test verifies that the binaries for the different architectures are being successfully built and are able to be TFTPed.

## Issues and Related PRs

* Resolves [CASMCMS-8504](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8504)
* Resolves [CASMTRIAGE-5597](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5597)
* [Source PR](https://github.com/Cray-HPE/cms-tools/pull/114)
* [stable/1.5 backport PR](https://github.com/Cray-HPE/csm/pull/2478)

## Testing

Tested on ashton (installed with 1.5.0-alpha.66). Without the changes, the test fails. With the changes, the test correctly validates all of the binaries, and passed.

## Risks and Mitigations

Without this change, the iPXE test will always fail, even on systems where Arm64 binaries are not being built (although the default setting is to build them).

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
