### PR TITLE
Fix thanos-ruler-kube-prometheus-stack-thanos-ruler pod disruption budget

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.9
+    version: 0.28.10
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
Summary and Scope
Fix thanos-ruler-kube-prometheus-stack-thanos-ruler pod disruption budget.
This regarding the pod disruption budget for thanos-ruler-kube-prometheus-stack-thanos-ruler . We see that this statefulset is defined as a singleton but the pod disruption budget doesn't allow that singleton pod to be removed when a node is drained. Kubernetes guidelines say that singleton pods should tolerate downtime and not have a pod disruption budget.

Issues and Related PRs
[CASMMON-342](https://jira-pro.it.hpe.com:8443/browse/CASMMON-342)

https://github.com/Cray-HPE/cray-sysmgmt-health/pull/130

Testing
List the environments in which these changes were tested.

Tested on: Mug
before the fix

kubectl -n sysmgmt-health get pdb
NAME MIN AVAILABLE MAX UNAVAILABLE ALLOWED DISRUPTIONS AGE
kube-prometheus-stack-thanos-ruler 1 N/A 0 84d

After fix

kubectl -n sysmgmt-health get pdb
No resources found in sysmgmt-health namespace.