### PR TITLE
CASMTRIAGE-5815 - Update Prometheus URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-kiali to 0.5.2 (CASMTRIAGE-5815)
 - Update cray-dhcp-kea to 0.10.25
 - Update csm-testing and goss-servers version to 1.17.2 (CASMTRIAGE-5758)
 - Update csm-testing and goss-servers version to 1.17.1 (CASMPET-6260)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -152,7 +152,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.5.1
+    version: 0.5.2
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

CSM 1.5 changes the name of the configured Prometheus instance.

```
ncn-m001:~ # kubectl get prometheus -A
NAMESPACE        NAME                              VERSION   DESIRED   READY   RECONCILED   AVAILABLE   AGE
sysmgmt-health   cray-sysmgmt-health-kube-p-prom   v2.41.0   2         4       True         True        24h
```

Kiali is configured to use the old name

```
ncn-m001:~ # kubectl -n istio-system get kiali -o yaml | yq4 eval '.. | select(has("prometheus"))'
grafana:
  url: https://grafana.cmn.fanta.hpc.amslabs.hpecorp.net/
prometheus:
  url: http://cray-sysmgmt-health-promet-prometheus.sysmgmt-health:9090
tracing:
  enabled: false
```

The end result is that many of the GUI functions do not work correctly as Kiali cannot connect to Prometheus.

This PR corrects the Prometheus URL used by Kiali

## Issues and Related PRs

* Resolves [CASMTRIAGE-5815](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5815)

## Testing

### Tested on:

  * `fanta`

### Test description:

Installed new chart on fanta
```
ncn-m001:~/cspiller # loftsman ship --manifest-path ./deploy.yaml
2023-08-05T10:01:48Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-08-05T10:01:48Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-08-05T10:01:48Z INF Ensuring that the loftsman namespace exists command=ship
2023-08-05T10:01:48Z INF Running a release for the provided manifest at ./deploy.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-kiali v0.5.2-20230805094426+2bd5291
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-08-05T10:01:48Z INF Found value overrides for chart, applying:
externalAuthority: kiali-istio.cmn.fanta.hpc.amslabs.hpecorp.net
kiali-operator:
  cr:
    spec:
      external_services:
        grafana:
          url: https://grafana.cmn.fanta.hpc.amslabs.hpecorp.net/
 chart=cray-kiali command=ship namespace=operators version=0.5.2-20230805094426+2bd5291
2023-08-05T10:01:48Z INF Running helm install/upgrade with arguments: upgrade --install cray-kiali cray-kiali-0.5.2-20230805094426+2bd5291.tgz --namespace operators --create-namespace --set global.chart.name=cray-kiali --set global.chart.version=0.5.2-20230805094426+2bd5291 -f /tmp/loftsman-1691229708/cray-kiali-values.yaml chart=cray-kiali command=ship namespace=operators version=0.5.2-20230805094426+2bd5291
2023-08-05T10:01:49Z INF Release "cray-kiali" does not exist. Installing it now.
NAME: cray-kiali
LAST DEPLOYED: Sat Aug  5 10:01:48 2023
NAMESPACE: operators
STATUS: deployed
REVISION: 1
TEST SUITE: None
 chart=cray-kiali command=ship namespace=operators version=0.5.2-20230805094426+2bd5291
2023-08-05T10:01:49Z INF Ship status: success. Recording status, manifest to configmap loftsman-cspiller-kiali in namespace loftsman command=ship
2023-08-05T10:01:49Z INF Recording log data to configmap loftsman-cspiller-kiali-ship-log in namespace loftsman command=ship
```
Vefified Kiali was configured with correct Prometheus URL
```
ncn-m001:~/cspiller # kubectl -n istio-system get kiali -o yaml | yq4 eval '.. | select(has("prometheus"))'
grafana:
  url: https://grafana.cmn.fanta.hpc.amslabs.hpecorp.net/
prometheus:
  url: http://cray-sysmgmt-health-kube-p-prometheus.sysmgmt-health:9090
tracing:
  enabled: false
```
Verified Kiali GUI now works as expected

![image](https://github.com/Cray-HPE/cray-kiali/assets/86013738/265e9b45-06f8-4393-ae34-d96a67a0dd1f)

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

