### PR TITLE
CASMINST-6663: Prevent Goss tests from failing due to missing environment variable

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.17.10-1.noarch
-    - goss-servers-1.17.10-1.noarch
+    - csm-testing-1.17.11-1.noarch
+    - goss-servers-1.17.11-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.6.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The way a few Goss tests were written left them susceptible to problems if the `HOSTNAME` env variable is not set. This PR modifies the tests to also use other methods to determine the hostname.

## Issues and Related PRs

* [CSM 1.5 manifest PR](https://github.com/Cray-HPE/csm/pull/2870)
* [CSM 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2872)
* [CSM 1.3 manifest PR](https://github.com/Cray-HPE/csm/pull/2871)
* [`metal-provision` CSM 1.6 PR](https://github.com/Cray-HPE/metal-provision/pull/505)
* [`metal-provision` CSM 1.5 PR](https://github.com/Cray-HPE/metal-provision/pull/506)