### PR TITLE
CRAYSAT-1751: Update sat version in CSM 1.4

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -29,7 +29,7 @@ quay.io:
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.6
+      - 3.21.7
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.6"
+sat_version="3.21.7"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION


## Summary and Scope

Update the version of cray-sat to 3.21.7 to resolve several CVEs reported by Snyk and VTN. See the sat changelog for details.

This same change is being made to the SAT 2.5 product stream.

## Issues and Related PRs

* Resolves [CRAYSAT-1751](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1751)
* Resolves [CRAYSAT-1752](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1752)
* The same change is made to the SAT 2.5 product stream here: https://github.com/Cray-HPE/sat-product-stream/pull/57/files

## Testing

See PR which create the new cray-sat version in the sat repository for testing details. Tested this new container version on mug.

## Risks and Mitigations

Low risk. This just pulls in newer dependencies to fix CVEs, and the new container image was tested on mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

