### PR TITLE
Remove required tenant prompt when initializing (CASMPET-6649)

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.82.5-1.x86_64
+    - craycli-0.82.6-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.5-1.noarch
     - cray-cmstools-crayctldeploy-1.12.0-1.x86_64
     - cray-site-init-1.31.3-1.x86_64
-    - craycli-0.82.5-1.x86_64
+    - craycli-0.82.6-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch


### PR DESCRIPTION
### Summary and Scope

Change --tenant argument to be optional to prevent BW incompatible change for non-interactive use cases.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6649

### Testing

Tested on ashton:

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.
ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = ""

[auth.login]
username = "vshasta"
```

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local --tenant vcluster-blue
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.

ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = "vcluster-blue"

[auth.login]
username = "vshasta"
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
