### PR TITLE
ALT-683 Allow wlm role to create BOS sessions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.32.6
+    version: 1.32.7
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update to cray-opa 1.32.7 to support the new PBS provisioning hook.

## Issues and Related PRs

* Resolves [ALT-683](https://jira-pro.it.hpe.com:8443/browse/ALT-683)

## Testing

Tested with cray-opa unit tests.

### Tested on:

  * Local development environment

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? Yes

## Risks and Mitigations

If the wlm role's client secret is leaked, attackers could shutdown or reboot nodes on the system.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

