### PR TITLE
CASMCMS-8707 - fix arch of image upload after customization.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -182,7 +182,7 @@ spec:
             tag: 2.1.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.9.6
+    version: 3.9.7
     namespace: services
     swagger:
     - name: ims


### PR DESCRIPTION
## Summary and Scope

The build arch env variable was not being set in all containers for the IMS jobs kicked off. That meant that it was defaulting to 'x86_64' and in the case of customizing an 'aarch64' image, when complete it was getting incorrectly uploaded and labeled as an 'x86_64' image.

This adds the 'BUILD_ARCH' env variable to the job templates for the containers that was missing that variable. This will get set to the correct value when IMS templates the job and now flows through with the correct value.

Code PR: https://github.com/Cray-HPE/ims/pull/89

## Issues and Related PRs
* Resolves [CASMCMS-8707](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8707)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new IMS helm chart on Mug, then ran jobs to insure the correct values are getting picked up and set.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk change as it is just adding missing env vars to the various containers.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable