### PR TITLE
Add using spire tokens back to the node-heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-node-heartbeat to 2.1-3 (CASMTRIAGE-5649)
 - Update cray-keycloak-users-localize to 1.11.4 (CASMTRIAGE-5647 and CASMPET-6645)
 - Update cray-externaldns to 1.5.0 (CASMPET-6554)
 - Update cray-ims-load-artifacts to 2.6.0 (CASMCMS-8623)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64.rpm
     - cray-site-init-1.32.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.0-3.x86_64.rpm
+    - csm-node-heartbeat-2.1-3.x86_64.rpm
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - ilorest-4.2.0.0-20.x86_64
     - metal-ipxe-2.4.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

When the node heartbeat code was pulled over from the SKERN repos it was pulled over with SPIRE token use disabled. This mod puts the SPIRE token code back into place. The proper way to disable SPIRE token use is to modify the /etc/sysconfig/heartbeat file and set USE_TOKENS to true.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5649](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5649)

## Testing

TBD

### Tested on:

  * `drax`

### Test description:

Manually installed the RPM and verified that once the service started that ncn-s002 went to Ready in HSM.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - just tested on a single node, leaving it in place for now
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

