### PR TITLE
Fix etcd balance test -- explicitly ask for columns from kubectl (CASMTRIAGE-5885)

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -56,7 +56,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.2.3-1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - pit-init-1.4.2-1.noarch
-    - platform-utils-1.6.3-1.noarch
+    - platform-utils-1.6.4-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.8.aarch64
     - spire-agent-1.5.5-1.8.x86_64


### PR DESCRIPTION
### Summary and Scope

Change kubectl parsing and not rely on column order.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5885

### Testing (baldar)

```
ncn-m001:~ # /opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_cluster_balance
**************************************************************************

=== Check the Number of Pods in Each Cluster. Verify they are Balanced. ===
=== Each cluster should contain at least three pods, but may contain more. ===
=== Ensure that no two pods in a given cluster exist on the same worker node. ===
Wed 16 Aug 2023 08:38:02 PM UTC
cray-bos-bitnami-etcd-0                                           2/2     Running            0                  23h     10.32.0.23    ncn-w003   <none>           <none>
cray-bos-bitnami-etcd-1                                           2/2     Running            0                  23h     10.36.0.27    ncn-w001   <none>           <none>
cray-bos-bitnami-etcd-2                                           2/2     Running            0                  23h     10.40.0.17    ncn-w004   <none>           <none>

cray-bss-bitnami-etcd-0                                           2/2     Running            0                  23h     10.32.0.36    ncn-w003   <none>           <none>
cray-bss-bitnami-etcd-1                                           2/2     Running            0                  23h     10.36.0.33    ncn-w001   <none>           <none>
cray-bss-bitnami-etcd-2                                           2/2     Running            0                  24h     10.40.0.29    ncn-w004   <none>           <none>

cray-fas-bitnami-etcd-0                                           2/2     Running            0                  23h     10.36.0.5     ncn-w001   <none>           <none>
cray-fas-bitnami-etcd-1                                           2/2     Running            0                  23h     10.39.0.41    ncn-w002   <none>           <none>
cray-fas-bitnami-etcd-2                                           2/2     Running            0                  23h     10.40.0.8     ncn-w004   <none>           <none>

cray-hbtd-bitnami-etcd-0                                          2/2     Running            0                  23h     10.39.0.39    ncn-w002   <none>           <none>
cray-hbtd-bitnami-etcd-1                                          2/2     Running            0                  23h     10.36.0.46    ncn-w001   <none>           <none>
cray-hbtd-bitnami-etcd-2                                          2/2     Running            0                  23h     10.40.0.16    ncn-w004   <none>           <none>

cray-hmnfd-bitnami-etcd-0                                         2/2     Running            0                  23h     10.36.0.7     ncn-w001   <none>           <none>
cray-hmnfd-bitnami-etcd-1                                         2/2     Running            0                  23h     10.32.0.19    ncn-w003   <none>           <none>
cray-hmnfd-bitnami-etcd-2                                         2/2     Running            0                  23h     10.40.0.21    ncn-w004   <none>           <none>

cray-power-control-bitnami-etcd-0                                 2/2     Running            1 (20h ago)        20h     10.40.0.87    ncn-w004   <none>           <none>
cray-power-control-bitnami-etcd-1                                 2/2     Running            1 (20h ago)        20h     10.32.0.24    ncn-w003   <none>           <none>
cray-power-control-bitnami-etcd-2                                 2/2     Running            1 (20h ago)        20h     10.36.0.11    ncn-w001   <none>           <none>

cray-uas-mgr-bitnami-etcd-0                                       2/2     Running            0                  23h     10.32.0.11    ncn-w003   <none>           <none>
cray-uas-mgr-bitnami-etcd-1                                       2/2     Running            0                  23h     10.36.0.28    ncn-w001   <none>           <none>
cray-uas-mgr-bitnami-etcd-2                                       2/2     Running            0                  23h     10.40.0.77    ncn-w004   <none>           <none>

 --- PASSED ---

ncn-m001:~ # /opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_cluster_balance | tail
cray-power-control-bitnami-etcd-0                                 2/2     Running            1 (20h ago)      20h     10.40.0.87    ncn-w004   <none>           <none>
cray-power-control-bitnami-etcd-1                                 2/2     Running            1 (20h ago)      20h     10.32.0.24    ncn-w003   <none>           <none>
cray-power-control-bitnami-etcd-2                                 2/2     Running            1 (20h ago)      20h     10.36.0.11    ncn-w001   <none>           <none>

cray-uas-mgr-bitnami-etcd-0                                       2/2     Running            0                23h     10.32.0.11    ncn-w003   <none>           <none>
cray-uas-mgr-bitnami-etcd-1                                       2/2     Running            0                23h     10.36.0.28    ncn-w001   <none>           <none>
cray-uas-mgr-bitnami-etcd-2                                       2/2     Running            0                23h     10.40.0.77    ncn-w004   <none>           <none>

 --- PASSED ---
```

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

