### PR TITLE
CASMTRIAGE-5694: Update TTL to max int for users-localize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)
 - Update cray-keycloak-users-localize to 1.11.4 (CASMTRIAGE-5647 and CASMPET-6645)
 - Update cray-externaldns to 1.5.0 (CASMPET-6554)
 - Update cray-ims-load-artifacts to 2.6.0 (CASMCMS-8623)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.4
+    version: 1.11.5
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the TTL in keycloak-users-localize to max int so the job will not be deleted. This is needed to keep existing documentation and tests.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5694](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5694)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * drax

### Test description:

Tested install and upgrade. Small one line change to the ttlSecondsAfterFinished.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No risk only changes length of time for the job to be removed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

