### PR TITLE
CASMTRIAGE-5817: Do not include csm-node-identity in list of packages updated on nodes by CFS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -208,7 +208,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.14
+    version: 1.15.15
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This reverts one part of a change made to csm-config. Specifically, it removes `csm-node-identity` from the list of packages that are updated on NCNs and Compute nodes by CFS. This is how it behaved prior to CSM 1.4.2.

The actual problem is not with CFS, it's with the `csm-node-identity` package. But for CSM 1.4.2, the simplest and least risky fix is to go back to how things were. For CSM 1.5, the newer version of that package does not seem to suffer from the same problem, so no need to revert the change in CFS there.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5817](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5817)
* [Source PR](https://github.com/Cray-HPE/csm-config/pull/167)

