### PR TITLE
Additional CASMTRIAGE-5788 Fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.13
+    version: 1.16.14
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
The `ncn_sysctl.yml` playbook had a syntax issue preventing hosts from being detected when invoked.
