### PR TITLE
CRAYSAT-1774: Add cray-sat-podman RPM to noos repository

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,6 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
+    - cray-sat-podman-2.1.0-1.noarch
     - cray-site-init-1.32.3-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

This package was part of the SAT product stream and is being added to the CSM product stream to merge the SAT product into CSM fully.

Technically this package is also already installed in the Kubernetes management NCN images, but it seems like a good idea to keep including it in a Nexus package repository like SAT does today. This would enable updates of this package if needed without updating the management NCN images.

## Issues and Related PRs

* Resolves [CRAYSAT-1774](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1774)
* Merge after https://github.com/Cray-HPE/sat-podman/pull/34
* Also wait for a stable build of cray-sat-podman to be produced

## Testing

### Tested on:

  * Jenkins

### Test description:

The Jenkins build should validate that the RPM can be downloaded from the location specified in the `index.yaml` manifest file.

## Risks and Mitigations

Pretty low-risk as it's just adding an RPM that used to be provided by the SAT product to the CSM product.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
