### PR TITLE
CRAYSAT-1741: Update cray-sat version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.24.0
+      - 3.25.0
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.24.0"
+sat_version="3.25.0"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 # Tag iuf-container image as csm-latest


### PR DESCRIPTION
## Summary and Scope

Update the version of the cray-sat container image. This will pull in support for specifying the new DKMS parameter in layers of CFS configurations created by `sat bootprep`.

## Issues and Related PRs

* Resolves [CRAYSAT-1741](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1741)
* Corresponding update to the SAT 2.6 release: https://github.com/Cray-HPE/sat-product-stream/pull/54

## Testing

### Tested on:

  * mug

### Test description:

This new version of the cray-sat container image was tested as described in the commit and pull request to the sat repository.

## Risks and Mitigations

Low risk.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable