### PR TITLE
CASMNET-1807 / CASMNET-2147 - Zone SOA and delegation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-powerdns-manager version to 0.8.2 (CASMNET-2147)
 - Update cray-product-catalog version to 1.9.0 (CASM-3981)
 - Update iuf-cli rpm to 1.5.4 (CASMTRIAGE-5798)
 - Update csm-testing and goss-servers version to 1.16.52 (CASMTRIAGE-5835)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -69,5 +69,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.8.1 # update platform.yaml cray-precache-images with this
+    version: 0.8.2 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -70,7 +70,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.25
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.1
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.2
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

The CASMNET-1806 fix did not correct the start of authority record for reverse zones.
```
/ $ pdnsutil list-zone 252.10.in-addr.arpa | grep SOA
252.10.in-addr.arpa	3600	IN	SOA	a.misconfigured.dns.server.invalid hostmaster.252.10.in-addr.arpa 2023081501 10800 3600 604800 3600
```
The top level domain is missing NS records for the subdomains which results in zone validation errors.
```
/ $ pdnsutil check-all-zones
Checked 3 records of 'mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 3 records of 'hsn', 0 errors, 0 warnings.
Checked 3 records of 'cmn', 0 errors, 0 warnings.
Checked 3 records of 'hmn', 0 errors, 0 warnings.
Checked 3 records of 'hmnlb', 0 errors, 0 warnings.
Checked 3 records of 'mtl', 0 errors, 0 warnings.
Checked 3 records of 'nmn', 0 errors, 0 warnings.
Checked 3 records of 'can', 0 errors, 0 warnings.
Checked 3 records of 'nmnlb', 0 errors, 0 warnings.
Checked 2 records of '107.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 2 records of '106.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 8 records of '100.92.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 37 records of '252.10.in-addr.arpa', 0 errors, 0 warnings.
[Error] No delegation for zone 'can.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 74 records of 'can.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
[Error] No delegation for zone 'nmn.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
[Info] pbs_comm_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] pbs_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] slurmctld_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] slurmdbd_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] uai_nmn_blackhole.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
Checked 90 records of 'nmn.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
Checked 7 records of '100.94.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 21 records of '253.10.in-addr.arpa', 0 errors, 0 warnings.
[Error] No delegation for zone 'mtl.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 66 records of 'mtl.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
[Error] No delegation for zone 'hmnlb.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 19 records of 'hmnlb.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
[Error] No delegation for zone 'nmnlb.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 22 records of 'nmnlb.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
[Error] No delegation for zone 'hmn.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 111 records of 'hmn.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
[Error] No delegation for zone 'cmn.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 141 records of 'cmn.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
Checked 52 records of '254.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 22 records of '1.10.in-addr.arpa', 0 errors, 0 warnings.
[Error] No delegation for zone 'hsn.mug.hpc.amslabs.hpecorp.net' in parent 'mug.hpc.amslabs.hpecorp.net'
Checked 20 records of 'hsn.mug.hpc.amslabs.hpecorp.net', 1 errors, 0 warnings.
Checked 69 records of '162.102.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 26 zones, 8 had errors.
```

## Issues and Related PRs

* Resolves [CASMNET-2147](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2147), [CASMNET-1807](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1807)

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Deployed on mug.

Reverse zone SOA record is now valid.
```
/ $ pdnsutil list-zone 252.10.in-addr.arpa  | grep SOA
252.10.in-addr.arpa	3600	IN	SOA	primary.mug.hpc.amslabs.hpecorp.net hostmaster.mug.hpc.amslabs.hpecorp.net 2023082202 10800 3600 604800 3600
```
Top level domain now contains the missing NS records.
```
/ $ pdnsutil list-zone mug.hpc.amslabs.hpecorp.net
$ORIGIN .
can.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
cmn.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
hmnlb.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
hmn.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
mtl.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
mug.hpc.amslabs.hpecorp.net	3600	IN	SOA	primary.mug.hpc.amslabs.hpecorp.net hostmaster.mug.hpc.amslabs.hpecorp.net 2023082201 10800 3600 604800 3600
nmnlb.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
nmn.mug.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.mug.hpc.amslabs.hpecorp.net.
primary.mug.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.162.61
```
Zone validation is clean.
```
/ $ pdnsutil check-all-zones
Checked 19 records of 'hmnlb.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 11 records of 'mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 2 records of '107.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 22 records of 'nmnlb.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 74 records of 'can.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 3 records of 'nmn', 0 errors, 0 warnings.
Checked 3 records of 'cmn', 0 errors, 0 warnings.
Checked 3 records of 'can', 0 errors, 0 warnings.
Checked 52 records of '254.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 3 records of 'hmn', 0 errors, 0 warnings.
Checked 2 records of '106.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 3 records of 'nmnlb', 0 errors, 0 warnings.
[Info] pbs_comm_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] pbs_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] slurmctld_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] slurmdbd_service.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
[Info] uai_nmn_blackhole.nmn.mug.hpc.amslabs.hpecorp.net. record for 'A' is not a valid hostname.
Checked 88 records of 'nmn.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 141 records of 'cmn.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 3 records of 'hsn', 0 errors, 0 warnings.
Checked 3 records of 'hmnlb', 0 errors, 0 warnings.
Checked 7 records of '100.94.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 3 records of 'mtl', 0 errors, 0 warnings.
Checked 66 records of 'mtl.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 20 records of 'hsn.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 22 records of '1.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 37 records of '252.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 111 records of 'hmn.mug.hpc.amslabs.hpecorp.net', 0 errors, 0 warnings.
Checked 8 records of '100.92.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 71 records of '162.102.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 21 records of '253.10.in-addr.arpa', 0 errors, 0 warnings.
Checked 26 zones, 0 had errors.
```

## Risks and Mitigations

Note that this changes the PowerDNS library from `github.com/SeanWallace/go-powerdns/v2` to `github.com/spillerc-hpe/go-powerdns/v2` which is a fork that adds support for the DNSSEC rectify API call.

At some point our DNSSEC and TSIG additions should be contributed back upstream to enable moving to v3 of the library so we no longer have to maintain this fork.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

