### PR TITLE
CASM-4506: Bump version of iuf-cli for 1.6

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -29,6 +29,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-trust-1.6.7-1.noarch
     - csm-ssh-keys-1.5.5-1.noarch
     - csm-ssh-keys-roles-1.5.5-1.noarch
-    - iuf-cli-1.5.4-1.x86_64
+    - iuf-cli-1.6.0-1.x86_64
     - libcsm-0.0.4-1.noarch
     - loftsman-1.2.0-3.x86_64


### PR DESCRIPTION
## Summary and Scope

Changes to bump iuf-cli version to 1.6.0 for 1.6 release.

## Issues and Related PRs

* Resolves [CASM-4506](https://jira-pro.it.hpe.com:8443/browse/CASM-4506)

## Testing

TBD

### Tested on:

  * `mug`
  * Local development environment
  * Virtual Shasta

### Test description:

- Run iuf-cli and confirm changes are present.

## Risks and Mitigations

None


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

