### PR TITLE
CASMTRIAGE-5835 - worker rebuild stuck at "canu validate network bgp --verbose"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers version to 1.16.52 (CASMTRIAGE-5835)
 - Update csm-testing and goss-servers version to 1.16.50 (CASMTRIAGE-5685)
 - Update cray-kiali to 0.5.2 (CASMTRIAGE-5815)
 - Add Ceph version v16.2.13 to docker index.yaml (CASMPET-6731)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -37,8 +37,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.1-3.aarch64
     - csm-node-heartbeat-2.1-3.x86_64
     - csm-node-identity-1.0.22-1.noarch
-    - csm-testing-1.16.51-1.noarch
-    - goss-servers-1.16.51-1.noarch
+    - csm-testing-1.16.52-1.noarch
+    - goss-servers-1.16.52-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - ilorest-4.2.0.0-20.x86_64


### PR DESCRIPTION
## Summary and Scope

In the event that the management network spine switch password is not set in vault, the guidance given by the `check_bgp_neighbors_established.sh` script contains a syntax error and fails.
```
20230809_142217_574952377 ## executable starting ##
###########################################################################
NAME DATA AGE
metallb 1 70d
CHN
No value found at secret/net-creds/switch_admin
command terminated with exit code 2
ERROR: Detected Vault is running. Missing switch admin password from vault. Please run the following commands:
VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r .data["vault-root"] | base64 -d)
alias vault="kubectl -n vault exec -i cray-vault-0 -c vault – env VAULT_TOKEN=\"$VAULT_PASSWD\" VAULT_ADDR=http://127.0.0.1:8200/
VAULT_FORMAT=json vault"
vault kv put secret/net-creds/switch_admin admin=SWITCH_ADMIN_PASSWORD
FAIL
###########################################################################
20230809_142218_831707098 ## executable completed (exit code=20) ##
```
The `jq` command to extract the vault-root token is missing quotes.
```
ncn-m001:~ # VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r .data["vault-root"] | base64 -d)
jq: error: vault/0 is not defined at <top-level>, line 1:
.data[vault-root]
jq: error: root/0 is not defined at <top-level>, line 1:
.data[vault-root]
jq: 2 compile errors
```

## Issues and Related PRs

* Resolves [CASMTRIAGE-5835](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5835)

## Testing

### Tested on:

  * `fanta`
  * Customer system `B`
  * surtur

### Test description:

```
ncn-m001:~/cspiller # ./check_bgp_neighbors_established.sh
NAME      DATA   AGE
metallb   1      8d
CHN
No value found at secret/net-creds/switch_admin
command terminated with exit code 2
ERROR: Detected Vault is running.  Missing switch admin password from vault.  Please run the following commands:
        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
        alias vault="kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=\"$VAULT_PASSWD\" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault"
        vault kv put secret/net-creds/switch_admin admin=SWITCH_ADMIN_PASSWORD
FAIL

ncn-m001:~/cspiller # VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
ncn-m001:~/cspiller # alias vault="kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=\"$VAULT_PASSWD\" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault"
ncn-m001:~/cspiller # vault kv put secret/net-creds/switch_admin admin=testpass
ncn-m001:~/cspiller # vault kv get secret/net-creds/switch_admin
{
  "request_id": "a7a2f1fc-4159-95ed-47dc-ac0347b97a1b",
  "lease_id": "",
  "lease_duration": 2764800,
  "renewable": false,
  "data": {
    "admin": "testpass"
  },
  "warnings": null
}
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

