### PR TITLE
CASMINST-6650 update csm-testing to v1.17.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update csm-testing and goss-servers to v1.17.9, fix storage node upgrade tests (CASMINST-6650)
 - Update cilium to v1.14.1, Hubble to v0.12.0, and add Tetragon images (CASMPET-6745)
 - Update iuf-cli version to 1.6.3 (CASMPET-6760)
 - Update csm-node-heartbeat version to 2.3 (CASMTRIAGE-5999)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.17.8-1.noarch
-    - goss-servers-1.17.8-1.noarch
+    - csm-testing-1.17.9-1.noarch
+    - goss-servers-1.17.9-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.6.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

update csm-testing to v1.17.9. 
[CASMINST-6650](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6650): fix storage goss test that require ceph admin keyring to only run on ncn-s00[1-3]

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

