### PR TITLE
CASMINST-6666-release-1.5 update csm-config to version 16.2.22

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.21
+    version: 1.16.22
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

CASMINST-6666 fix csm.storage.smartmon ansible play so that it only deploys node-exporter if the ceph admin keyring is present.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6666](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6666)

## Testing

### Tested on:

  * Beau (vshasta2)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

