### PR TITLE
CASMTRIAGE-5737 release/1.4 bump csm-testing and goss-servers version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing and goss-servers version to 1.15.49 (CASMTRIAGE-5737)
 - Update iuf to v0.1.11; cray-nls and cray-iuf to 2.11.2 (CASM-4467)
 - Update cray-nls and cray-iuf to 2.11.1 (CASMTRIAGE-5568)
 - Update iuf to 0.1.10; cray-nls and cray-iuf to 2.11.0; downgrade argoexec to v3.3.6 (CASM-4352)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,9 +34,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.47-1.noarch
+    - csm-testing-1.15.49-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
-    - goss-servers-1.15.47-1.noarch
+    - goss-servers-1.15.49-1.noarch
     - iuf-cli-1.4.5-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Bump csm-testing and goss-servers version to include changes for CASMTRIAGE-5737-release/1.5
CASMTRIAGE-5737 fixes bugs in ceph-service-status.sh goss script.

## Testing

Tested on a CSM-1.4 system. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

