### PR TITLE
CASMSEC-402: Kyverno chart needs to handle a large amount of change requests during CSM upgrade

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,8 +62,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
@@ -84,7 +84,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.5.3
+    version: 1.5.4
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION

## Summary and Scope

Kyverno chart needs to handle a large amount of change requests during CSM upgrade. Upgrading kyverno from version 1.7.5 to 1.9.5.

## Testing

Performed upgrade testing along with policy, policy report and cluster policy check.
Attaching logs here.
[Kyverno_upgrade_175_to_195_artiChart.txt](https://github.com/Cray-HPE/csm/files/12756118/Kyverno_upgrade_175_to_195_artiChart.txt)

### Tested on:

MUG

### Test description:

Upgrade testing.