### PR TITLE
CASMTRIAGE-5630: Split iPXE check into two tests; modify suites to run appropriate iPXE check

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.40-1.noarch
-    - goss-servers-1.16.40-1.noarch
+    - csm-testing-1.16.41-1.noarch
+    - goss-servers-1.16.41-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

See [source PR](https://github.com/Cray-HPE/csm-testing/pull/506) for details.

## Issues and Related PRs

* [source PR](https://github.com/Cray-HPE/csm-testing/pull/506)
* Resolves [CASMTRIAGE-5630](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5630)
* Relates to [CASMTRIAGE-5616](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5616)
* [stable/1.5 backport PR](https://github.com/Cray-HPE/csm/pull/2511)
* [metal-provision main PR](https://github.com/Cray-HPE/metal-provision/pull/244)
* [metal-provision lts/csm-1.5 PR](https://github.com/Cray-HPE/metal-provision/pull/245)

## Testing

See [source PR](https://github.com/Cray-HPE/csm-testing/pull/506) for details.

## Risks and Mitigations

Without this change, the check run in prerequisites.sh during upgrades will always fail.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
