### PR TITLE
CASMTRIAGE-5758: fix a bug in postgres_pods_running.sh script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers version to 1.17.2 (CASMTRIAGE-5758)
 - Update csm-testing and goss-servers version to 1.17.1 (CASMPET-6260)
 - Update cray-dns-unbound to v0.7.23 (CASMTRIAGE-5735)
 - Revert csm-latest tag usage for iuf container image (CASMTRIAGE-5738)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.5-1.noarch
     - csm-ssh-keys-roles-1.5.5-1.noarch
-    - csm-testing-1.17.1-1.noarch
-    - goss-servers-1.17.1-1.noarch
+    - csm-testing-1.17.2-1.noarch
+    - goss-servers-1.17.2-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.6.0-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Fix a bug in postgres_pods_running.sh script.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5758](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5758)

## Testing

### Tested on:

  * `drax`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

