### PR TITLE
CASMNET-2148: Bump cray-dhcp-kea to 0.10.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-dhcp-kea to 0.10.25
 - Update iuf to v0.1.11 (CASM-4467)
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -49,7 +49,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.24 # update platform.yaml cray-precache-images with this
+    version: 0.10.25 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.24
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.25
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.22
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.1


### PR DESCRIPTION
## Summary and Scope

CASMNET-1937 added the `-P 67` option to the Kea DHCP server startup.  This, as intended, prevented unprivileged users from launching a DHCP client and requesting an IPv4 address.  Unintended, however was the disruption of more than 50% of system DHCP clients in terms of unnecessary back-off and retry logic and the failure of some Mountain PXE clients to obtain an IPv4 address at all (as described in CAST-33296).

This change removes the `-P 67` option which allows DHCP to again function entirely properly.



## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-2148](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2148

## Testing

### Tested on:

* Surtur
* Hela - Aruba-based system.  DISCOVER and RENEW tested for all Mountain and River node types.
* Rocket - Dell/Mellanox-based system.  DISCOVER and RENEW tested for all node types.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

Removing the `-P 67` option re-opens the behavior that CASMNET-1937 was intended to prevent.  Follow-on [CASMNET-2150](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2150) will close this gap.  A per-spec and healthy DHCP across the system - provided by this fix - is of primary importance.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

