### PR TITLE
Use locally built image, prevent slew of error'd pods if jobs failing (CASMPET-6676)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -228,7 +228,7 @@ spec:
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
-    version: 0.2.1
+    version: 0.2.2
     namespace: kube-system
   - name: cray-node-labels
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Use locally built image, change cronjob to not ddos with tons of error pods if backups fail.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6676

### Testing

ashton (before with config error):

```
pod/kube-etcdbackup-28149980-zs4jm     0/1     Completed                    0               34m
pod/kube-etcdbackup-28149990-rgl2m     0/1     CreateContainerConfigError   0               24m
pod/kube-etcdbackup-28150000-r4rjj     0/1     CreateContainerConfigError   0               14m
pod/kube-etcdbackup-28150008-h8vp4     0/1     CreateContainerConfigError   0               6m34s
pod/kube-etcdbackup-28150009-fjt4m     0/1     CreateContainerConfigError   0               5m34s
pod/kube-etcdbackup-28150010-2j6h8     0/1     CreateContainerConfigError   0               4m34s
pod/kube-etcdbackup-28150011-jmz9p     0/1     CreateContainerConfigError   0               3m34s
pod/kube-etcdbackup-28150012-fhr4p     0/1     CreateContainerConfigError   0               2m34s
pod/kube-etcdbackup-28150013-pnt7w     0/1     CreateContainerConfigError   0               94s
pod/kube-etcdbackup-28150014-47hrv     0/1     CreateContainerConfigError   0               34s
job.batch/kube-etcdbackup-28149980   1/1           14s        34m
job.batch/kube-etcdbackup-28149990   0/1           24m        24m
job.batch/kube-etcdbackup-28150000   0/1           14m        14m
job.batch/kube-etcdbackup-28150008   0/1           6m34s      6m34s
job.batch/kube-etcdbackup-28150009   0/1           5m34s      5m34s
job.batch/kube-etcdbackup-28150010   0/1           4m34s      4m34s
job.batch/kube-etcdbackup-28150011   0/1           3m34s      3m34s
job.batch/kube-etcdbackup-28150012   0/1           2m34s      2m34s
job.batch/kube-etcdbackup-28150013   0/1           94s        94s
job.batch/kube-etcdbackup-28150014   0/1           34s        34s
```

ashton (after with config error):

```
pod/kube-etcdbackup-28150099-25vlm     0/1     Completed                    0               3m13s
pod/kube-etcdbackup-28150102-vqdcl     0/1     CreateContainerConfigError   0               13s
job.batch/kube-etcdbackup-28150099   1/1           13s        3m13s
job.batch/kube-etcdbackup-28150101   0/1           73s        73s
job.batch/kube-etcdbackup-28150102   0/1           13s        13s
```

ashton (after recovered from config error):

```
pod/kube-etcdbackup-28150105-nqlx2     0/1     Completed   0               23s
job.batch/kube-etcdbackup-28150103   0/1           2m23s      2m23s
job.batch/kube-etcdbackup-28150105   1/1           13s        23s
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
