### PR TITLE
CASMTRIAGE-5798 release/1.4 update iuf-cli rpm to remove recursion error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-
+- Update iuf-cli rpm to 1.4.6 (CASMTRIAGE-5798)
 - Update cray-dns-unbound to v0.7.23 (CASMTRIAGE-5735,CASMTRIAGE-5805)
 - Update cray-dhcp-kea to 0.10.25
 - Remove iuf:csm-latest tag from IUF images (CASMTRIAGE-5781)

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -37,7 +37,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-testing-1.15.49-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - goss-servers-1.15.49-1.noarch
-    - iuf-cli-1.4.5-1.x86_64
+    - iuf-cli-1.4.6-1.x86_64
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
     - metal-ipxe-2.2.14-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update IUF cli rpm. This change stops the possible recursion error that happens when the media dir and bootprep dir provided to IUF are the same.

## Issues and Related PRs

* Resolves CASMTRIAGE-5798

## Testing

Tested on Beau, CSM 1.4.

### Test description:

- Installed the iuf-cli rpm and saw that no recursion error occurred when the bootprep dir and media dir were the same.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

