### PR TITLE
CASMTRIAGE-5685 PostgeSQL backup test failure in vShasta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers version to 1.16.50 (CASMTRIAGE-5685)
 - Add Ceph version v16.2.13 to docker index.yaml (CASMPET-6731)
 - Update cray-dhcp-kea to 0.10.25
 - Update csm-testing and goss-servers version to 1.16.49 (CASMTRIAGE-5758)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.4-1.noarch
     - csm-ssh-keys-roles-1.5.4-1.noarch
-    - csm-testing-1.16.49-1.noarch
-    - goss-servers-1.16.49-1.noarch
+    - csm-testing-1.16.50-1.noarch
+    - goss-servers-1.16.50-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.6-1.noarch
     - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Backport of https://github.com/Cray-HPE/csm/pull/2661 for `release/1.5`.