### PR TITLE
CASMTRIAGE-5692 - HMNFD chart to 4.0.0, v1.19.0 for branch 1.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -68,12 +68,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.19.1/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 3.0.2
+    version: 4.0.0
     namespace: services
     swagger:
     - name: hmnfd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.18.1/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.19.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
     version: 2.16.1


### PR DESCRIPTION
## Summary and Scope

Updates HMNFD chart to 4.0.0 - This was updated in main several weeks ago, but not in branch stable/1.5

## Issues and Related PRs

* CASMTRIAGE-5692

## Testing

No testing - original PR was tested on release 1.5

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

