### PR TITLE
Decrease timeouts when failing to get no-wipe status (CASMTRIAGE-5896)

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -57,7 +57,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - pit-init-1.4.2-1.noarch
-    - platform-utils-1.6.4-1.noarch
+    - platform-utils-1.6.5-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.8.aarch64
     - spire-agent-1.5.5-1.8.x86_64


### PR DESCRIPTION
### Summary and Scope

Speed up the no-wipe test in the failure case.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5896

### Testing (ashton)

Before:
```
ncn-m002:/opt/cray/platform-utils # time ./ncnHealthChecks.sh -s no_wipe_status
=== NCN Master nodes: ncn-m002 ncn-m003 ===
=== NCN Worker nodes: ncn-w001 ncn-w002 ncn-w003 ===
=== NCN Storage nodes: ncn-s001 ncn-s002 ncn-s003 ===

**************************************************************************

=== NCN node xnames and metal.no-wipe status ===
=== metal.no-wipe=1, expected setting - the client ===
=== already has the right partitions and a bootable ROM. ===
=== Note that before the PIT node has been rebooted into ncn-m001, ===
=== metal.no-wipe status may not available. ===
=== NCN Master nodes: ncn-m002 ncn-m003 ===
=== NCN Worker nodes: ncn-w001 ncn-w002 ncn-w003 ===
=== NCN Storage nodes: ncn-s001 ncn-s002 ncn-s003 ===
Error from server (NotFound): secrets "admin-client-auth" not found
curl: (7) Failed to connect to api-gw-service-nmn.local port 443 after 9 ms: No route to host
Failed to get token, skipping metal.no-wipe checks.
Tue 29 Aug 2023 09:48:05 PM UTC
ncn-m002: x3000c0s2b0n0 - unavailable
ncn-m003: x3000c0s3b0n0 - unavailable
ncn-w001: x3000c0s15b0n0 - unavailable
ncn-w002: x3000c0s16b0n0 - unavailable
ncn-w003: x3000c0s17b0n0 - unavailable
ncn-s001: x3000c0s29b0n0 - unavailable
ncn-s002: x3000c0s30b0n0 - unavailable
ncn-s003: x3000c0s31b0n0 - unavailable
 --- FAILED --- metal.no-wipe status is not 1. (note: node_status = upgrade/rebuild, then metal.no-wipe=0 is valid)


real	2m9.904s
user	0m0.795s
sys	0m0.391s
```

After:
```
ncn-m002:/opt/cray/platform-utils # time ./ncnHealthChecks-brad.sh -s no_wipe_status
=== NCN Master nodes: ncn-m002 ncn-m003 ===
=== NCN Worker nodes: ncn-w001 ncn-w002 ncn-w003 ===
=== NCN Storage nodes: ncn-s001 ncn-s002 ncn-s003 ===

**************************************************************************

=== NCN node xnames and metal.no-wipe status ===
=== metal.no-wipe=1, expected setting - the client ===
=== already has the right partitions and a bootable ROM. ===
=== Note that before the PIT node has been rebooted into ncn-m001, ===
=== metal.no-wipe status may not available. ===
=== NCN Master nodes: ncn-m002 ncn-m003 ===
=== NCN Worker nodes: ncn-w001 ncn-w002 ncn-w003 ===
=== NCN Storage nodes: ncn-s001 ncn-s002 ncn-s003 ===
Error from server (NotFound): secrets "admin-client-auth" not found
curl: (7) Failed to connect to api-gw-service-nmn.local port 443 after 9 ms: No route to host
Failed to get token, skipping metal.no-wipe checks.
Tue 29 Aug 2023 09:47:54 PM UTC
ncn-m002: x3000c0s2b0n0 - unavailable
ncn-m003: x3000c0s3b0n0 - unavailable
ncn-w001: x3000c0s15b0n0 - unavailable
ncn-w002: x3000c0s16b0n0 - unavailable
ncn-w003: x3000c0s17b0n0 - unavailable
ncn-s001: x3000c0s29b0n0 - unavailable
ncn-s002: x3000c0s30b0n0 - unavailable
ncn-s003: x3000c0s31b0n0 - unavailable
 --- FAILED --- Failed to get token, skipped metal.no-wipe checks. Could not verify no-wipe status.


real	0m3.271s
user	0m0.550s
sys	0m0.122s
```

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

