### PR TITLE
CASMPET-6520 Multi-tenancy: add Vault Transit (KMS) Support

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -132,7 +132,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.4.1
+    version: 1.6.0
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -251,11 +251,11 @@ spec:
   # Tapms service
   - name: cray-tapms-crd
     source: csm-algol60
-    version: 0.2.1
+    version: 0.3.0
     namespace: tapms-operator
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 0.2.2
+    version: 0.3.0
     namespace: tapms-operator
     swagger:
     - name: tapms-operator


### PR DESCRIPTION
## Summary and Scope

Update the chart versions of cray-vault, cray-tapms, and cray-tapms-crd as required to add Vault support into the multi-tenancy TAPMS operator.

## Issues and Related PRs

* Resolves [CASMPET-6520](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6520) as well as several items in the master epic [CASM-3945](https://jira-pro.it.hpe.com:8443/browse/CASM-3945)
* Details in 
  * https://github.com/Cray-HPE/cray-tapms-operator/pull/32
  * https://github.com/Cray-HPE/docs-csm/pull/3944


