### PR TITLE
CASMPET-6731 add Ceph v16.2.13 to CSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Add Ceph version v16.2.13 to docker index.yaml (CASMPET-6731)
 - Update cray-dhcp-kea to 0.10.25
 - Update csm-testing and goss-servers version to 1.16.49 (CASMTRIAGE-5758)
 - Update csm-testing and goss-servers version to 1.16.48 (CASMTRIAGE-5737)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -71,6 +71,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Required by ceph and ceph monitoring
     quay.io/ceph/ceph:
+      - v16.2.13
       - v17.2.6
 
     quay.io/ceph/ceph-grafana:


### PR DESCRIPTION
## Summary and Scope
This is needed in CSM-1.5 in case the CSM-1.4.2 patch was not picked up on a system.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

