### PR TITLE
CASMMON-334 Stop the flood of useless Apparmor messages for node-exporter pod - release/1.5

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.5
+    version: 0.28.7
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

_Impacted NCN-{M,W} console logs as they are filled with AppArmor errors. Critical bug fix._
_Backwards compatible bugfix._

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMMON-334](https://jira-pro.it.hpe.com:8443/browse/CASMMON-334)
* [CAST-33453](https://jira-pro.it.hpe.com:8443/browse/CAST-33453)
* cray-sysmgmt-health PRs - https://github.com/Cray-HPE/cray-sysmgmt-health/pull/127 and https://github.com/Cray-HPE/cray-sysmgmt-health/pull/126
* Change will also be needed in `<release/1.4>`

## Testing

### Tested on:

  * `<mug>`
  * Local development environment
  * Virtual Shasta

### Test description:

_Tested successfully and no dmesg errors were seen or audit logs created after the changes._
- Upgrade tested.

Latest chart from PR -
```
ncn-m001:/mnt/developer/sum # helm list -A | grep cray-sys
cray-sysmgmt-health                     sysmgmt-health  1               2023-07-31 10:00:54.455706616 +0000 UTC deployed        cray-sysmgmt-health-0.28.7-20230731093243+69172b3       45.1.1
```
podAnnotations is seen -
```
ncn-m001:/mnt/developer/sum # kubectl describe pod -n sysmgmt-health cray-sysmgmt-health-prometheus-node-exporter-kdttv
Name:         cray-sysmgmt-health-prometheus-node-exporter-kdttv
Namespace:    sysmgmt-health
Priority:     0
Node:         ncn-m001/10.252.1.4
Start Time:   Mon, 31 Jul 2023 10:02:20 +0000
Labels:       app.kubernetes.io/component=metrics
              app.kubernetes.io/instance=cray-sysmgmt-health
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=prometheus-node-exporter
              app.kubernetes.io/part-of=prometheus-node-exporter
              app.kubernetes.io/version=1.5.0
              controller-revision-hash=78874c4c8b
              helm.sh/chart=prometheus-node-exporter-4.8.1
              jobLabel=node-exporter
              pod-template-generation=2
              release=cray-sysmgmt-health
Annotations:  cluster-autoscaler.kubernetes.io/safe-to-evict: true
              **container.apparmor.security.beta.kubernetes.io/node-exporter: unconfined**
              kubernetes.io/psp: cray-sysmgmt-health-prometheus-node-exporter
```
No errors seen -
```
ncn-m001:/mnt/developer/sum # dmesg -T | tail -5
[Mon Jul 31 10:00:01 2023] weave: port 2(vethweplc6b48c6) entered blocking state
[Mon Jul 31 10:00:01 2023] weave: port 2(vethweplc6b48c6) entered forwarding state
[Mon Jul 31 10:00:01 2023] weave: port 4(vethweplcc55234) entered blocking state
[Mon Jul 31 10:00:01 2023] weave: port 4(vethweplcc55234) entered forwarding state
[Mon Jul 31 10:00:01 2023] IPv6: ADDRCONF(NETDEV_CHANGE): vethweplcc55234: link becomes ready
```
No audit logs generated -
```
ncn-m001:/mnt/developer/sum # ls /var/log/audit
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable