### PR TITLE
Bump chart timeout for hnc-controller (CASMPET-6743)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -255,6 +255,7 @@ spec:
     source: csm-algol60
     version: 0.0.6
     namespace: hnc-system
+    timeout: 10m0s
   - name: cray-k8s-encryption
     source: csm-algol60
     version: 0.0.4


### PR DESCRIPTION
### Summary and Scope

This was noticed in vshasta, but would probably be good to add for safety on metal as well.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6743

### Testing

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
