### PR TITLE
CASMTRIAGE-5650 Fix spire compute issue

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -239,7 +239,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.4.2
+    version: 1.5.0
     namespace: spire
 
   # Tapms service

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -763,6 +763,38 @@ spec:
           - '{{ kubernetes.sealed_secrets.keycloak_users_localize | toYaml }}'
       cray-hms-bss:
         addvertisAddress: http://{{ network.netstaticips.nmn_api_gw_local }}:8888
+        cray-service:
+          containers:
+            cray-bss:
+              env:
+              - name: HSM_URL
+                value: http://cray-smd
+              - name: NFD_URL
+                value: http://cray-hmnfd
+              - name: SPIRE_TOKEN_URL
+                value: https://cray-spire-tokens.spire:54440
+              - name: S3_ENDPOINT
+                valueFrom:
+                  secretKeyRef:
+                    key: http_s3_endpoint
+                    name: bss-s3-credentials
+              - name: S3_BUCKET
+                value: boot-image
+              - name: S3_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    key: access_key
+                    name: bss-s3-credentials
+              - name: S3_SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    key: secret_key
+                    name: bss-s3-credentials
+              - name: BSS_ADVERTISE_ADDRESS
+                valueFrom:
+                  configMapKeyRef:
+                    key: addvertisAddress
+                    name: bss-env-config
       gatekeeper-policy-manager:
         gatekeeper-policy-manager:
           externalAuthority: opa-gpm.cmn.{{ network.dns.external }}


### PR DESCRIPTION
This bumps spire-server to 1.5.0 in order to fix the spire TLS problem. It also overrides the cray-bss env variables. Due to how the cray-service chart works we need to add the entire set of env variables. This will break if any default env variables change.