### PR TITLE
CASMPET-6805: Fix bug in Cray-Spire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Update cray-spire to v1.5.3 for Bug fix (CASMPET-6805)
 - Update cray-spire to v1.5.2 for TPM support (CASMPET-6801)
 - Upate cray-opa to v1.32.6, fix tpm endpoints (CASMPET-6800)
 - Update csm-testing and goss-servers to v1.16.56, fix storage node upgrade tests (CASMINST-6650)

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -239,7 +239,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.5.2
+    version: 1.5.3
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This is a bugfix to repair missed naming volume from a secret

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6805](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6805)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * baldar

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

