### PR TITLE
MTL-2000 Disable repo sign check

### DIFF
--- a/rpm/cloud-init.yaml
+++ b/rpm/cloud-init.yaml
@@ -12,7 +12,8 @@ zypper:
       baseurl: "https://packages.local/repository/csm-noos?ssl_verify=no"
       enabled: 1
       autorefresh: 1
-      gpgcheck: 0
+      gpgcheck: 1
+      repo_gpgcheck: 0
     # Use Zypper friendly variables so the correct service pack repository is added.
     # NEVER force add a distro repository, or packages that do care about the distro version can break.
     - id: csm-sle
@@ -20,7 +21,8 @@ zypper:
       baseurl: "https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no"
       enabled: 1
       autorefresh: 1
-      gpgcheck: 0
+      gpgcheck: 1
+      repo_gpgcheck: 0
 # List of packages to install. These do not need version pins, because the latest version in nexus is determined by this
 # tarball. Version pinning here would be redundant, and likely lead to more failures if anyone neglected updating it.
 packages:


### PR DESCRIPTION
Repositories are not signed. In order for Zypper to add these repositories without prompting we must disable repo signing checks.

Without this change, the new repos will cause the following prompt:

```bash
ncn-m001:~ # zypper ref
Repository 'CSM Embedded NCN Packages (added by Ansible)' is up to date.
Repository 'csm-noos-rusty' is up to date.
Warning: File 'repomd.xml' from repository 'csm-sle-15sp4-rusty' is unsigned.

    Note: Signing data enables the recipient to verify that no modifications occurred after the data
    were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
    and in extreme cases even to a system compromise.

    Note: File 'repomd.xml' is the repositories master index file. It ensures the integrity of the
    whole repo.

    Warning: We can't verify that no one meddled with this file, so it might not be trustworthy
    anymore! You should not continue unless you know it's safe.

File 'repomd.xml' from repository 'csm-sle-15sp4-rusty' is unsigned, continue? [yes/no] (no):
```
