### PR TITLE
CASMHMS-6069: Make KEA Resilient

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -55,6 +55,9 @@ artifactory.algol60.net/csm-docker/stable:
     cray-capmc:
       - 2.7.0
 
+    cray-dhcp-kea:
+      - 0.10.25
+
     # Utility to help make changes for adding river cabinets
     hardware-topology-assistant:
     - 0.2.0

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -15,3 +15,5 @@ artifactory.algol60.net/csm-helm-charts/stable:
   charts:
     cray-hms-capmc:
       - 3.0.8
+    cray-dhcp-kea:
+      - 0.10.25

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -49,7 +49,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.10.25 # update platform.yaml cray-precache-images with this
+    version: 0.11.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.25
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.2


### PR DESCRIPTION
## Summary and Scope

This changes KEA from being a singleton to being in a clustered deployment.

## Issues and Related PRs

* Resolves [CASMHMS-6069](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6069)

## Testing

For testing, see https://github.com/Cray-HPE/cray-dhcp-kea/pull/58

## Risks and Mitigations

Without large scale testing, it is difficult to capture all edge cases. The old chart (v0.10.25) will be shipped alongside the new chart (v0.11.0) should it need to be reverted.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

