### PR TITLE
CASMCMS-8800: Automatically removed deprecated BOS v1 fields from session templates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,13 +128,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.6.3
+    version: 2.7.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.6.3/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.7.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.14.2

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.6.3-1.noarch
+    - bos-reporter-2.7.0-1.noarch
     - cani-0.2.0-1.x86_64
     - canu-1.7.5-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

To reduce potential problems caused by BOS v1 templates that are not valid BOS v2 templates, automatically strip deprecated (and vestigial) BOS v1 fields which cause this.
