### PR TITLE
CASMMON-337: Smartmon role should not run during image customization

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.17
+    version: 1.16.18
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Do not run smartmon role during CFS image customization -- only run it on live nodes.

Source PR: 
https://github.com/Cray-HPE/csm-config/pull/183