### PR TITLE
CASMTRIAGE-5798 release/1.5 update iuf-cli rpm to remove recursion error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update iuf-cli rpm to 1.5.4 (CASMTRIAGE-5798)
 - Update csm-testing and goss-servers version to 1.16.50 (CASMTRIAGE-5685)
 - Update cray-kiali to 0.5.2 (CASMTRIAGE-5815)
 - Add Ceph version v16.2.13 to docker index.yaml (CASMPET-6731)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -31,6 +31,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-roles-1.5.4-1.noarch
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
-    - iuf-cli-1.5.3-1.x86_64
+    - iuf-cli-1.5.4-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-3.x86_64


### PR DESCRIPTION
## Summary and Scope

Update iuf-cli rpm to remove recursion error when bootprep directory and media directory are the same.

## Issues and Related PRs

* Resolves CASMTRIAGE-5798
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

