### PR TITLE
Change cray artifacts to return more than 1000 files (CASMPET-6168)

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.32.0-1.x86_64
-    - craycli-0.82.6-1.x86_64
+    - craycli-0.82.7-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.5-1.noarch
     - cray-cmstools-crayctldeploy-1.12.0-1.x86_64
     - cray-site-init-1.32.0-1.x86_64
-    - craycli-0.82.6-1.x86_64
+    - craycli-0.82.7-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch


### PR DESCRIPTION
### Summary and Scope

Use boto3 pagination api to fully list bucket contents.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6168

### Testing

mug:

Before:

```
cray artifacts list thanos | grep ^Key | wc -l
1000

cray artifacts list velero | grep ^Key | wc -l
1000
```

After:
```
cray artifacts list thanos | grep ^Key | wc -l
1583

cray artifacts list velero | grep ^Key | wc -l
2913
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
