### PR TITLE
CASM-3981: Bump cray-product-catalog version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-product-catalog version to 1.9.0 (CASM-3981)
 - Update iuf-cli rpm to 1.5.4 (CASMTRIAGE-5798)
 - Update csm-testing and goss-servers version to 1.16.52 (CASMTRIAGE-5835)
 - Update csm-testing and goss-servers version to 1.16.50 (CASMTRIAGE-5685)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -198,5 +198,6 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.3.1
       - 1.3.2
       - 1.8.12
+      - 1.9.0
     cray-nexus-setup:
       - 0.10.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -214,7 +214,7 @@ spec:
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version: 1.8.12
+    version: 1.9.0
     namespace: services
 
   # Cray UAS Manager service


### PR DESCRIPTION
## Summary and Scope

Changes to bump cray-product-catalog version 10 1.9.0

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-3981](https://jira-pro.it.hpe.com:8443/browse/CASM-3981)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `lemondrop`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

