### PR TITLE
CASMINST-6654/CASMINST-6657/CASMINST-6658: Goss testing improvements

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -46,7 +46,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.5.6-1.noarch
     - csm-testing-1.16.54-1.noarch
     - goss-servers-1.16.54-1.noarch
-    - hpe-csm-goss-package-0.3.21-hpe3.x86_64
+    - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.53-1.noarch
-    - goss-servers-1.16.53-1.noarch
+    - csm-testing-1.16.54-1.noarch
+    - goss-servers-1.16.54-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe3.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.54-1.noarch
-    - goss-servers-1.16.54-1.noarch
+    - csm-testing-1.16.55-1.noarch
+    - goss-servers-1.16.55-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Because of how the CMS tests were implemented in Goss, some genuine errors that prevent them from running will not result in any test failures (or even tests reported as being skipped). This causes silent failures in our automated test runs, most recently observed in the vshasta automated runs. This updates the csm-testing suite to avoid this (so that if the tests cannot run, failures will be logged for them).

I also added a commit for [CASMINST-6657](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6657) to update the RPM version for `hpe-csm-goss-package` to match the version from `metal-provision`.

And added a commit for [CASMINST-6658](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6658), to add a Goss endpoint to run additional tests during vshasta runs.

## Issues and Related PRs

* [CSM 1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/2843)
* [`metal-provision` CSM 1.5 manifest PR](https://github.com/Cray-HPE/metal-provision/pull/488)
* [`metal-provision` CSM 1.6 manifest PR](https://github.com/Cray-HPE/metal-provision/pull/489)

## Testing

Tested on mug.

## Risks and Mitigations

The change is very small, and doesn't actually involve changing the test itself. It just changes the logic used to determine when and how the test is run.
