### PR TITLE
CASMTRIAGE-5616: Update Goss iPXE test to look for the x86-64 iPXE pod

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.38-1.noarch
-    - goss-servers-1.16.38-1.noarch
+    - csm-testing-1.16.39-1.noarch
+    - goss-servers-1.16.39-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

In CSM 1.5, cray-ipxe now has two pods -- one which builds x86-64 binaries, and one which builds aarch64. The labels of these pods are both different from the previous iPXE pod label, which is causing a Goss test to fail. This test is run to ensure that NCN boots will work, so in that context we are only concerned with the x86-64 iPXE pod. The cmsdev test tool already includes more complete test coverage of iPXE, including the new aarch64 binaries, so it doesn't make sense to duplicate that here.

This modifies the test to use the correct label for the x86-64 pod.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5616](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5616)
* Related to the changes made to cmsdev with [CASMCMS-8504](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8504)
* [Source PR](https://github.com/Cray-HPE/csm-testing/pull/504)
* [stable/1.5 backport PR](https://github.com/Cray-HPE/csm/pull/2484)

## Testing

I tested the updated `kubectl` command on ashton (installed with csm-1.5.0-alpha.66) and verified that it works.

## Risks and Mitigations

Without this change, this test will always fail.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
