### PR TITLE
CASMHMS-6058 Add quotes around numbers in cray-power-control chart for new variables.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -102,7 +102,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.1.0
+    version: 2.1.1
     namespace: services
     swagger:
     - name: power-control


### PR DESCRIPTION
## Summary and Scope

New variables added in v2.1 did not have quotes around them. This caused a failure during vShasta install. Added the quotes.

## Issues and Related PRs

* Resolves [CASMHMS-6058](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6058)

## Testing

Tested on:

  * Beau - vShasta

Test description:

Verified the new values were properly being picked up when the service is upgraded.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

Minimal risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable