### PR TITLE
CASMCMS-8714/CASMCMS-8715: Fix CVEs in cfs-ara and cfs-operator

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -112,7 +112,7 @@ spec:
   # CMS
   - name: cfs-ara
     source: csm-algol60
-    version: 1.1.0
+    version: 1.1.1
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -149,7 +149,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.18.1
+    version: 1.18.2
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

### CASMCMS-8714

Snyk reported that cfs-ara is vulnerable to this CVE:
https://security.snyk.io/vuln/SNYK-PYTHON-DJANGO-5750790

This updates cfs-ara to a version where the Django module is pinned to a version with this CVE fixed.

### CASMCMS-8715
Snyk reported that cfs-operator is vulnerable to this CVE:
https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-5777683

This updates cfs-operator to a version where the cryptography module is pinned to a version with this CVE fixed.

## Issues and Related PRs

* [release/1.4 backport manifest PR](https://github.com/Cray-HPE/csm/pull/2589)
* [stable/1.5 backport manifest PR](https://github.com/Cray-HPE/csm/pull/2590)
* [release/1.6 backport manifest PR](https://github.com/Cray-HPE/csm/pull/2591)

* Resolves [CASMCMS-8714](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8714)
* Resolves [CASMCMS-8715](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8715)
* [`cfs-ara` source PR](https://github.com/Cray-HPE/cfs-ara/pull/13)
* [`cfs-operator` source PR](https://github.com/Cray-HPE/cfs-operator/pull/89)

