### PR TITLE
Remove etcd cluster migration test (CASMPET-6642)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.39-1.noarch
-    - goss-servers-1.16.39-1.noarch
+    - csm-testing-1.16.40-1.noarch
+    - goss-servers-1.16.40-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Remove test that fails if etcd clusters haven't yet been migrated.  This is necessary as cray-fox (diags) uses a separate installer and this test will always fail.  All jiras associated with the bitnami migration are done, so removing the test.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6642

### Testing

Just removing a test

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
