### PR TITLE
CASMCMS-8696: bump csm-config version to 1.16.21

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.19
+    version: 1.16.21
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Ansible play to customize an image with kata containers and install necessary packages to facilitate remote ims image building.

## Issues and Related PRs


* Resolves [CASMCMS-8696](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8696)

## Testing

### Tested on:
Tested on mug.

### Test description:

Ran customizations on metal image on mug environment.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

