### PR TITLE
CASMINST-6532/CASMINST-6535: Update lists of RPMs that CFS installs/updates on nodes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -198,7 +198,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.6
+    version: 1.16.8
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This update the list of RPMs that are installed/updated from Nexus by CFS. Among other things, this will address the fact that it was not updating the Cray CLI RPM on NCNs.

## Issues and Related PRs

* Resolves [CASMINST-6532](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6532)
* Resolves [CASMINST-6535](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6535)
* [Source PR](https://github.com/Cray-HPE/csm-config/pull/142)
* [stable/1.5 backport PR](https://github.com/Cray-HPE/csm/pull/2526)
* [release/1.4 PR](https://github.com/Cray-HPE/csm/pull/2525)

## Testing

I tested the updated configuration on bradi, where the problem was originally discovered after it was updated to CSM 1.4.1.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
