### PR TITLE
CASMHMS-6084: Correct HSM swagger spc for node Arch

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.9.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.10.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 2.0.3


### PR DESCRIPTION
## Summary and Scope

The HSM swagger spec incorrectly had `Unknown` in the Arch enum when it should be `UNKNOWN`.

## Issues and Related PRs

* Resolves [CASMHMS-6084](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6084)

## Testing

Swagger only change

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

