### PR TITLE
CASMCMS-8691: Use noos CMS RPMs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.6
+    version: 1.6.8
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -134,7 +134,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.5.5/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.6.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.13.2
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.15
+    version: 1.16.16
     namespace: services
     values:
       cray-import-config:
@@ -201,7 +201,7 @@ spec:
             tag: 1.8.12
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.5.4
+    version: 1.5.6
     namespace: services
   - name: gitea
     source: csm-algol60

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -28,6 +28,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - bos-reporter-2.6.0-1.noarch
     - cani-0.1.0-1.x86_64
     - canu-1.7.5-1.x86_64
+    - cf-ca-cert-config-framework-2.6.1-1.noarch
+    - cfs-debugger-1.5.0-1.noarch
+    - cfs-state-reporter-1.9.4-1.noarch
+    - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.0-1.x86_64
     - cray-site-init-1.32.0-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
@@ -37,6 +41,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.1-3.aarch64
     - csm-node-heartbeat-2.1-3.x86_64
     - csm-node-identity-1.0.22-1.noarch
+    - csm-ssh-keys-1.5.6-1.noarch
+    - csm-ssh-keys-roles-1.5.6-1.noarch
     - csm-testing-1.16.52-1.noarch
     - goss-servers-1.16.52-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,8 +23,5 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cfs-debugger-1.4.0-1.noarch
-    - cfs-state-reporter-1.9.3-1.noarch
-    - cfs-trust-1.6.7-1.noarch
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,12 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - cf-ca-cert-config-framework-2.6.0-1.noarch
-    - cfs-debugger-1.4.0-1.noarch
-    - cfs-state-reporter-1.9.3-1.noarch
-    - cfs-trust-1.6.7-1.noarch
-    - csm-ssh-keys-1.5.4-1.noarch
-    - csm-ssh-keys-roles-1.5.4-1.noarch
     - iuf-cli-1.5.4-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -23,9 +23,3 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
-    - cf-ca-cert-config-framework-2.6.0-1.noarch
-    - cfs-debugger-1.4.0-1.noarch
-    - cfs-state-reporter-1.9.3-1.noarch
-    - cfs-trust-1.6.7-1.noarch
-    - csm-ssh-keys-1.5.4-1.noarch
-    - csm-ssh-keys-roles-1.5.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

This completes the work of converting the CMS team RPMs to `noos`. In a couple of cases, the associated services were bumped to keep the versions in sync, but they are functionally equivalent.

## Issues and Related PRs

- [CSM 1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/2704)
- [`metal-provision` CSM 1.5 manifest PR](https://github.com/Cray-HPE/metal-provision/pull/363)
- [`metal-provision` CSM 1.6 manifest PR](https://github.com/Cray-HPE/metal-provision/pull/364)
