### PR TITLE
CASMTRIAGE-5820: Update BOS to fix HSM arch queries (1.5)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.6.1
+    version: 2.6.2
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Updates BOS to fix an issue where it was incorrectly handling the arch field when it was unknown for components.

## Issues and Related PRs

* Resolves CASMTRIAGE-5820

## Testing

### Tested on:

  * fearne (Virtual Shasta)

### Test description:

- Ran a test session that was previously failing

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

