### PR TITLE
CASMINST-6597: Add update-mgmt-ncn-cfs-config.sh script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -102,6 +102,8 @@ rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/chrony/" "${BUILDDIR}/chrony/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
+rsync -aq "${ROOTDIR}/update-mgmt-ncn-cfs-config.sh" "${BUILDDIR}/"
+chmod 755 "${BUILDDIR}/update-mgmt-ncn-cfs-config.sh"
 
 # Copy manifests
 rsync -aq "${ROOTDIR}/manifests/" "${BUILDDIR}/manifests/"
@@ -250,8 +252,10 @@ fi
 # Download HPE GPG signing key (for verifying signed RPMs)
 cmd_retry curl -sfSLRo "${BUILDDIR}/hpe-signing-key.asc" "$HPE_SIGNING_KEY"
 
-# Save cray/nexus-setup and quay.io/skopeo/stable images for use in install.sh
-vendor-install-deps "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
+# Use a newer version of cfs-config-util that hasn't rolled out to other products yet
+CFS_CONFIG_UTIL_IMAGE="arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.0.0"
+# Save cray/nexus-setup, quay.io/skopeo/stable, and cfs-config-util images for use in install.sh
+vendor-install-deps --include-cfs-config-util "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
 
 # Scan container images
 parallel -j 30% --halt-on-error now,fail=1 -v \

--- a/update-mgmt-ncn-cfs-config.sh
+++ b/update-mgmt-ncn-cfs-config.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This updates the CFS configuration that applies to management NCNs by adding
+# the appropriate layers for this version of the CSM product.
+#
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+source "${ROOTDIR}/lib/install.sh"
+
+# Print a message with extra emphasis to indicate a stage.
+function print_stage(){
+    msg="$1"
+    echo "====> ${msg}"
+}
+
+# Exit with an error message and an exit code of 1.
+function exit_with_error() {
+    msg="$1"
+    >&2 echo "${msg}"
+    exit 1
+}
+
+load-cfs-config-util
+trap "{ print_stage 'Cleaning up dependencies'; clean-install-deps &>/dev/null; }" EXIT
+
+function print_usage() {
+    cat <<EOF
+usage: ${BASH_SOURCE[0]} [options]
+
+Update the CFS configuration for configuring management NCNs by adding or
+updating the layer for ${RELEASE}.
+
+Options:
+
+  -h, --help              Print this usage information.
+
+EOF
+
+    cfs-config-util-options-help
+}
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+print_stage "Updating CFS configuration(s)"
+
+# Note that recipes with CSM 1.4 still used the site.yml playbook in the
+# default bootprep files, so that playbook must be used here.
+cfs-config-util update-configs --product "${RELEASE_NAME}:${RELEASE_VERSION}" \
+    --playbook site.yml --playbook ncn-initrd.yml $@
+rc=$?
+
+if [[ $rc -eq 2 ]]; then
+    print_usage
+    exit_with_error "cfs-config-util received invalid arguments."
+elif [[ $rc -ne 0 ]]; then
+    exit_with_error "Failed to update CFS configurations. cfs-config-util exited with exit status $rc."
+fi
+
+print_stage "Completed update of CFS configuration(s)"


### PR DESCRIPTION
## Summary and Scope

This script is used to update only the CSM-provided layers of a CFS
configuration. This is useful during a patch installation when `sat
bootprep` may not be run with a whole set of new products.

Documentation will be added to the patch procedure to describe how to
use this script.

This script was mostly copied from the sat-product-stream repository.
It uses existing shell functions defined in the hpc-shastarelm-release
shared library which is already git-vendor'd into this repository. Those
functions run the `cfs-config-util` container image with `podman`.

## Issues and Related PRs

* Resolves [CASMINST-6597](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6597)
* Merge after https://github.com/Cray-HPE/python-csm-api-client/pull/19
* Merge after https://github.com/Cray-HPE/cfs-config-util/pull/22

## Testing

### Tested on:

  * mug

### Test description:

Built a stripped down CSM release distribution tar file, copied it to
mug, modified the product catalog to look like the matching version of
CSM had been installed and provided a new branch of the
csm-config-management repo in VCS, and then ran this script with the
following arguments:

```
./update-mgmt-ncn-cfs-config.sh --base-query role=management --save \
    --create-backups
```

Verified that this updated the CFS configuration which was currently set
as the desiredConfig on the CFS components corresponding to the
management nodes and then waited for CFS batcher to configure them. Also
verified that it created an update of the configuration before the
modifications were made.

## Risks and Mitigations

This is a pretty low-risk change as it's adding a new script. If the script doesn't work, we're in no worse of a position than we were before the introduction of the script.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
- [ ] Update to a stable version of cfs-config-util when the PR is merged and the new release branch is created

