### PR TITLE
Updated sls and smd for vm node support

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,15 +12,15 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.2
     namespace: services
     swagger:
     - name: sls
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.3.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.5
+    version: 7.1.0
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.10.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.13.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 2.0.3


### PR DESCRIPTION
## Summary and Scope

Added support in SLS and HSM (SMD) for the VirtualNode xname type.

## Issues and Related PRs

* Resolves [CASMHMS-6071](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6071)
* Resolves [CASMHMS-6073](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6073)

## Testing

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

