### PR TITLE
CASMHMS-6058: Reduce PCS's ETCD Usage for Completed Records

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -102,12 +102,12 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.4
+    version: 2.1.0
     namespace: services
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.10.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.0.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
## Summary and Scope

PCS's ETCD volume usage can grow large if there are too many power cap task or transition requests in a 24-hour period. To mitigate this issue, I reduced the size of completed records and made the maximum number of completed records to keep and the duration to keep records configurable

## Issues and Related PRs

* Resolves [CASMHMS-6058](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6058)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/37

## Risks and Mitigations

This makes completed transition and power-cap records incompatible with older versions of PCS (v1.x.x) due to the change in the way they are stored in ETCD to reduced their size.

It does not break the ability to downgrade PCS from v2.x.x to v1.x.x. However, if PCS is downgraded, the older PCS (v1.x.x) will not be able to read some of the information in the completed records.

We think this is acceptable since downgrades generally happen when there's a problem with the system and the ability to view the completed records is not needed since there should not be any ongoing transition or power capping operations during a downgrade. Also, all previously existing records are purged after 24 hours by default anyway. So the issue would be transient.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

