### PR TITLE
Update metrics-server to K8S 1.22 compatible version (CASMPET-6639)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -33,7 +33,7 @@ spec:
   charts:
   - name: cray-metrics-server
     source: csm-algol60
-    version: 0.4.1
+    version: 0.5.0
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

New metric-server image for K8S 1.22, fixes namespace delete issue

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6639

### Testing

Tested on ashton:

```
pit:~/brad # kubectl delete -f ./blue.yaml -n tenants
tenant.tapms.hpe.com "vcluster-blue" deleted
```

```
pit:~/brad # kubectl get ns | grep blue
pit:~/brad
```

```
pit:~ # helm history -n kube-system cray-metrics-server
REVISION	UPDATED                 	STATUS    	CHART                    	APP VERSION	DESCRIPTION
1       	Sun Jun 25 14:37:38 2023	superseded	cray-metrics-server-0.4.1	v0.3.6     	Install complete
2       	Wed Jun 28 17:23:51 2023	deployed  	cray-metrics-server-0.5.0	v0.6.3     	Upgrade complete
```

```
pit:~/brad # kubectl logs -n kube-system metrics-server-86bff57b87-cw2j4
I0628 17:30:26.279095       1 serving.go:342] Generated self-signed cert (/tmp/apiserver.crt, /tmp/apiserver.key)
I0628 17:30:27.616407       1 requestheader_controller.go:169] Starting RequestHeaderAuthRequestController
I0628 17:30:27.616441       1 configmap_cafile_content.go:201] "Starting controller" name="client-ca::kube-system::extension-apiserver-authentication::client-ca-file"
I0628 17:30:27.616470       1 shared_informer.go:240] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I0628 17:30:27.616469       1 configmap_cafile_content.go:201] "Starting controller" name="client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file"
I0628 17:30:27.616491       1 shared_informer.go:240] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I0628 17:30:27.616453       1 shared_informer.go:240] Waiting for caches to sync for RequestHeaderAuthRequestController
I0628 17:30:27.616682       1 secure_serving.go:267] Serving securely on [::]:4443
I0628 17:30:27.616734       1 tlsconfig.go:240] "Starting DynamicServingCertificateController"
W0628 17:30:27.616794       1 shared_informer.go:372] The sharedIndexInformer has started, run more than once is not allowed
I0628 17:30:27.616783       1 dynamic_serving_content.go:131] "Starting controller" name="serving-cert::/tmp/apiserver.crt::/tmp/apiserver.key"
I0628 17:30:27.717303       1 shared_informer.go:247] Caches are synced for RequestHeaderAuthRequestController
I0628 17:30:27.717329       1 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I0628 17:30:27.717337       1 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
