### PR TITLE
CASMHMS-3700 Add Tavern CT tests for HMNFD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,7 +516,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a fix to add subseconds to the log timestamps.
 - Added a fix for CPU throttling on cray-cfs-operator pods at scale.
 - Added a fix for CPU throttling on cray-conman pods at scale.
-- Added a fix for CPU throttling on cray-hmnfdi pods at scale.
+- Added a fix for CPU throttling on cray-hmnfd pods at scale.
 - Added a fix for CPU throttling on cray-hbtd pods at scale.
 - Updated the install documentation to have the right version of iLO.
 - Added a workaround script for when a initrd and kernel are missing and

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -71,12 +71,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.19.1/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 3.0.2
+    version: 4.0.0
     namespace: services
     swagger:
     - name: hmnfd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.18.1/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.19.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
     version: 2.16.1

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.16.42-1.noarch
     - goss-servers-1.16.42-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
-    - hpe-csm-scripts-0.5.5-1.noarch
+    - hpe-csm-scripts-0.6.0-1.noarch
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
     - iuf-cli-1.5.3-1.x86_64


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes for HMNFD targeting CSM-1.6:

* Refactored docker-compose file for runCT environment and replaced RTS with RIE.
* Updated CT tests to hms-test:5.1.0 image.
* Added non-disruptive, disruptive, and destructive Tavern CT tests for HMNFD.
* Made minor corrections and cleaned up the API swagger_v2 specification.

### Issues and Related PRs

* Resolves CASMHMS-3700.

### Testing

Unit, integration, CT smoke and Tavern tests passing in GitHub actions. Deployed updated tests on Dorian vShasta system running CSM-1.5.0-beta.10 and verified they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, adds test coverage for HMNFD.