### PR TITLE
CASMINST-6650-release-1.4 update csm-testing to v1.15.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update csm-testing and goss-servers to v1.15.54, fix storage node upgrade tests (CASMINST-6650)
 - Update spire to 2.12.4 to allow pooler resource customization (CASMPET-6720)
 - Update iuf-cli rpm to 1.4.6 (CASMTRIAGE-5798)
 - Update csm-testing and goss-servers version to 1.15.51 (CASMTRIAGE-5835)

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -24,6 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - cray-node-exporter-1.5.0.1-1.noarch
-    - csm-testing-1.15.53-1.noarch
-    - goss-servers-1.15.53-1.noarch
+    - csm-testing-1.15.54-1.noarch
+    - goss-servers-1.15.54-1.noarch
     - smart-mon-1.0.3-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.74.0-1.x86_64
-    - csm-testing-1.15.53-1.noarch
-    - goss-servers-1.15.53-1.noarch
+    - csm-testing-1.15.54-1.noarch
+    - goss-servers-1.15.54-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,8 +34,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.53-1.noarch
-    - goss-servers-1.15.53-1.noarch
+    - csm-testing-1.15.54-1.noarch
+    - goss-servers-1.15.54-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - iuf-cli-1.4.6-1.x86_64
     - libcsm-0.0.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

update csm-testing to v1.15.54. 
[CASMINST-6650](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6650): fix storage goss test that require ceph admin keyring to only run on ncn-s00[1-3]

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
