### PR TITLE
CASMINST-6523: Create modified iPXE check that looks for either CSM 1.4 or CSM 1.5 style iPXE deployment

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.45-1.noarch
-    - goss-servers-1.16.45-1.noarch
+    - csm-testing-1.16.46-1.noarch
+    - goss-servers-1.16.46-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This corrects the iPXE check failure seen during 1.5 to 1.5 upgrades.

* See [source PR](https://github.com/Cray-HPE/csm-testing/pull/512) for details
* Resolves [CASMINST-6523](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6523)/[CASMINST-6541](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6541)
* [stable/1.5 backport](https://github.com/Cray-HPE/csm/pull/2561)
* [metal-provision main PR](https://github.com/Cray-HPE/metal-provision/pull/264)
* [metal-provision lts/csm-1.5 PR](https://github.com/Cray-HPE/metal-provision/pull/265)
