### PR TITLE
CASMHMS-5831 Update hmcollector kafka topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update hmcollector kafka topics (CASMHMS-5831)
 - Include ceph image v16.2.13 in docker index (CASMPET-6516)
 - Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -67,7 +67,7 @@ spec:
     namespace: services
     values:
       global:
-        appVersion: 2.23.0
+        appVersion: 2.25.1
       kafkaBrokers:
         - BrokerAddress: cluster-kafka-bootstrap.sma.svc.cluster.local:9092
           TopicsToPublish:
@@ -79,11 +79,15 @@ spec:
             - cray-telemetry-pressure
             - cray-telemetry-humidity
             - cray-telemetry-liquidflow
+            - cray-telemetry-metric
+            - cray-telemetry-powerfactor
+            - cray-telemetry-frequency
+            - cray-telemetry-percent
             - cray-fabric-telemetry
             - cray-fabric-perf-telemetry
             - cray-fabric-crit-telemetry
             - cray-dmtf-resource-event
-            - cray-fabric-health-events
+            - cray-fabric-health
         - BrokerAddress: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092
           TopicsToPublish:
             - cray-dmtf-resource-event


### PR DESCRIPTION
## Summary and Scope

As new firmware is being updated at sites with even older software, new telemetry is being delivered to HMS. This change allows the hms-hmcollector to handle receiving this new telemetry and to put it on the kafka bus.

Backwards compatible.

## Issues and Related PRs

* Resolves [CASMHMS-5831](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5831)

## Testing

### Tested on:

  * `tyr`

### Test description:

Verified that the new telemetry was picked up by the collector and trying to put the messages on the kafka bus.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

