### PR TITLE
Fixes for goss-k8s-pods-ips-in-nmn-pool.yaml in CSM 1.5 (CASMTRIAGE-5638)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.40-1.noarch
-    - goss-servers-1.16.40-1.noarch
+    - csm-testing-1.16.42-1.noarch
+    - goss-servers-1.16.42-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Cleanup goss-k8s-pods-ips-in-nmn-pool.yaml test, parse K8S 1.22 output correct and discover NMN subnet from SLS.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5638
* https://jira-pro.it.hpe.com:8443/browse/CASMINST-3769

### Testing

drax:

```
ncn-m001:/opt/cray/tests/install/ncn # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-pods-ips-in-nmn-pool-brad.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 0.747s
Count: 2, Failed: 0, Skipped: 0
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
