### PR TITLE
CASMPET-6554: update cray-externaldns to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-externaldns to 1.5.0 (CASMPET-6554)
 - Update cray-ims-load-artifacts to 2.6.0 (CASMCMS-8623)
 - Update cray-nexus-setup to 0.10.1 (CASM-4351)
 - Update cray-oauth2-proxies to 0.3.1 (CASMPET-6664)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -156,7 +156,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.4.1
+    version: 1.5.0
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update cray-externaldns to 1.5.0 for CVE remediation.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6554](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6554)
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `ashton`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

