### PR TITLE
CASMHMS-6072: Pull in updated HMS Discovery chart.

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -37,13 +37,9 @@ spec:
     source: csm-algol60
     version: 2.0.3
     namespace: services
-  - name: cray-hms-reds
-    source: csm-algol60
-    version: 3.0.1
-    namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 2.0.5
+    version: 3.0.0
     namespace: services
 
   # Cray DHCP Kea

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -47,7 +47,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - goss-servers-1.17.12-1.noarch
     - csm-testing-1.17.12-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
-    - hpe-csm-scripts-0.6.2-1.noarch
+    - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -55,6 +55,9 @@ function unbound_psp_check() {
 # CRUS is removed in CSM 1.6, and should be removed during the upgrade, if it exists
 undeploy -n services cray-crus
 
+# REDS is removed in CSM 1.6, and should be removed before installing the CSM 1.6 cray-hms-discovery
+undeploy -n services cray-hms-reds
+
 #
 # cray-etcd-backup and cray-etcd-defrag moving from operators to services namespace,
 # uninstall prior to upgrade.


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Pull in updated HMS Discovery chart.

Will need https://github.com/Cray-HPE/shasta-cfg/pull/9 also pulled in.
For Vshasta will also need: https://github.com/Cray-HPE/livecd-gcp-infrastructure/pull/239



REDS is no longer needed with the new functionality added to HMS Discovery. REDS will no longer be installed on fresh-installs and removed on upgrades.


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-6072

## Testing

_List the environments in which these changes were tested._


### Tested on:

  * Mug
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No


For testing see: https://github.com/Cray-HPE/hms-discovery/pull/33

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

Will need https://github.com/Cray-HPE/shasta-cfg/pull/9 also pulled in.

No known issues.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

