### PR TITLE
CASMINST-6532: Update lists of RPMs that CFS installs/updates on nodes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -208,7 +208,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.12
+    version: 1.15.13
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2524

Needed in order to include Cray CLI fixes and updates (like [CASMCMS-8599](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8599)) in CSM 1.4