### PR TITLE
noos iuf-cli; new libcsm and csi

### DIFF
--- a/rpm/cloud-init.yaml
+++ b/rpm/cloud-init.yaml
@@ -5,21 +5,22 @@
 # nexus in either context.
 # The `packages` URL resolves to the PIT nexus and the Kubernetes nexus when in a bootstrap
 # and runtime environment (respectively).
-repos:
-  - id: csm-noos
-    name: csm-noos
-    baseurl: "https://packages/repository/csm-noos?ssl_verify=no"
-    enabled: 1
-    autorefresh: 1
-    gpgcheck: 0
-  # Use Zypper friendly variables so the correct service pack repository is added.
-  # NEVER force add a distro repository, or packages that do care about the distro version can break.
-  - id: csm-sle
-    name: "csm-sle-${releasever_major}sp${releasever_minor}"
-    baseurl: "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no"
-    enabled: 1
-    autorefresh: 1
-    gpgcheck: 0
+zypper:
+  repos:
+    - id: csm-noos
+      name: csm-noos
+      baseurl: "https://packages/repository/csm-noos?ssl_verify=no"
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: 0
+    # Use Zypper friendly variables so the correct service pack repository is added.
+    # NEVER force add a distro repository, or packages that do care about the distro version can break.
+    - id: csm-sle
+      name: "csm-sle-${releasever_major}sp${releasever_minor}"
+      baseurl: "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no"
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: 0
 # List of packages to install. These do not need version pins, because the latest version in nexus is determined by this
 # tarball. Version pinning here would be redundant, and likely lead to more failures if anyone neglected updating it.
 packages:

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.9.4-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
-    - cray-site-init-1.32.1-1.x86_64
+    - cray-site-init-1.32.2-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.82.9-1.aarch64
     - craycli-0.82.9-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.9.4-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
-    - cray-site-init-1.32.0-1.x86_64
+    - cray-site-init-1.32.1-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.82.9-1.aarch64
     - craycli-0.82.9-1.x86_64
@@ -50,6 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
+    - iuf-cli-1.6.1-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-ipxe-2.4.4-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.1-1.x86_64
+    - iuf-cli-1.6.2-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-ipxe-2.4.4-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,5 +23,5 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - libcsm-0.0.4-1.noarch
+    - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,6 +23,5 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - iuf-cli-1.5.4-1.x86_64
-    - libcsm-0.0.4-1.noarch
+    - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -23,3 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
+    - libcsm-0.0.5-1.noarch
+    - loftsman-1.2.0-3.x86_64
+


### PR DESCRIPTION
MTL-2000 is failing to find iuf-cli and libcsm in sle-15sp5 and noos.

This pulls in a new iuf-cli that publishes to noos, as well as a new libcsm that publishes to sp3/sp4/sp5.

Additionally CSI was tested again with MTL-2000 and needed some minor tweaks to how it patches the data structure.

This also copies loftsman into the sp5 index.yaml file for sp5, as it also publishes for 3/4/5 (it should be switched to noos soon).
