### PR TITLE
CASMTRIAGE-5951-release/1.5 update cray-nls and cray-iuf to 3.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-nls and cray-iuf to 3.1.10 (CASMTRIAGE-5951)
 - Update csm-node-heartbeat version to 2.2 (CASMHMS-6089)
 - Update cray-nls cray-iuf version to 3.1.9 (CASMPET-6732)
 - Update cray-powerdns-manager version to 0.8.2 (CASMNET-2147)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -240,11 +240,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 3.1.9
+    version: 3.1.10
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 3.1.9
+    version: 3.1.10
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

These changes are for having a graceful error when no --limit-management-rollout parameter is supplied to IUF during management-nodes-rollout

## Issues and Related PRs


* Resolves [CASMTRIAGE-5951](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5951)

## Testing

Tested upgrade on Dorain. (CSM 1.6 vShasta)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

