### PR TITLE
CASMHS-6096: Fix FRU History 'Detected' Event Generation in CSM 1.5

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -23,6 +23,9 @@ spec:
     version: 7.0.5
     namespace: services
     values:
+      global:
+        appVersion: 2.11.1
+        testVersion: 2.11.1
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

HSM's FRU tracking was not creating a new 'Detected' event after a 'Removed' event if the same FRU was detected (Removed and put back in the same spot).

## Issues and Related PRs

* Resolves [CASMHMS-6096](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6096)

## Testing

For testing, see https://github.com/Cray-HPE/hms-smd/pull/122

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

