### PR TITLE
CASMTRIAGE-5647: Update cray-keycloak-users-localize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-keycloak-users-localize to 1.11.4 (CASMTRIAGE-5647 and CASMPET-6645)
 - Update cray-ims-load-artifacts to 2.6.0 (CASMCMS-8623)
 - Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Update cray-oauth2-proxies to 0.3.1 (CASMPET-6664)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.3
+    version: 1.11.4
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This changes the TTL for deletion of the keycloak-users-localize job so it no longer gets deleted automatically so the test for this job being done never fails, as well as changes the initial setup of LDAP on keycloak so the LDAP federation on keycloak is enabled at startup which allows all users to be seen right after sync instead of having an error.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5647](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5647)
* Resolves [CASMPET-6645](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6645)

## Testing

### Tested on:

  * Fanta

### Test description:

Ran the new version on fanta to check the ttl was correct in the new job and that the admin UI had users available after sync without disabling and enabling.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No risks or mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

