### PR TITLE
CASMPET-6745: Update cilium to v1.14.1, Hubble to v0.12.0, and add Tetragon images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+- Update cilium to v1.14.1, Hubble to v0.12.0, and add Tetragon images (CASMPET-6745)
 - Update iuf-cli version to 1.6.3 (CASMPET-6760)
 - Update csm-node-heartbeat version to 2.3 (CASMTRIAGE-5999)
 - Update cray-nls and cray-iuf version to 4.0.4 (CASMTRIAGE-5951)

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -171,17 +171,23 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Cilium images required by platform
     quay.io/cilium/cilium:
-      - v1.13.2
+      - v1.14.1
     quay.io/cilium/operator-generic:
-      - v1.13.2
+      - v1.14.1
 
     # Cilium Hubble images
     quay.io/cilium/hubble-relay:
-      - v1.13.2
+      - v1.14.1
     quay.io/cilium/hubble-ui:
-      - v0.11.0
+      - v0.12.0
     quay.io/cilium/hubble-ui-backend:
+      - v0.12.0
+
+    # Cilium Tetragon images
+    quay.io/cilium/tetragon:
       - v0.11.0
+    quay.io/cilium/tetragon-operator:
+      - v1.11.0
 
     # Cilium images needed for connectivity testing
     quay.io/cilium/alpine-curl:


### PR DESCRIPTION
## Summary and Scope

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6745](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6745)
* Requires PR in node-images

## Testing

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

I did some testing on the cilium cluster installing the various CLI utilities and running the cilium install with kube-proxy replacement disabled.

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant environment (if yes, please include results or a description of the test)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

