### PR TITLE
CASMNET-1150 - Create HSN and CHN NID records in PowerDNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-powerdns-manager to v0.8.3 (CASMNET-1150, CASMNET-2003, and CAST-31486)
 - Update cray-spire to v1.5.2 for TPM support (CASMPET-6801)
 - Upate cray-opa to v1.32.6, fix tpm endpoints (CASMPET-6800)
 - Update csm-testing and goss-servers to v1.17.9, fix storage node upgrade tests (CASMINST-6650)

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -69,5 +69,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.8.2 # update platform.yaml cray-precache-images with this
+    version: 0.8.3 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -70,7 +70,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.2
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

`cray-powerdns-manager` only creates xname records for compute nodes in the HSN and CHN DNS zones.

```
x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	A	10.253.0.8
x3000c0s17b1n0h0.chn.surtur.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.193.212
```
Users and WLMs prefer NID aliases (e.g. `nid001000.hsn.surtur.hpc.amslabs.hpecorp.net`) and in addition to this HSN NIC specific aliases are required (e.g. `nid001000-hsn0`, `nid001000-hsn1` etc.

This PR changes `cray-powerdns-manager` to create CNAME records for the required aliases that point back to the xname record.

In addition to creating the required HSN records, CHN NID aliases are also created for compute nodes fulfilling a customer requirement ([CAST-31486](https://jira-pro.it.hpe.com:8443/browse/CAST-31486)).

## Issues and Related PRs

* Resolves [CASMNET-2003](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2003), [CASMNET-1150](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1150), [CAST-31486](https://jira-pro.it.hpe.com:8443/browse/CAST-31486)

## Testing

### Tested on:

  * `surtur`
  * `mug`
  * Local development environment
 
### Test description:

Code deployed on surtur

Verified that CHN aliases are correctly created
```
/ $ pdnsutil list-zone chn.surtur.hpc.amslabs.hpecorp.net | grep x3000c0s17b1
nid000001.chn.surtur.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s17b1n0h0.chn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s17b1n0h0.chn.surtur.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.193.212
```
Verified that DNS lookup functions as expected
```
ncn-m001:~ # host nid000001.chn.surtur.hpc.amslabs.hpecorp.net
nid000001.chn.surtur.hpc.amslabs.hpecorp.net is an alias for x3000c0s17b1n0h0.chn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s17b1n0h0.chn.surtur.hpc.amslabs.hpecorp.net has address 10.102.193.212
```

Verified that HSN aliases are correctly created
```
/ $ pdnsutil list-zone hsn.surtur.hpc.amslabs.hpecorp.net | grep x3000c0s17b1
nid000001-hsn0.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net.
nid000001.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	A	10.253.0.8
```
Verified the DNS lookup functions as expected
```
ncn-m001:~ # host nid000001.hsn.surtur.hpc.amslabs.hpecorp.net
nid000001.hsn.surtur.hpc.amslabs.hpecorp.net is an alias for x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net has address 10.253.0.8
ncn-m001:~ # host nid000001-hsn0.hsn.surtur.hpc.amslabs.hpecorp.net
nid000001-hsn0.hsn.surtur.hpc.amslabs.hpecorp.net is an alias for x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s17b1n0h0.hsn.surtur.hpc.amslabs.hpecorp.net has address 10.253.0.8
```
In the case where a node has multiple HSN NICs the main NID aliases points to the hsn0 NIC which is consistent with Unbound.
```
/ $ pdnsutil list-zone hsn.surtur.hpc.amslabs.hpecorp.net | grep x3000c0s4b0n0h
nid100007-hsn0.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s4b0n0h0.hsn.surtur.hpc.amslabs.hpecorp.net.
nid100007-hsn1.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s4b0n0h1.hsn.surtur.hpc.amslabs.hpecorp.net.
nid100007.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s4b0n0h0.hsn.surtur.hpc.amslabs.hpecorp.net.
x3000c0s4b0n0h0.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	A	10.253.0.2
x3000c0s4b0n0h1.hsn.surtur.hpc.amslabs.hpecorp.net	3600	IN	A	10.253.0.1
```

Code deployed on mug, verified HSN records are created correctly on a system that has no CHN.
```
nid000001-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b1n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000001.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b1n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000002-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b2n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000002.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b2n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000003-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b3n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000003.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b3n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000004-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b4n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid000004.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b4n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100004-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s7b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100004.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s7b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100005-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s9b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100005.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s9b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100006-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s11b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100006.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s11b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100012-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s34b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100012.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s34b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100013-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s36b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100013.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s36b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100014-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s38b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100014.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s38b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100015-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s31b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100015.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s31b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100016-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s33b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100016.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s33b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100017-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s35b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100017.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s35b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100018-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s37b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100018.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s37b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100019-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s39b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid100019.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3001c0s39b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid49169408-hsn0.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s32b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
nid49169408.hsn.mug.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s32b0n0h0.hsn.mug.hpc.amslabs.hpecorp.net.
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

