### PR TITLE
Remove step that uninstalls etcd-operator (CASMTRIAGE-5821)

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -127,11 +127,6 @@ fi
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
 
-#
-# Remove the old etcd operator now that new manifests have been applied
-#
-undeploy -n operators cray-etcd-operator
-
 set +x
 cat >&2 <<EOF
 + CSM applications and services upgraded


### PR DESCRIPTION
### Summary and Scope

Keep the etcd-operator around until after deploy-products has run,
allowing non-CSM etcd clusters to remain healthy through NCN
rebuilds.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5821

### Testing

tyr:

```
ncn-m002:~ # kubectl get po -n services | grep 'fox\|cvt'
cray-cvt-556898ccbb-dwkp4                                         2/2     Running            0          16h
cray-cvt-etcd-h5tr5fzfz8                                          1/1     Running            0          15h
cray-cvt-etcd-nf95mvm9z7                                          1/1     Running            0          11h
cray-cvt-etcd-nzqg6zjhch                                          1/1     Running            0          16h
cray-fox-6cbc67fdb9-b8pxb                                         2/2     Running            0          11h
cray-fox-etcd-59rzm8t9sz                                          1/1     Running            0          15h
cray-fox-etcd-gsrc8ntc6v                                          1/1     Running            0          11h
cray-fox-etcd-hh68l6lt4b                                          1/1     Running            0          16h
```

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

