### PR TITLE
CASMCMS-8770: List spire-agent as requirement for cfs-state-reporter

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - canu-1.7.5-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-debugger-1.5.0-1.noarch
-    - cfs-state-reporter-1.10.0-1.noarch
+    - cfs-state-reporter-1.10.1-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
     - cray-site-init-1.32.2-1.x86_64


### PR DESCRIPTION
I accidentally forgot to include cfs-state-reporter in the other manifest PR for this ticket:
https://github.com/Cray-HPE/csm/pull/2743