### PR TITLE
CASMINST-6650-release-1.3 update csm-testing to 1.14.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update csm-testing and goss-servers to v1.14.64, fix storage node upgrade tests (CASMINST-6650)
 - Include ceph image v16.2.13 in docker index (CASMPET-6516)
 - Update cray-dhcp-kea to 0.10.23 (CASMTRIAGE-5494)
 - Update cray-dhcp-kea to 0.10.22 (CASMNET-2110 CASMNET-1752 CASMNET-2108 CASMNET-2109 CASMNET-1525)

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-cmstools-crayctldeploy-1.10.0-1.x86_64
     - cray-site-init-1.26.5-1.x86_64
-    - csm-testing-1.14.63-1.noarch
-    - goss-servers-1.14.63-1.noarch
+    - csm-testing-1.14.64-1.noarch
+    - goss-servers-1.14.64-1.noarch
     - metal-basecamp-1.2.0-1.x86_64
     - metal-ipxe-2.2.9-1.noarch
     - pit-init-1.2.35-1.noarch


### PR DESCRIPTION
## Summary and Scope

update csm-testing to v1.14.64. 
[CASMINST-6650](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6650): fix storage goss test that require ceph admin keyring to only run on ncn-s00[1-3]

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
