### PR TITLE
CASMPET-6696: Update cert-manager api to /v1/ usage

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,7 +144,7 @@ spec:
     namespace: ceph-rgw
   - name: cray-certmanager-issuers
     source: csm-algol60
-    version: 0.6.2
+    version: 0.6.3
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Since we have a /v1/ compliant cert-manager now, update usage of the certmanager api to /v1/ to be proactive about future updates which will remove all pre /v1/ api's entirely.

## Issues and Related PRs

CASMPET-6696

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

dorian

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta dorian

### Test description:

Installed on dorian and let the issuers refresh after a day or two and validated we no longer have any old api usage for this chart.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

n/a not backwards compatible with pre 1.5 as that cert-manager only has alpha apis.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

