### PR TITLE
CASMINST-6664: Revert unintentional CSM 1.3 changes for CASMINST-6624

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.14.5
+    version: 1.14.7
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This reverts the smartmon changes that were accidentally made to `csm-config` in CSM 1.3