### PR TITLE
CASMHMS-6055 - Update FAS Chart to 3.0.4 for FAS v1.29.0 - CSM 1.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -55,12 +55,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.3.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.0.3
+    version: 3.0.4
     namespace: services
     swagger:
     - name: firmware-action
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.28.0/api/docs/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.29.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
     version: 3.0.2


### PR DESCRIPTION
## Summary and Scope

Updates FAS chart to v3.0.4 FAS v1.29.0 for bugfix of Action IDs becoming NIL