### PR TITLE
Bump version of csm-ipxe to pick up new helm-chart variable for undio…

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.11.4
+    version: 1.11.5
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
A new variable was exposed to the ipxe building processes, but was not exposed in a meaningful way through the helm chart values file. As a result, there was not a good way to programmatically inject the correct value in a non-interactive way.

## Issues and Related PRs
* Resolves [CASMCMS-8699](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8699)

## Risks and Mitigations

Low risk; this is a new variable to the values file.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
