### PR TITLE
CASMCMS-8812: Skip CMS conman Goss test on vshasta

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.17.9-1.noarch
-    - goss-servers-1.17.9-1.noarch
+    - csm-testing-1.17.10-1.noarch
+    - goss-servers-1.17.10-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.6.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
1.6 backport of https://github.com/Cray-HPE/csm/pull/2857

This PR supersedes the changes in this manifest PR:
https://github.com/Cray-HPE/csm/pull/2851