### PR TITLE
CASMTRIAGE-5927: Add cray-product-catalog 1.8.8 into build to keep Argo happy

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -200,6 +200,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-product-catalog-update:
       - 1.3.1
       - 1.3.2
+      - 1.8.8
       - 1.8.12
       - 1.9.0
     cray-nexus-setup:


### PR DESCRIPTION
Argo needs version 1.8.8 of the Cray Product Catalog updater or it won't come out to play with the other kids.

(the CSM build process really should go and find out what versions of images that Argo needs, and automatically pull them in, to avoid this kind of problem, IMO)