### PR TITLE
CASMCMS-8599: Add CLI support for BOS v2 session include_disabled option

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.82.4-1.x86_64
+    - craycli-0.82.5-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.5-1.noarch
     - cray-cmstools-crayctldeploy-1.12.0-1.x86_64
     - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.82.4-1.x86_64
+    - craycli-0.82.5-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

In CSM 1.4, BOS added the include_disabled option when creating V2 sessions. This exposes that option for use in the CLI. This adds a single flag to a single BOS CLI command.

## Issues and Related PRs

* Resolves [CASMCMS-8599](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8599)
* [stable/1.5 backport PR](https://github.com/Cray-HPE/csm/pull/2487)
* [release/1.4 backport PR](https://github.com/Cray-HPE/csm/pull/2489)
* [metal-provision main PR](https://github.com/Cray-HPE/metal-provision/pull/225)
* [metal-provision lts/csm-1.5 PR](https://github.com/Cray-HPE/metal-provision/pull/226)

## Testing

Ran CLI regression tests (including a new test added to cover this option specifically).

## Risks and Mitigations

Low risk -- single new option to single BOS command.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
