### PR TITLE
CASMPET-6650-stable/1.5 put ceph monitoring images needed in csm docker manifest 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)
 - Update cray-keycloak-users-localize to 1.11.4 (CASMTRIAGE-5647 and CASMPET-6645)
 - Update cray-externaldns to 1.5.0 (CASMPET-6554)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -69,13 +69,21 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Rebuilt third-party images below
 
-    # Required by ceph
-
+    # Required by ceph and ceph monitoring
     quay.io/ceph/ceph:
-      - v15.2.15
-      - v15.2.16
-      - v16.2.9
       - v17.2.6
+
+    quay.io/ceph/ceph-grafana:
+      - 9.4.7
+
+    quay.io/prometheus/prometheus:
+      - v2.43.0
+
+    quay.io/prometheus/node-exporter:
+      - v1.5.0
+
+    quay.io/prometheus/alertmanager:
+      - v0.25.0
 
     docker.io/portainer/kubectl-shell:
       - latest-v1.21.1-amd64


### PR DESCRIPTION
## Summary and Scope

Include container images needed for storage node in csm docker manifest. These will no longer be loaded locally on storage nodes but will be loaded into pit-nexus and regular nexus so that storage nodes don't need to run a local docker registry.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

