### PR TITLE
hpe-yq publishes to noos

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -41,6 +41,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - goss-servers-1.17.4-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.6.2-1.noarch
+    - hpe-yq-4.33.3-1.aarch64
+    - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,7 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cfs-debugger-1.4.0-1.noarch
     - cfs-state-reporter-1.9.3-1.noarch
     - cfs-trust-1.6.7-1.noarch
-    - hpe-yq-4.33.3-1.aarch64
-    - hpe-yq-4.33.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,8 +29,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.7-1.noarch
     - csm-ssh-keys-1.5.5-1.noarch
     - csm-ssh-keys-roles-1.5.5-1.noarch
-    - hpe-yq-4.33.3-1.aarch64
-    - hpe-yq-4.33.3-1.x86_64
     - iuf-cli-1.5.3-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -29,5 +29,3 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
     - cfs-trust-1.6.7-1.noarch
     - csm-ssh-keys-1.5.5-1.noarch
     - csm-ssh-keys-roles-1.5.5-1.noarch
-    - hpe-yq-4.33.3-1.aarch64
-    - hpe-yq-4.33.3-1.x86_64


### PR DESCRIPTION
hpe-yq now publishes to noos, which did not require a version change. sle-15sp5, sle-15sp4, and sle-15sp3 still have hpe-yq-4.33.0 but are no longer receiving updates.
