### PR TITLE
CASMTRIAGE-6116 - cray-dhcp-kea-helper pods log a KeyError when the BSS Global metadata is missing

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -52,7 +52,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.0 # update platform.yaml cray-precache-images with this
+    version: 0.11.1 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3


### PR DESCRIPTION
## Summary and Scope

If the `cray-dhcp-kea-helper` job runs when the BSS Global metadata has been created but the cloud-init metadata has not been created then it fails with a `KeyError` instead of trapping the error and exiting gracefully leaving the Kubernetes CronJob pod in Error state.

```
ncn-m001:~ # kubectl -n services logs cray-dhcp-kea-helper-28266561-6xrds
Traceback (most recent call last):
  File "/srv/kea/dhcp-helper.py", line 1431, in <module>
    main()
  File "/srv/kea/dhcp-helper.py", line 1404, in main
    load_static_ncn_ips(sls_hardware)
  File "/srv/kea/dhcp-helper.py", line 589, in load_static_ncn_ips
    if 'cloud-init' in bss_data[0]:
                       ~~~~~~~~^^^
KeyError: 0
```

This PR improves the error handling of this scenario.

The `cray-dhcp-kea-helper` cronjob also goes into an error state if the Kea API is unavailable.
```
ncn-m001:~ # kubectl -n services logs cray-dhcp-kea-helper-28274400-xkg7m
2023-10-05 00:01:32,455 - __main__ - ERROR - Kea API is not working as expected.
```

This is expected when Kea is first deployed and the main `cray-dhcp-kea` pods are still starting however changing this to exit with a zero return code is undesirable as some warning is required if dhcp-helper is consistently unable to access the API or failing for some reason.

This PR causes completed `cray-dhcp-kea-helper` jobs older than a configurable number of seconds (600 by default) to be automatically cleaned up resulting in less noise however still providing a system administrator some indication that something is wrong if the job is continually failing.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6116](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6116) and [CASMTRIAGE-6133](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6133)

## Testing

### Tested on:

  * `fanta`

### Test description:

Emptied the BSS Global metadata structure.

```
ncn-m001:~/cspiller/tmp # cray bss bootparameters list --hosts Global --format json
[
  {
    "hosts": [
      "Global"
    ],
    "cloud-init": {
      "meta-data": null,
      "user-data": null,
      "phone-home": {
        "pub_key_dsa": "",
        "pub_key_rsa": "",
        "pub_key_ecdsa": "",
        "instance_id": "",
        "hostname": "",
        "fqdn": ""
      }
    }
  }
]
```

Applied `dhcp-helper.py` changes to the system, verified it now exits gracefully.

```
ncn-m001:~/cspiller/tmp # kubectl -n services logs cray-dhcp-kea-helper-28280790-4cwzc
2023-10-09 10:30:07,075 - __main__ - WARNING - Unable to extract cloud-init metadata from BSS response
2023-10-09 10:30:07,075 - __main__ - WARNING - Cray-bss empty
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

