### PR TITLE
CASMTRIAGE-5685 PostgeSQL backup test failure in vShasta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers version to 1.17.3 (CASMTRIAGE-5685)
 - Update cray-dhcp-kea to 0.10.25
 - Update csm-testing and goss-servers version to 1.17.2 (CASMTRIAGE-5758)
 - Update csm-testing and goss-servers version to 1.17.1 (CASMPET-6260)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.5-1.noarch
     - csm-ssh-keys-roles-1.5.5-1.noarch
-    - csm-testing-1.17.2-1.noarch
-    - goss-servers-1.17.2-1.noarch
+    - csm-testing-1.17.3-1.noarch
+    - goss-servers-1.17.3-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.6.1-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Fix PostgeSQL backup tests by providing `CRAY_CREDENTIALS` for `cray` CLI utility.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5685](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5685)

## Testing
### Tested on:

  *`yasha`

### Test description:

Ran test script on vShasta env.

## Risks and Mitigations

Low - test modification only.
