### PR TITLE
CRAYSAT-1767: Set cray-sat version in csm-config

### DIFF
--- a/build/images/inspect.sh
+++ b/build/images/inspect.sh
@@ -45,9 +45,6 @@ function resolve_mirror() {
     if [[ "$image" == artifactory.algol60.net/csm-docker/stable/* ]]; then
         # nothing needs to be changed
         echo "${image}"
-    elif [[ "$image" == artifactory.algol60.net/sat-docker/stable/* ]]; then
-        # nothing needs to be changed
-        echo "${image}"
     else
         # docker.io/library/alpine:latest > artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:latest
         # quay.io/skopeo/stable:v1.4.1 > artifactory.algol60.net/csm-docker/stable/quay.io/skopeo/stable:v1.4.1

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -102,7 +102,7 @@ artifactory.algol60.net/csm-docker/stable:
     # This image is used in an init container specified in the loftsman manifest
     # for the csm-config import job.
     docker.io/library/alpine:
-      - 3.18
+      - 3
 
     # Openjdk is used during install procedures to generate keystores
     docker.io/library/openjdk:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -99,6 +99,11 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/istio/kubectl:
       - 1.5.4
 
+    # This image is used in an init container specified in the loftsman manifest
+    # for the csm-config import job.
+    docker.io/library/alpine:
+      - 3.18
+
     # Openjdk is used during install procedures to generate keystores
     docker.io/library/openjdk:
       - 11-jre-slim

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -21,15 +21,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-artifactory.algol60.net/sat-docker/stable:
-  images:
-    cray-sat:
-      - 3.25.6
-
 artifactory.algol60.net/csm-docker/stable:
   images:
     canu:
       - 1.7.6
+
+    # cray-sat is not included in any Helm charts
+    cray-sat:
+      - 3.26.0
+
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:
       - 1.4.0

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -66,6 +66,7 @@ sat_version="@SAT_VERSION@"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 # Bootstrap sat by writing the sat version to the file used by the sat-podman
 # wrapper script. This is later written by the CSM layer of the CFS config.
+mkdir -p /opt/cray/etc/sat
 echo "${sat_version}" > /opt/cray/etc/sat/version
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -59,7 +59,7 @@ nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
 skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
-sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
+sat_image="artifactory.algol60.net/csm-docker/stable/cray-sat"
 # This value is replaced by release.sh at CSM release distribution build time
 sat_version="@SAT_VERSION@"
 # This csm-latest tag is being phased out, but still used as a default

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 
@@ -60,8 +60,13 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.25.6"
+# This value is replaced by release.sh at CSM release distribution build time
+sat_version="@SAT_VERSION@"
+# This csm-latest tag is being phased out, but still used as a default
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
+# Bootstrap sat by writing the sat version to the file used by the sat-podman
+# wrapper script. This is later written by the CSM layer of the CFS config.
+echo "${sat_version}" > /opt/cray/etc/sat/version
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -199,6 +199,27 @@ spec:
         catalog:
           image:
             tag: 1.8.12
+        import_job:
+          initContainers:
+          # This init container will write the desired cray-sat version to vars/main.yml
+          # in the csm.ncn.sat role. This allows the loftsman manifest to specify the
+          # cray-sat container image version, which means the CSM build can set it to match
+          # the version of the container image it packages in the CSM release.
+          - name: set-sat-version
+            # release.sh sets image at CSM distribution build time
+            image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.18"
+            volumeMounts:
+            - mountPath: /shared
+              name: config-overlay
+            env:
+            - name: CRAY_SAT_VERSION
+              # release.sh sets value at CSM release distribution build time
+              value: "csm-latest"
+            command: ['/bin/sh']
+            args:
+            - -c
+            - mkdir -p /shared/roles/csm.ncn.sat/vars/ && echo "sat_container_image_version: $CRAY_SAT_VERSION" > /shared/roles/csm.ncn.sat/vars/main.yml
+
   - name: csm-ssh-keys
     source: csm-algol60
     version: 1.5.6

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.22
+    version: 1.17.0
     namespace: services
     values:
       cray-import-config:

--- a/release.sh
+++ b/release.sh
@@ -67,7 +67,7 @@ yq e "(.spec.charts[] | select(.name == \"cray-csm-barebones-recipe-install\") |
 
 # Get the version of the cray-sat container image in this CSM build. There should
 # only be one version, but if there is more than one, take the latest.
-CRAY_SAT_VERSION="$(yq '."artifactory.algol60.net/sat-docker/stable".images.cray-sat[]' ${ROOTDIR}/docker/index.yaml | sort -Vr | head -n 1)"
+CRAY_SAT_VERSION="$(yq '."artifactory.algol60.net/csm-docker/stable".images.cray-sat[]' ${ROOTDIR}/docker/index.yaml | sort -Vr | head -n 1)"
 
 # Set cray-sat tag in csm-config Helm chart via the Loftsman manifest
 yq e "(.spec.charts[] | select(.name == \"csm-config\") |

--- a/release.sh
+++ b/release.sh
@@ -65,6 +65,30 @@ yq e "(.spec.charts[] | select(.name == \"cray-csm-barebones-recipe-install\") |
 yq e "(.spec.charts[] | select(.name == \"cray-csm-barebones-recipe-install\") | .values.cray-import-kiwi-recipe-image.import_job.PRODUCT_NAME) = \"${RELEASE_NAME}\"" -i "${BUILDDIR}/manifests/sysmgmt.yaml"
 yq e "(.spec.charts[] | select(.name == \"cray-csm-barebones-recipe-install\") | .values.cray-import-kiwi-recipe-image.import_job.name) = \"${RELEASE_NAME}-image-recipe-import-${RELEASE_VERSION}\"" -i "${BUILDDIR}/manifests/sysmgmt.yaml"
 
+# Get the version of the cray-sat container image in this CSM build. There should
+# only be one version, but if there is more than one, take the latest.
+CRAY_SAT_VERSION="$(yq '."artifactory.algol60.net/sat-docker/stable".images.cray-sat[]' ${ROOTDIR}/docker/index.yaml | sort -Vr | head -n 1)"
+
+# Set cray-sat tag in csm-config Helm chart via the Loftsman manifest
+yq e "(.spec.charts[] | select(.name == \"csm-config\") |
+       .values.cray-import-config.import_job.initContainers[] |
+       select(.name == \"set-sat-version\") | .env[] |
+       select(.name == \"CRAY_SAT_VERSION\") | .value) = \"${CRAY_SAT_VERSION}\"" \
+    -i "${BUILDDIR}/manifests/sysmgmt.yaml"
+
+# Get Alpine Linux image tag from docker/index.yaml
+ALPINE_LINUX_TAG="$(yq '."artifactory.algol60.net/csm-docker/stable".images."docker.io/library/alpine"[]' ${ROOTDIR}/docker/index.yaml | sort -Vr | head -n 1)"
+
+# Set Alpine Linux image in csm-config Helm chart via the Loftsman manifest
+yq e "(.spec.charts[] | select(.name == \"csm-config\") |
+       .values.cray-import-config.import_job.initContainers[] |
+       select(.name == \"set-sat-version\") | .image)
+       = \"artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:${ALPINE_LINUX_TAG}\"" \
+    -i "${BUILDDIR}/manifests/sysmgmt.yaml"
+
+# Replace @SAT_VERSION@ in script run during installations
+sed -i "s/@SAT_VERSION@/${CRAY_SAT_VERSION}/" "${BUILDDIR}/lib/setup-nexus.sh"
+
 # Generate Nexus blob store configuration
 generate-nexus-config blobstore <"${ROOTDIR}/nexus-blobstores.yaml" >"${BUILDDIR}/nexus-blobstores.yaml"
 


### PR DESCRIPTION
## Summary and Scope

Add an initContainer definition to the values defined for the `csm-config` Helm chart. This initContainer sets the cray-sat image tag to match the version included in the CSM build, so that they are always consistent. The Ansible content in csm-config sets this cray-sat container image tag in the file `/opt/cray/etc/sat/version`, so that the sat-podman wrapper script knows which version of the image to run.

Add logic to `release.sh` that inspects the container image tags specified in `docker/index.yaml` and injects those tags for the cray-sat container image and the Alpine Linux container image into the csm-config Helm chart values in the Loftsman manifest.

Modify `lib/setup-nexus.sh` to set the `cray-sat` container image version and tag the latest one as `csm-latest`. We are phasing out reliance on this `csm-latest` tag, but it is still the default used by the sat-podman wrapper script if the file `/opt/cray/etc/sat/version` does not exist. Modify `lib/setup-nexus.sh` to also write the tag of the `cray-sat` image to `/opt/cray/etc/sat/version` as well. This is only executed on `ncn-m001`, but that is sufficient for bootstrapping. When the CSM layer of the CFS configuration is applied, this file will be set on all master and worker management nodes.

## Issues and Related PRs

* Resolves [CRAYSAT-1767](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1767)
* Merge after https://github.com/Cray-HPE/csm-config/pull/213

## Testing

### Tested on:

  * mug

### Test description:

I've done various manual tests of each piece of this.

I have tested that shipping a similar Loftsman manifest on mug does result in the correct content being uploaded to the csm-config-management VCS repository. I have tested the individual `yq` commands and `sed` commands added to the `release.sh` script separately outside of their full context.

## Risks and Mitigations

This adds an initContainer to the `csm-config` Helm chart, and if that fails, the import of the csm-config-management repo to VCS will fail.

It's also possible I don't understand the build process fully, and I may have done something incorrectly that won't work due to the ordering of build steps. This should be reviewed carefully.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
