### PR TITLE
CASM-4467 stable 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update iuf to 0.1.11; cray-nls and cray-iuf to 3.1.8
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)
 - Update cray-keycloak-users-localize to 1.11.4 (CASMTRIAGE-5647 and CASMPET-6645)
@@ -15,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add acpid to 2.0.31-2.0 (MTL-2019)
 - Update cray-dhcp-kea to 0.10.24 (CASMNET-2095)
 - Update cray-keycloak to 5.0.3 (CASMTRIAGE-5527)
-- Update iuf to 0.1.10; cray-nls and cray-iuf to 4.0.0; downgrade argoexec to v3.3.6 (CASM-4352)
+- Update iuf to 0.1.10; cray-nls and cray-iuf to 3.1.7; downgrade argoexec to v3.3.6 (CASM-4352)
 - Update cray-powerdns-manager to 0.8.1 (CASMNET-2122)
 - update cray-ims to 3.9.3 (CASMCMS-8624)
 - Update craycli to 0.82.2 (CASMCMS-8624)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,7 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.2.0
 
     iuf:
-    - v0.1.10
+    - v0.1.11
 
     # Rebuilt third-party images below
 

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.0
+    version: 3.1.8
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.0
+    version: 3.1.8
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

Cray-cli recently introduced a `-tenant` option as part of `cray init` command. When it was introduced, this `tenant` flag was required. However, this caused issues with existing scripts as none of them supplied the `-tenant` flag.

The `-tenant` flag was then made optional. However, the iuf-container image still used the version of cray-cli where the `-tenant` flag was required. This is causing issues in `deliver-product` and `deploy-product` stages.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4467](https://jira-pro.it.hpe.com:8443/browse/CASM-4467)
* Merge with/before/after:
   * https://github.com/Cray-HPE/cray-nls/pull/194
   * https://github.com/Cray-HPE/cray-nls/pull/193
   * https://github.com/Cray-HPE/cray-nls-charts/pull/57

## Testing

### Tested on:

  * Wasp
  * Surtur

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Ran IUF

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

