### PR TITLE
CASMMON-340 create endpoint,service and service monitor to enabling SMART data on UAN

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.8
+    version: 0.28.9
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
create endpoint,service and service monitor to enabling SMART data on UAN

## Issues and Related PRs
[
_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._](

https://jira-pro.it.hpe.com:8443/browse/CASMMON-340
tested on shandy
custmization.yaml changes under cray-sysmgmt-health chart
      uanNodeExporter:
        enabled: true
        endpoints:
        - 10.252.1.23


![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/22464568/736551ab-287a-4f65-ad36-3c72f5e17988)

![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/22464568/5bffede9-05e2-42e0-9251-9e4d87b96e64)



ncn-m001:/mnt/developer/ram # curl http://10.252.1.23:9100/metrics |more
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which node_exporter was built.
# TYPE node_exporter_build_info gauge
100 20117    0 20117    0  node_exporter_build_info{branch="HEAD",goversion="go1.19.3",revision="1b48970ffcf5630534fb00bb0687d73c66d1c959",version="1.5.0"} 1
   0  9822k      0 --:--:-- --:-# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
-:-- --:--:-- 982# TYPE node_scrape_collector_duration_seconds gauge
2k
node_scrape_collector_duration_seconds{collector="textfile"} 0.001161701
# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
# TYPE node_scrape_collector_success gauge
node_scrape_collector_success{collector="textfile"} 1
# HELP node_textfile_mtime_seconds Unixtime mtime of textfiles successfully read.
# TYPE node_textfile_mtime_seconds gauge
node_textfile_mtime_seconds{file="/var/lib/node_exporter/smartmon.prom"} 1.694069332e+09
# HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
# TYPE node_textfile_scrape_error gauge
node_textfile_scrape_error 0
# HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
# TYPE promhttp_metric_handler_errors_total counter
promhttp_metric_handler_errors_total{cause="encoding"} 0
promhttp_metric_handler_errors_total{cause="gathering"} 0
# HELP smartmon_airflow_temperature_cel_raw_value SMART metric airflow_temperature_cel_raw_value
# TYPE smartmon_airflow_temperature_cel_raw_value gauge
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sda",smart_id="190",type="sat"} 24
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdb",smart_id="190",type="sat"} 24
# HELP smartmon_airflow_temperature_cel_threshold SMART metric airflow_temperature_cel_threshold
# TYPE smartmon_airflow_temperature_cel_threshold gauge
smartmon_airflow_temperature_cel_threshold{disk="/dev/sda",smart_id="190",type="sat"} 0
smartmon_airflow_temperature_cel_threshold{disk="/dev/sdb",smart_id="190",type="sat"} 0
# HELP smartmon_airflow_temperature_cel_value SMART metric airflow_temperature_cel_value
# TYPE smartmon_airflow_temperature_cel_value gauge
smartmon_airflow_temperature_cel_value{disk="/dev/sda",smart_id="190",type="sat"} 76
smartmon_airflow_temperature_cel_value{disk="/dev/sdb",smart_id="190",type="sat"} 76
# HELP smartmon_airflow_temperature_cel_worst SMART metric airflow_temperature_cel_worst
# TYPE smartmon_airflow_temperature_cel_worst gauge
smartmon_airflow_temperature_cel_worst{disk="/dev/sda",smart_id="190",type="sat"} 66
smartmon_airflow_temperature_cel_worst{disk="/dev/sdb",smart_id="190",type="sat"} 63
# HELP smartmon_current_pending_sector_raw_value SMART metric current_pending_sector_raw_value
# TYPE smartmon_current_pending_sector_raw_value gauge
smartmon_current_pending_sector_raw_value{disk="/dev/sda",smart_id="197",type="sat"} 0
smartmon_current_pending_sector_raw_value{disk="/dev/sdb",smart_id="197",type="sat"} 0
# HELP smartmon_current_pending_sector_threshold SMART metric current_pending_sector_threshold
# TYPE smartmon_current_pending_sector_threshold gauge
smartmon_current_pending_sector_threshold{disk="/dev/sda",smart_id="197",type="sat"} 0
smartmon_current_


