### PR TITLE
CASMPET-6516 release/1.4 add ceph v16.2.13 to docker index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Include ceph image v16.2.13 in docker index (CASMPET-6516)
 - Update csm-testing and goss-servers version to 1.15.49 (CASMTRIAGE-5737)
 - Update cray-nls and cray-iuf to 2.11.3 (CASMTRIAGE-5738)
 - Update iuf to v0.1.11; cray-nls and cray-iuf to 2.11.2 (CASM-4467)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -75,6 +75,7 @@ artifactory.algol60.net/csm-docker/stable:
       - v15.2.15
       - v15.2.16
       - v16.2.9
+      - v16.2.13
 
     # XXX See also k8s.gcr.io/coredns:1.7.0 below
     docker.io/coredns/coredns:


### PR DESCRIPTION
## Summary and Scope
CASMPET-6516 add ceph v16.2.13 to docker index. This is needed for ceph to be upgraded, the local docker registry to be stopped, and smartmonitoring deployment on storage nodes.

https://github.com/Cray-HPE/docs-csm/pull/4046 is dependent on this image being present.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

