### PR TITLE
CASMPET: Update OPA endpoints for TPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Upate cray-opa to v1.32.6, fix tpm endpoints (CASMPET-6800)
 - Update csm-testing and goss-servers to v1.17.9, fix storage node upgrade tests (CASMINST-6650)
 - Update cilium to v1.14.1, Hubble to v0.12.0, and add Tetragon images (CASMPET-6745)
 - Update iuf-cli version to 1.6.3 (CASMPET-6760)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.32.5
+    version: 1.32.6
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This fixes the endpoint for the TPM-Provisioner server api to be the correct endpoint for the authorize endpoints

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6800](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6800)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Baldar

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

