### PR TITLE
Revert "CASMSEC-402: Kyverno chart needs to handle a large amount of change requests during CSM upgrade"

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,8 +62,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
@@ -84,7 +84,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.5.4
+    version: 1.5.3
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
Reverts Cray-HPE/csm#2919

This was causing validation to fail:
```
[2023-10-03T16:29:27.128Z] + skopeo inspect docker://artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5
[2023-10-03T16:29:27.707Z] time="2023-10-03T16:29:27Z" level=fatal msg="Error parsing image name \"docker://artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5\": reading manifest v1.9.5 in artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller: manifest unknown: The named manifest is not known to the registry."
```