### PR TITLE
CASMPET-6516 release/1.3 add Ceph v16.2.13 to docker index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Include ceph image v16.2.13 in docker index (CASMPET-6516)
 - Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)
 - Update cray-dns-unbound to 0.7.21 (CASMNET-2121 CASMTRIAGE-5155)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -65,6 +65,7 @@ artifactory.algol60.net/csm-docker/stable:
       - v15.2.15
       - v15.2.16
       - v16.2.9
+      - v16.2.13
 
     # XXX See also k8s.gcr.io/coredns:1.7.0 below
     docker.io/coredns/coredns:


### PR DESCRIPTION
## Summary and Scope

CASMPET-6516 add ceph v16.2.13 to docker index. This is needed for ceph to be upgraded, the local docker registry to be stopped, and smartmonitoring deployment on storage nodes.

https://github.com/Cray-HPE/docs-csm/pull/4029 is dependent on this image being present in Nexus.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

