### PR TITLE
CASMCMS-8789: Update cfs-api and operator for image cleanup and v3 bug fixes (1.5)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -137,19 +137,19 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.7.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.14.2
+    version: 1.15.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.14.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.15.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.19.0
+    version: 1.20.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Adds cleanup for IMS sessions created by CFS image customizations sessions.
Also adds a fix for layer status reporting for CFS components

## Issues and Related PRs

* Resolves CASMCMS-8789
* Resolves CASMTRIAGE-6032

## Testing

See individual tickets

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

