### PR TITLE
Add smart-mon rpm to 1.4 tarball (CASMINST-6561)

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -95,7 +95,8 @@ pipeline {
                                     rpm/cray/csm/sle-15sp3/index.yaml \
                                     rpm/cray/csm/sle-15sp3-compute/index.yaml \
                                     rpm/cray/csm/sle-15sp4/index.yaml \
-                                    rpm/cray/csm/sle-15sp4-compute/index.yaml
+                                    rpm/cray/csm/sle-15sp4-compute/index.yaml \
+                                    rpm/cray/csm/noos/index.yaml
                             """
                         }
                     }

--- a/hack/gen-rpm-index.sh
+++ b/hack/gen-rpm-index.sh
@@ -48,6 +48,7 @@ docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i arti.hpc.amslabs.hpecorp.net/int
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/mirror-HPE-SPP/SUSE_LINUX/SLES15-SP2/x86_64/current/                  hpe/SUSE_LINUX/SLES15-SP2/x86_64/current \
 -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                              cray/csm/sle-15sp3 \
 -d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                              cray/csm/sle-15sp3 \
+-d  https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/                                              cray/csm/noos \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                               cray/cos-2.3/sle15_sp3_ncn \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_ncn/                               cray/cos-2.1/sle15_sp2_ncn \
 -d  https://arti.hpc.amslabs.hpecorp.net/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                               cray/cos-2.2/sle15_sp3_ncn \

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -78,7 +78,8 @@ nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERS
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3-compute" "csm-${RELEASE_VERSION}-sle-15sp3-compute"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4"         "csm-${RELEASE_VERSION}-sle-15sp4"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute" "csm-${RELEASE_VERSION}-sle-15sp4-compute"
-nexus-upload raw "${ROOTDIR}/rpm/embedded" "csm-${RELEASE_VERSION}-embedded"
+nexus-upload raw "${ROOTDIR}/rpm/embedded"                   "csm-${RELEASE_VERSION}-embedded"
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/noos"              "csm-${RELEASE_VERSION}-noos"
 
 clean-install-deps
 

--- a/nexus-repositories.yaml
+++ b/nexus-repositories.yaml
@@ -119,3 +119,18 @@ group:
   memberNames:
   - csm-0.0.0-embedded
 
+---
+name: csm-0.0.0-noos
+format: raw
+storage:
+  blobStoreName: csm
+---
+name: csm-noos
+format: raw
+storage:
+  blobStoreName: csm
+type: group
+group:
+  memberNames:
+  - csm-0.0.0-noos
+

--- a/release.sh
+++ b/release.sh
@@ -163,6 +163,7 @@ rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp3/index.yaml" "${BUILDDIR}/rpm/cray/cs
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp3-compute/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp3-compute" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp4" -s
 rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp4-compute/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp4-compute" -s
+rpm-sync "${ROOTDIR}/rpm/cray/csm/noos/index.yaml" "${BUILDDIR}/rpm/cray/csm/noos" -s
 #rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp2/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp2" 
 #rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp2-compute/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp2-compute" 
 #rpm-sync "${ROOTDIR}/rpm/cray/csm/sle-15sp3/index.yaml" "${BUILDDIR}/rpm/cray/csm/sle-15sp3" 
@@ -198,6 +199,7 @@ createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp3"
 createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp3-compute"
 createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp4"
 createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp4-compute"
+createrepo "${BUILDDIR}/rpm/cray/csm/noos"
 
 # Extract docs RPM into release
 mkdir -p "${BUILDDIR}/tmp/docs"

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -1,0 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
+  rpms:
+    - smart-mon-1.0.3-1.noarch

--- a/validate.sh
+++ b/validate.sh
@@ -10,7 +10,7 @@ DEFAULT_HELM_REPO="csm"
 HELM_FILE="./helm/index.yaml"
 CONTAINER_FILE="./docker/index.yaml"
 
-RPM_INDEX_FILES="rpm/cray/csm/sle-15sp2/index.yaml rpm/cray/csm/sle-15sp2-compute/index.yaml rpm/cray/csm/sle-15sp3/index.yaml rpm/cray/csm/sle-15sp3-compute/index.yaml"
+RPM_INDEX_FILES="rpm/cray/csm/sle-15sp2/index.yaml rpm/cray/csm/sle-15sp2-compute/index.yaml rpm/cray/csm/sle-15sp3/index.yaml rpm/cray/csm/sle-15sp3-compute/index.yaml rpm/cray/csm/noos/index.yaml"
 
 HELM_REPOS_INFO="dist/validate/helm-repos.yaml"
 LOFTSMAN_MANIFESTS="manifests/*"


### PR DESCRIPTION
### Summary and Scope

Include smart-mon rpm in 1.4.2 patch

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6561

### Testing

Build output:

```
[2023-07-26T15:57:37.246Z] 2023-07-26 15:57:37,094	INFO	Adding password to password_mgr for https://artifactory.algol60.net/artifactory/

[2023-07-26T15:57:37.246Z] 2023-07-26 15:57:37,094	INFO	adding basic_auth_handler to opener

[2023-07-26T15:57:37.246Z] 2023-07-26 15:57:37,096	INFO	Reading https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/

[2023-07-26T15:57:37.510Z] 2023-07-26 15:57:37,288	INFO	https://artifactory.algol60.net/artifactory/ is the parent url of https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/

[2023-07-26T15:57:37.510Z] 2023-07-26 15:57:37,397	INFO	[200 OK] https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/smart-mon/noarch/smart-mon-1.0.3-1.noarch.rpm
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
