### PR TITLE
Add tenant name header allowing other headers (CASMINST-6514)

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -24,7 +24,7 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - cray-site-init-1.32.0-1.x86_64
-    - craycli-0.82.6-1.x86_64
+    - craycli-0.82.8-1.x86_64
     - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-2.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.5-1.noarch
     - cray-cmstools-crayctldeploy-1.12.0-1.x86_64
     - cray-site-init-1.32.0-1.x86_64
-    - craycli-0.82.6-1.x86_64
+    - craycli-0.82.8-1.x86_64
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch


### PR DESCRIPTION
### Summary and Scope

Change how tenant name header is passed to also work with other headers.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6514

### Testing

mug:

```
ncn-w004:~/.config/cray/configurations # cray uas create --publickey ~/.ssh/id_rsa.pub --format toml -vvvv
Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.vers
REQUEST: POST to https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas
OPTIONS: {'params': {'imagename': None, 'ports': None}, 'data': <MultipartEncoder: {'publickey': ('id_rsa.pub', <_io.BufferedReader name='/root/.ssh/id_rsa.pub'>)}>, 'headers': {'Content-Type': 'multipart/form-data; boundary=183efc470a9645c4af49e8b12f917d14', 'Cray-Tenant-Name': 'vcluster-blue'}, 'verify': False}
uai_age = "0m"
uai_connect_string = "ssh vers@10.102.162.162"
uai_host = "ncn-w006"
uai_img = "artifactory.algol60.net/csm-docker/stable/cray-uai-sles15sp3:1.8.1"
uai_ip = "10.102.162.162"
uai_msg = "ContainerCreating"
uai_name = "uai-vers-00422161"
uai_status = "Waiting"
username = "vers"

[uai_portmap]
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
