### PR TITLE
CASMTRIAGE-6131: Fix bug with CFS session creation by CFS batcher

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -145,7 +145,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.16.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.9.0
+    version: 1.9.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Resolves [CASMTRIAGE-6131](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6131) by fixing a bug causing CFS batcher to create CFS sessions that did nothing.

See source PR for full details:
https://github.com/Cray-HPE/cfs-batcher/pull/59

[1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/2947)

This bug did not exist in CSM 1.4 or earlier.