### PR TITLE
CASMCMS-8828 - increase default IMS job memory size.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -176,12 +176,12 @@ spec:
             tag: 2.3.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.10.0
+    version: 3.10.1
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.10.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.10.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.4


### PR DESCRIPTION
## Summary and Scope

When PVC's were introduced for image storage we decreased the memory requests and limit sizes to make scheduling jobs easier. With some larger jobs, the new default was not sufficient, so this bumps it back up a bit.

Code PR: https://github.com/Cray-HPE/ims/pull/100

## Issues and Related PRs
* Resolves [CASMCMS-8828](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8828)

## Testing
### Tested on:
  * `Slice`

### Test description:

Manual change of the setting resulted in successful job completion.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just increasing resource allocations.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

