### PR TITLE
Additional CASMTRIAGE-5788 fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -208,7 +208,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.15
+    version: 1.15.16
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
The `ncn_sysct.yml` playbook was not callable, it was completely messed up in the cherry-pick.
