### PR TITLE
CASMTRIAGE-5914: Fix HSN NIC numbering in HSM discovery

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.4
+    version: 7.0.5
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Fixes a bug in HSN NIC numbering that is causing discovery errors when 4 HSN NICs are present in CSM 1.6.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5914](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5914)

## Testing

For testing see https://github.com/Cray-HPE/hms-smd/pull/118

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
