### PR TITLE
CASMCMS-8756: Update BOS for database migration fix (1.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.5.5
+    version: 2.6.1
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Updates BOS to pull in a fix to the database key migration when upgrading BOS from a BOS version that has already run the migration once.

## Issues and Related PRs

* Resolves CASMCMS-8756

## Testing

### Tested on:

  * Mug

### Test description:

Tested repeat upgrades

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

