### PR TITLE
Include post services install suite in ncn-k8s-combined-healthcheck (CASMPET-6670)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.3-1.noarch
     - csm-ssh-keys-roles-1.5.3-1.noarch
-    - csm-testing-1.16.46-1.noarch
-    - goss-servers-1.16.46-1.noarch
+    - csm-testing-1.16.47-1.noarch
+    - goss-servers-1.16.47-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.5-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
### Summary and Scope

Add combined health check for use after CSM services are upgraded, but NCNs have not yet rolled by IUF management node rollout.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6670

### Testing

Drax (one expected failure):

```
ncn-m003:~ # /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck-post-service-upgrade

NCN and Kubernetes Checks (post CSM services upgrade)
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20230718_212313.352790-566853-ygO1buGe/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-m001.hmn:9008/ncn-healthcheck-master-single-post-service-upgrade
Test Name: Check hmnfd service
Description: Performs a basic health check on the hmnfd service. If this test fails, then manually run '/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t hmnfd' on the same node where the test failed. For more information, see 'troubleshooting/interpreting_hms_health_check_results.md' in the CSM documentation.
Test Summary: Command: hms-ct-test-hmnfd: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000020071 seconds
Node: ncn-m001



GRAND TOTAL: 679 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
