### PR TITLE
CASMTRIAGE-5974: Update cfs-api to address bugs in the new v3 api (1.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -137,12 +137,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.6.3/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.14.1
+    version: 1.14.2
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.13.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.14.2/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.0


### PR DESCRIPTION
## Summary and Scope

Fixes three CFS bugs
- Fixes component list when filtering by id
- Fixes repeat upgrade migrations when other CFS services repopulated the old options data format during the initial migration.
- Fixes the minimum length requirement on the desired configuration field to allow it to be empty.

## Issues and Related PRs

* Resolves CASMTRIAGE-5974
* Resolves CASMTRIAGE-5977
* Resolves CASMCMS-8783

## Testing

### Tested on:

  * Mug

### Test description:

Tested migration that was previously failing, tested id filtering for both the v2 and v3 apis, and tested the creation of components with empty configurations.


## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

