### PR TITLE
CASMTRIAGE-5846: csm-config: Change sysctl_set var to be dynamic depending on where it is executed

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.16
+    version: 1.16.17
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Manifest PR requested by Dennis to use Michael's csm-config changes.