### PR TITLE
Adds undionly.kpxe build options for vShasta.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -127,7 +127,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.11.3
+    version: 1.11.4
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Adds back missing support for undionly.kpxe for vshasta

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8692](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8692)
