### PR TITLE
CASMCMS-8743 - include MTL compute image in barebones install.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -167,13 +167,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.1.0
+    version: 2.3.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.1.0
+            tag: 2.3.0
   - name: cray-ims
     source: csm-algol60
     version: 3.9.8


### PR DESCRIPTION
## Summary and Scope

This includes the MTL compute images in the barebones install package. It looks in the current csm manifest and pulls the compute image version from there, then downloads the compute images and builds them into the manifest file. There were changes in the ims-load-artifacts image to templatize the bos kernel parameters and cray-kiwi-image-recipe to fix creating bos v2 session templates for the images being uploaded.

Code PR: https://github.com/Cray-HPE/image-recipes/pull/64

## Issues and Related PRs
* Resolves [CASMCMS-8743](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8743)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the new version via helm, insured the artifacts ended up where they were supposed to be, were added to the cray product catalog, had the bos session templates created, and booted the compute nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change - just adding 2 images to the install process.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
