### PR TITLE
CASMINST-6633: include kernel-source rpm

### DIFF
--- a/hack/embedded-repo.sh
+++ b/hack/embedded-repo.sh
@@ -39,10 +39,11 @@ for LIST_TYPE in installed installed.deps; do
     done
 done | tr '=' '-' | sort -u > "${TMPDIR}/ncn.rpm-list"
 
-# Explicitly append kernel-default and kernel-default-debuginfo packages to rpm list
+# Explicitly append kernel-default, kernel-default-debuginfo, and kernel-source packages to rpm list
 if [ -n "$KERNEL_DEFAULT_DEBUGINFO_VERSION" ]; then
     echo "kernel-default-${KERNEL_DEFAULT_DEBUGINFO_VERSION}" >> "${TMPDIR}/ncn.rpm-list"
     echo "kernel-default-debuginfo-${KERNEL_DEFAULT_DEBUGINFO_VERSION}" >> "${TMPDIR}/ncn.rpm-list"
+    echo "kernel-source-${KERNEL_DEFAULT_DEBUGINFO_VERSION}" >> "${TMPDIR}/ncn.rpm-list"
 fi
 
 echo "List of packages for embedded repo:"


### PR DESCRIPTION
## Summary and Scope

From the jira:

> As part of the move to DKMS, we have found that we need the kernel-source RPM available in the CSM NCN repo in order to build dynamically. It does not need to be installed in the image, just available in the repo so we can pull it into our kata container when building our image.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6633](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6633)
* Change will also be needed in `release/1.6`

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

N/A

