### PR TITLE
CASMPET-6260: Add goss test for nexus-keycloak integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers version to 1.17.1 (CASMPET-6260)
 - Update iuf to v0.1.11 (CASM-4467)
 - Put storage container images in docker/index.yaml (CASMPET-6650)
 - Update cray-keycloak-users-localize to 1.11.5 (CASMTRIAGE-5694)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.4-1.noarch
     - csm-ssh-keys-roles-1.5.4-1.noarch
-    - csm-testing-1.16.47-1.noarch
-    - goss-servers-1.16.47-1.noarch
+    - csm-testing-1.17.1-1.noarch
+    - goss-servers-1.17.1-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.6.0-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Adds a new test to check the config for nexus-keycloak plugin is correct to allow keycloak users to log into nexus.

## Issues and Related PRs

* Resolves [CASMPET-6260](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6260)

## Testing

### Tested on:

  * Mug

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

No risks


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

