### PR TITLE
CASMCMS-5820: Put new BOS into CSM-1.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.23
+    version: 2.0.26
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

BOS properly initializes a variable that otherwise uninitialized down a certain code path that was only triggered intermittently. 

It's a backwards compatible bugfix

## Issues and Related PRs


* Resolves [CASMTRIAGE-6045](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6045)

## Testing

### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low.
_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

