### PR TITLE
CASMTRIAGE-5737-release/1.6 bump csm-testing and goss-servers version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers versiont to 1.16.48 (CASMTRIAGE-5737)
 - Update iuf to v0.1.11 (CASM-4467)
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-- Update csm-testing and goss-servers versiont to 1.16.48 (CASMTRIAGE-5737)
+- Update csm-testing and goss-servers version to 1.16.48 (CASMTRIAGE-5737)
 - Update iuf to v0.1.11 (CASM-4467)
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.4-1.noarch
     - csm-ssh-keys-roles-1.5.4-1.noarch
-    - csm-testing-1.16.47-1.noarch
-    - goss-servers-1.16.47-1.noarch
+    - csm-testing-1.16.48-1.noarch
+    - goss-servers-1.16.48-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.6.0-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope
Bump csm-testing and goss-servers version to include changes for CASMTRIAGE-5737-release/1.6
CASMTRIAGE-5737 fixes bugs in ceph-service-status.sh goss script.

## Testing

Tested on CSM-1.5 system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

