### PR TITLE
Fix etcd backups check to dynamically list the clusters (CASMPET-6668)

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -28,7 +28,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.0-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - platform-utils-1.6.1-1.noarch
+    - platform-utils-1.6.2-1.noarch
     - metal-ipxe-2.4.4-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - pit-nexus-1.2.2-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -48,5 +48,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - pit-init-1.3.0-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64
-    - platform-utils-1.6.1-1.noarch
+    - platform-utils-1.6.2-1.noarch
     - spire-agent-1.5.5-1.7.x86_64


### PR DESCRIPTION
### Summary and Scope

Change health script to check for a dynamic list of etcd clusters when verifying we've got a backup in the past 24 hours.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6668

### Testing

Tested on ashton:

```
ncn-m002:~/brad # ./ncnHealthChecks.sh -s etcd_backups_check
**************************************************************************

=== Verify etcd clusters have a backup in the last 24 hours. ===
=== The complete list of backups can be listed as follows:
=== % /opt/cray/platform-utils/etcd/etcd-util.sh list_backups -
Wed 28 Jun 2023 08:00:52 PM UTC

-- cray-bos -- backups
PASS: backup found less than 24 hours old.

-- cray-bss -- backups
PASS: backup found less than 24 hours old.

-- cray-fas -- backups
PASS: backup found less than 24 hours old.

-- cray-hbtd -- backups
PASS: backup found less than 24 hours old.

-- cray-hmnfd -- backups
PASS: backup found less than 24 hours old.

-- cray-power-control -- backups
PASS: backup found less than 24 hours old.

-- cray-uas-mgr -- backups
PASS: backup found less than 24 hours old.
 --- PASSED ---
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
