### PR TITLE
CASMCMS-8753/CASMCMS-8755: BOS bug fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,13 +128,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.5.4
+    version: 2.5.5
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.5.4/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.5.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.13.2

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.5.4-1.noarch
+    - bos-reporter-2.5.5-1.noarch
     - canu-1.7.4-1.x86_64
     - cf-ca-cert-config-framework-2.6.0-1.noarch
     - cfs-debugger-1.4.0-1.noarch

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
-    - bos-reporter-2.5.4-1.noarch
+    - bos-reporter-2.5.5-1.noarch
     - cf-ca-cert-config-framework-2.6.0-1.noarch
     - cfs-debugger-1.4.0-1.noarch
     - cfs-state-reporter-1.9.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

This updates to a BOS version with two bugs fixed (see next section).

## Issues and Related PRs

* Fixes [CASMCMS-8753](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8753): Update API spec to reflect that BOS sometimes populates the 'tenant' field with a null value
  * [Source PR for CASMCMS-8753](https://github.com/Cray-HPE/bos/pull/190)
* Fixes [CASMCMS-8755](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8755)/[CASMTRIAGE-5818](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5818): Some BOS components API calls fail due to syntax error
  * [Source PR for CASMCMS-8755/CASMTRIAGE-5818](https://github.com/Cray-HPE/bos/pull/192)
* [1.5 manifest PR](https://github.com/Cray-HPE/csm/pull/2668)
* [stable 1.5 manifest PR](https://github.com/Cray-HPE/csm/pull/2667)
* [1.6 metal-provision manifest PR](https://github.com/Cray-HPE/metal-provision/pull/346)
* [1.5 metal-provision manifest PR](https://github.com/Cray-HPE/metal-provision/pull/347)

## Testing

Tested on mug. See source PRs for details.

## Risks and Mitigations

Low risk. Changes are small, easily understood, and well tested. Plus, without this, BOS v2 is broken.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
