### PR TITLE
CASMCMS-8812: Skip CMS conman Goss test on vshasta

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.56-1.noarch
-    - goss-servers-1.16.56-1.noarch
+    - csm-testing-1.16.57-1.noarch
+    - goss-servers-1.16.57-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The CMS conman test doesn't work on vshasta because one of the console services pods is blacklisted under vshasta (due to other problems that it causes). This PR updates the CMS test so that when running on vshasta, the conman test is skipped.

## Issues and Related PRs

This PR supersedes the changes in this manifest PR:
https://github.com/Cray-HPE/csm/pull/2852

[1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/2858)
[1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2862)
[1.5 `metal-provision` PR](https://github.com/Cray-HPE/metal-provision/pull/497)
[1.6 `metal-provision` PR](https://github.com/Cray-HPE/metal-provision/pull/498)