### PR TITLE
CASMHMS-5970 Add retries to BSS bootscript test cases

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,15 +36,15 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.1.3
+    version: 3.1.4
     namespace: services
     values:
         global:
-            appVersion: 1.25.1
+            appVersion: 1.26.0
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.25.1/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.26.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 4.0.2

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -38,9 +38,6 @@ spec:
     source: csm-algol60
     version: 3.1.4
     namespace: services
-    values:
-        global:
-            appVersion: 1.26.0
     swagger:
     - name: bss
       version: v1


### PR DESCRIPTION
### Summary and Scope

This PR adds retries to the bootscript CT test cases. Sometimes BSS returns a bootscript to re-attempt getting a bootscript, and this normally happens when BSS is syncing with HSM. Add retries to account for this.

### Issues and Related PRs

* Resolves [CASMHMS-5970](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5970).

### Testing

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, fixes an issue that only seems to occur in the hms-nightly-integration test runs.