### PR TITLE
CASMINST-6663: Prevent Goss tests from failing due to missing environ…

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.57-1.noarch
-    - goss-servers-1.16.57-1.noarch
+    - csm-testing-1.16.58-1.noarch
+    - goss-servers-1.16.58-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/2869