### PR TITLE
CASMCMS-8809/CASMTRIAGE-6041/CASMINST-6677: Update CFS and BOS for bug fixes and spire paths (1.5)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -116,7 +116,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.10.0
+    version: 1.11.0
     namespace: services
   - name: cfs-trust
     source: csm-algol60
@@ -128,21 +128,21 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.8.0
+    version: 2.9.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.8.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.9.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.15.0
+    version: 1.16.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.15.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.16.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-debugger-1.5.0-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cfs-state-reporter-1.10.1-1.noarch
+    - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
     - cray-site-init-1.32.3-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Updates CFS and BOS versions to fix spire paths in the reporters, error handling in cfs-hwsync-agent and long configuration names in the CFS v2 api

## Issues and Related PRs

* Resolves CASMCMS-8809
* Resolves CASMTRIAGE-6041
* Resolves CASMINST-6677

## Testing

All tested on Mug.  See individual tickets for descriptions

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

