### PR TITLE
CASMPET-6669: sysmgmt: thanos has hard-coded S3 endpoint of "rgw-vip.nmn"

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.4
+    version: 0.28.5
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMPET-6669
* Requires - https://github.com/Cray-HPE/cray-sysmgmt-health/pull/125

## Testing

_List the environments in which these changes were tested._

### Tested on:

mug
