### PR TITLE
CASMHMS-6066 Updated hpe-csm-scripts for improved vshasta support

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -38,7 +38,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.17.2-1.noarch
     - goss-servers-1.17.2-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
-    - hpe-csm-scripts-0.6.0-1.noarch
+    - hpe-csm-scripts-0.6.1-1.noarch
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
     - iuf-cli-1.5.3-1.x86_64


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMHMS-6066](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6066)

#### Issue Type

- Bugfix Pull Request

The HMS REDS service is not needed and therefore does not run in vShasta. This change skips the REDS CT when we are executing in vShasta.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [X] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [X] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency

Executed the script to show that the REDS CT ran. Touched the /etc/google_system file and re-ran showing that the REDS CT was skipped. Removed /etc/google_system file and the REDS CT again executed.
 
### Risks and Mitigations
 
No known risks