### PR TITLE
CASMMON-331 Add kafka-connect dashboard in cray-sysmgmt-health

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.5
+    version: 0.28.6
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

_Dashboard for kafka-connect after implementation of the jmx-exporter in [CASMMON-330](https://jira-pro.it.hpe.com:8443/browse/CASMMON-330)._

## Issues and Related PRs

* Resolves [CASMMON-331](https://jira-pro.it.hpe.com:8443/browse/CASMMON-331)
* Merge after `<https://github.hpe.com/hpe/hpc-car-sma-kafka-connect/pull/17>`

## Testing

### Tested on:

  * `<mug>`
  * `<hela>`
  * Local development environment

### Test description:

_The changes tested and success verified._

https://grafana.cmn.mug.hpc.amslabs.hpecorp.net/d/connect/kafka-connect?orgId=1&refresh=10s

```
ncn-m001:/mnt/developer/sum # helm upgrade -n sma cp-kafka-connect cp-kafka-connect-1.4.0.tgz
Release "cp-kafka-connect" has been upgraded. Happy Helming!
NAME: cp-kafka-connect
LAST DEPLOYED: Thu Jul  6 05:32:58 2023
NAMESPACE: sma
STATUS: deployed
REVISION: 26
TEST SUITE: None
NOTES:
This chart installs a Confluent Kafka Connect

https://docs.confluent.io/current/connect/index.html
```

```
ncn-m001:/mnt/developer/sum # kubectl get all -n sma | grep connect
pod/cp-kafka-connect-c4dfdfb5c-26f8x                2/2     Running     0          2m49s
service/cp-kafka-connect                            ClusterIP      10.26.244.22    <none>         8083/TCP,5556/TCP              2m49s
deployment.apps/cp-kafka-connect               1/1     1            1           2m49s
replicaset.apps/cp-kafka-connect-c4dfdfb5c                1         1         1       2m49s
```

![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/110656037/8bdb9447-6a85-4b3e-900b-2602a68b93f7)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct