### PR TITLE
CRAYSAT-1766: Update cray-sat version to fix vulnerabilities

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -24,7 +24,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.25.2
+      - 3.25.5
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.25.2"
+sat_version="3.25.5"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

Update the version of the cray-sat container image to fix vulnerabilities reported by Snyk scans.

Also fixes security vulnerabilities reported by dependabot.

## Issues and Related PRs

* Resolves [CRAYSAT-1766](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1766)
* Resolves [CRAYSAT-1778](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1778)

## Testing

### Tested on:

  * mug

### Test description:

This container image version was tested on mug with a simple smoke test.

## Risks and Mitigations

Low risk. Just updates python dependencies and rebuilds with new apk packages.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
