### PR TITLE
CASMTRIAGE-5914: Fix HSN NIC numbering in HSM discovery

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,8 +20,8 @@ spec:
     namespace: services
     values:
       global:
-        appVersion: 1.58.2
-        testVersion: 1.58.2
+        appVersion: 1.58.4
+        testVersion: 1.58.4
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

Fixes a bug in HSN NIC numbering that is causing discovery errors when 4 HSN NICs are present in CSM 1.3.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5914](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5914)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/118

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
