### PR TITLE
CASMCMS-8772: Update cfs-api for update jsonschema package (1.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -137,7 +137,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.6.3/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.14.0
+    version: 1.14.1
     namespace: services
     swagger:
     - name: cfs


### PR DESCRIPTION
## Summary and Scope

Updates the cfs-api to pull in an updated jsonschema package version, which fixes an error seen during the upgrade with incompatible python packages.

## Issues and Related PRs

* Resolves CASMCMS-8772

## Testing

### Tested on:

  * Mug

### Test description:

Upgraded, validated migration, tested api

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

