### PR TITLE
CASMPET-6404 Update tds-cpu-requests.yaml for cray-postgresql

### DIFF
--- a/lib/tds-cpu-requests.yaml
+++ b/lib/tds-cpu-requests.yaml
@@ -2,17 +2,30 @@ spec:
   kubernetes:
     services:
       cray-spire:
-        cray-service:
+        cray-postgresql:
+          sqlCluster:
+            resources:
+              requests:
+                cpu: "1"
+      spire:
+        cray-postgresql:
+          sqlCluster:
+            resources:
+              requests:
+                cpu: "1"
+      cray-dhcp-kea:
+        cray-postgresql:
           sqlCluster:
             resources:
               requests:
                 cpu: "1"
       cray-hms-smd:
-        cray-service:
+        cray-postgresql:
           sqlCluster:
             resources:
               requests:
                 cpu: "1"
+        cray-service:
           containers:
             cray-smd:
               resources:


### PR DESCRIPTION
## Summary and Scope

File `tds-cpu-requests.yaml` is used by small systems (3 workers). With `cray-postgresql` chart introduction in 1.5, customizations need to be updated to reflect new chart name.

## Issues and Related PRs

* Required after implementation of  [CASMPET-6404](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6404)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:
Currently, vShasta looks for this file in wrong location, so it's not used. Another PR for vShasta fixes the issue. Without this fix, vShasta upgrade fails on insufficient CPI limits.

## Risks and Mitigations
Low - not used currently.
