### PR TITLE
CASMTRIAGE-5735 - Exclude all internal networks from Unbound forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-dns-unbound to v0.7.23 (CASMTRIAGE-5735)
 - Update iuf to 0.1.11; cray-nls and cray-iuf to 3.1.8
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -55,11 +55,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.22 # update platform.yaml cray-precache-images with this
+    version: 0.7.23 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.22
+        appVersion: 0.7.23
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.24
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.22
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.1
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

If `cray-dns-unbound` cannot answer queries for `.cmn`, `.chn`, or `.can` from local data, the query will be forwarded to the configured upstream DNS server.

If the upstream DNS server is configured to drop queries for unknown zones or records this can result in bad behaviour as the query will timeout.

This PR configures Unbound to not forward the remainder of internal networks if an answer cannot be found in local data.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5735](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5735)

## Testing

### Tested on:

  * `brook`
  * `surtur`

### Test description:

Preflight check was failing on brook.
```
root@ncn-m001 2023-07-21 13:38:49 ~ # /opt/cray/tests/install/ncn/scripts/python/check_ncn_uan_ip_dns.py
2023-07-21 13:39:13,536 - __main__ - ERROR - ERROR: ncn-m003.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:39:49,661 - __main__ - ERROR - ERROR: ncn-w001.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:40:25,819 - __main__ - ERROR - ERROR: ncn-w002.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:41:01,959 - __main__ - ERROR - ERROR: ncn-w003.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:41:38,103 - __main__ - ERROR - ERROR: ncn-s001.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:42:14,231 - __main__ - ERROR - ERROR: uan001.cmn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:42:50,253 - __main__ - ERROR - ERROR: uan001.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:43:26,395 - __main__ - ERROR - ERROR: ncn-s002.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:44:02,521 - __main__ - ERROR - ERROR: ncn-s003.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:44:38,665 - __main__ - ERROR - ERROR: ncn-m001.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:45:14,797 - __main__ - ERROR - ERROR: ncn-m002.chn has more than 1 DNS entry
;; connection timed out; no servers could be reached

2023-07-21 13:45:32,819 - __main__ - ERROR - ERRORS: see above output.
root@ncn-m001 2023-07-21 13:45:32 ~ # 
```
After configuration change test now passes.
```
07/21 14:41 brook-ncn-m001:~ # /opt/cray/tests/install/ncn/scripts/python/check_ncn_uan_ip_dns.py
07/21 14:41 brook-ncn-m001:~ #
```
Performed further testing on surtur to validate config change does not impact FQDN resolution.
```
ncn-m001:~ # host ncn-m001.can
Host ncn-m001.can not found: 3(NXDOMAIN)

ncn-m001:~ # host ncn-m001.cmn
ncn-m001.cmn has address 10.102.67.27

ncn-m001:~ # host ncn-m001.cmn.surtur.hpc.amslabs.hpecorp.net
ncn-m001.cmn.surtur.hpc.amslabs.hpecorp.net is an alias for x3000c0s1b0n0.cmn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s1b0n0.cmn.surtur.hpc.amslabs.hpecorp.net has address 10.102.67.27
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

