### PR TITLE
CASMTRIAGE-5781 Remove iuf:csm-latest tag from IUF images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Remove iuf:csm-latest tag from IUF images (CASMTRIAGE-5781)
 - Include ceph image v16.2.13 in docker index (CASMPET-6516)
 - Update csm-testing and goss-servers version to 1.15.49 (CASMTRIAGE-5737)
 - Update cray-nls and cray-iuf to 2.11.3 (CASMTRIAGE-5738)

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -63,12 +63,6 @@ sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
 sat_version="3.21.6"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
-# Tag iuf-container image as csm-latest
-iuf_image="artifactory.algol60.net/csm-docker/stable/iuf"
-# this comes from `iuf-containers/.github/workflows/iuf-container.yaml`
-iuf_version="v0.1.10"
-skopeo-copy "${iuf_image}:${iuf_version}" "${iuf_image}:csm-latest"
-
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 
 # Upload repository contents


### PR DESCRIPTION
## Summary and Scope

We removed the concept of `csm-latest` for IUF but unfortunately I did not update setup-nexus.sh in the 1.4.2 branch. Other branches were updated.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5781](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5781)

## Testing

### Tested on:

Was previously tested with other release branches.

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x ] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

