### PR TITLE
CASMTRIAGE-5999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-node-heartbeat version to 2.3 (CASMTRIAGE-5999)
 - Update cray-nls and cray-iuf version to 4.0.4 (CASMTRIAGE-5951)
 - Update csm-node-heartbeat version to 2.2 (CASMHMS-6089)
 - Update cray-nls version to 4.0.3 (CASMPET-6732)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -38,8 +38,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.82.9-1.aarch64
     - craycli-0.82.9-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.2-3.aarch64
-    - csm-node-heartbeat-2.2-3.x86_64
+    - csm-node-heartbeat-2.3-1.aarch64
+    - csm-node-heartbeat-2.3-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

- upgrade csm-node-heartbeat version

## Issues and Related PRs

- https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5999
- https://github.com/Cray-HPE/csm-node-heartbeat/pull/5

## Testing

### Tested on:

- local system
- Baldar

### Test description:

csm-node-heartbeat=2.3-1 was installed. It properly removed cray-heartbeat in the process.

## Risks and Mitigations

None known.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

