### PR TITLE
CASMPET-6760 update iuf-cli version to 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update iuf-cli version to 1.6.3 (CASMPET-6760)
 - Update csm-node-heartbeat version to 2.3 (CASMTRIAGE-5999)
 - Update cray-nls and cray-iuf version to 4.0.4 (CASMTRIAGE-5951)
 - Update csm-node-heartbeat version to 2.2 (CASMHMS-6089)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.2-1.x86_64
+    - iuf-cli-1.6.3-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-ipxe-2.4.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update iuf-cli version to 1.6.3.

This fixes the IUF-CLI bug where logs were not being printed or saved in the argo_logs directory.


## Issues and Related PRs

* Resolves [CASMPET-6760](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6760)
*  Resolves [CASMINST-6618]( https://jira-pro.it.hpe.com:8443/browse/CASMINST-6618)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

