### PR TITLE
CASMHMS-6089 Update node heartbeat to use same gateway for vShasta and metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-node-heartbeat version to 2.2 (CASMHMS-6089)
 - Update cray-nls cray-iuf version to 3.1.9 (CASMPET-6732)
 - Update cray-powerdns-manager version to 0.8.2 (CASMNET-2147)
 - Update cray-product-catalog version to 1.9.0 (CASM-3981)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -38,8 +38,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.82.9-1.aarch64
     - craycli-0.82.9-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.1-3.aarch64
-    - csm-node-heartbeat-2.1-3.x86_64
+    - csm-node-heartbeat-2.2-3.aarch64
+    - csm-node-heartbeat-2.2-3.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

Worker nodes on lemondrop were starting the cray-heartbeat with the wrong gateway address due to some virtio kernel modules that were loaded for qemu ARM builds. vShasta v2 uses the same gateway address that metal nodes do, so there is no need to differentiate between the two.

There is no impact to metal based installs. This only impacts vShasta.

## Issues and Related PRs

* Resolves [CASMHMS-6089](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6089)

## Testing

### Tested on:

  * `lemondrop`

### Test description:

Put in place the new code on ncn-w001 on lemondrop and verified the gateway was correct and the heartbeat was working.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N - Issue will only impact test machines and 1.5 installs. RPM different for 1.5 installs, did - not want to install it onto a 1.4 system.
- Was downgrade tested? If not, why? N - no upgrade done
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No risks to metal installs.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

