### PR TITLE
CASMINST-6538: Add troubleshooting information to CMS Goss tests

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.72.1-1.x86_64
-    - csm-testing-1.15.48-1.noarch
-    - goss-servers-1.15.48-1.noarch
+    - csm-testing-1.15.49-1.noarch
+    - goss-servers-1.15.49-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.72.1-1.x86_64
-    - csm-testing-1.15.47-1.noarch
-    - goss-servers-1.15.47-1.noarch
+    - csm-testing-1.15.48-1.noarch
+    - goss-servers-1.15.48-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,9 +34,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.47-1.noarch
+    - csm-testing-1.15.48-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.47-1.noarch
+    - goss-servers-1.15.48-1.noarch
     - iuf-cli-1.4.5-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This just updates two of the Goss tests to provide information on what to do in the case of test failure. No difference in the actual tests, so very low risk. Just a quality of life thing for anyone doing the health checks.

## Issues and Related PRs

* [Source PR](https://github.com/Cray-HPE/csm-testing/pull/510)
* Resolves [CASMINST-6538](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6538) for CSM 1.4
* Manifest PRs forthcoming for CSM 1.5 that include this along with some additional changes
