### PR TITLE
CASMPET-6732-release1.5 bump cray-nls and cray-iuf version to 3.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-nls cray-iuf version to 3.1.9 (CASMPET-6732)
 - Update cray-powerdns-manager version to 0.8.2 (CASMNET-2147)
 - Update cray-product-catalog version to 1.9.0 (CASM-3981)
 - Update iuf-cli rpm to 1.5.4 (CASMTRIAGE-5798)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.8
+    version: 3.1.9
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.1.8
+    version: 3.1.9
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

CASMPET-6732-release1.5 bump cray-nls and cray-iuf version to 3.1.9

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

