### PR TITLE
CASMCMS-8816: Include updated virtiofs binary RPM in tarball to workaround upgrade problem

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,10 +44,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - goss-servers-1.16.59-1.noarch
     - csm-testing-1.16.59-1.noarch
+    - goss-servers-1.16.59-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
+    - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64


### PR DESCRIPTION
## Summary and Scope

Adding this RPM to the manifest will, in conjunction with [this PR to modify `prerequisites.sh`](https://github.com/Cray-HPE/docs-csm/pull/4313), allow CSM 1.5 upgrades to automatically work around [CASMTRIAGE-6084](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6084).

No backports to other branches is needed -- this is a problem unique to CSM 1.5 upgrades.

No PR needed to `metal-provision`. We only need this new RPM added to the tarball, but don't need it built into the NCN images.