### PR TITLE
Update cfs-operator to take a new AEE image

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -149,7 +149,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.20.0
+    version: 1.21.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The provided version of AEE in release/1.5 is missing necessary ansible modules. This brings them back in line.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8813](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8813)

## Testing

`csm-config` was run using this AEE version.

### Tested on:

  * `mug`
  * Local development environment
  * Virtual Shasta (@alanm-hpe )

## Risks and Mitigations

This is a required fix; CFS will not be able to run existing ansible-playbooks without it.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

