### PR TITLE
CASMINST-6538: Run CMS/HMS tests w/main Goss health check; add troubleshooting info to CMS/HMS test files

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.43-1.noarch
-    - goss-servers-1.16.43-1.noarch
+    - csm-testing-1.16.44-1.noarch
+    - goss-servers-1.16.44-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Simplify the CSM health validation procedure by moving the CMS and HMS CT tests into the main Goss automated test suite.
They already exist as Goss test, thanks to work done by Mikhail, so this just adds them to the main healthcheck suite.

## Issues and Related PRs

* [CASMINST-6538](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6538)
* [csm-testing source PR](https://github.com/Cray-HPE/csm-testing/pull/509)
* csm stable/1.5 backport PR
* csm 1.4.2 limited backport PR
* metal-provision main PR
* metal-provision lts/csm-1.5 PR
