### PR TITLE
CASMINST-6625: BGP test: Improve PW handling, prevent false passes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -43,8 +43,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.17.5-1.noarch
-    - goss-servers-1.17.5-1.noarch
+    - csm-testing-1.17.6-1.noarch
+    - goss-servers-1.17.6-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.6.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

This contains three primary improvements to the BGP check test, script, and automated scripts which call it:

1. Modify the BGP test so that it does not try to prompt the user for a password when it is called from Goss
2. Modify the automated scripts which call the test so that they will not force the user to set the environment variable if the password is available in Vault.
3. Modify the BGP test to fail if it sees "Connection Error" in the output, as a workaround for the false test passes reported in [CASMNET-2017](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2017), since that does not seem to be getting fixed with any kind of urgency. Relatedly, remove the misleading "PASS" from the end of the test script, as that is based on the CANU return code, which has little meaning until the aforementioned ticket is resolved.

## Issues and Related PRs

* Resolves [CASMINST-6625](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6625)
* Works around one of the CANU false passes reported in [CASMNET-2017](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2017)
* [Source PR](https://github.com/Cray-HPE/csm-testing/pull/528)
* [CSM 1.5 manifest PR](https://github.com/Cray-HPE/csm/pull/2762)
* [CSM 1.4.3 manifest PR](https://github.com/Cray-HPE/csm/pull/2763)
* [CSM 1.6 `metal-provision` manifest PR](https://github.com/Cray-HPE/metal-provision/pull/397)
* [CSM 1.5 `metal-provision` manifest PR](https://github.com/Cray-HPE/metal-provision/pull/398)

## Testing

See source PR.

## Risks and Mitigations

Low risk -- not much actual code logic change.
