### PR TITLE
CASMTRIAGE-5738 to release/1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-- Update iuf to 0.1.11; cray-nls and cray-iuf to 3.1.8
+- Revert csm-latest tag usage for iuf container image (CASMTRIAGE-5738)
+- Update iuf to 0.1.11; cray-nls and cray-iuf to 3.1.8 (CASM-4467)
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)
 - Update cray-keycloak-users-localize to 1.11.4 (CASMTRIAGE-5647 and CASMPET-6645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Revert csm-latest tag usage for iuf container image (CASMTRIAGE-5738)
+- Update iuf to 0.1.12 (CASMINST-6512)
 - Update iuf to 0.1.11; cray-nls and cray-iuf to 3.1.8 (CASM-4467)
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,7 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.2.0
 
     iuf:
-    - v0.1.11
+    - v0.1.12
 
     # Rebuilt third-party images below
 

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -63,12 +63,6 @@ sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
 sat_version="3.25.0"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
-# Tag iuf-container image as csm-latest
-iuf_image="artifactory.algol60.net/csm-docker/stable/iuf"
-# this comes from `iuf-containers/.github/workflows/iuf-container.yaml`
-iuf_version="v0.1.10"
-skopeo-copy "${iuf_image}:${iuf_version}" "${iuf_image}:csm-latest"
-
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 
 # Upload repository contents


### PR DESCRIPTION
## Summary and Scope

We reverted our use of `csm-latest` tag for iuf-containers image because csm-latest tag was having cache issues local a machine.

After we switched back to using hard-coded version tags, it turns out we were still configuring the infrastructure to use csm-latest. This caused some problems. This PR completely removes csm-latest tag for iuf from CSM.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5738](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5738)
* 
## Testing

### Tested on:

Not tested yet. Will be tested as part of CSM install

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

