### PR TITLE
CASMINST-6697: Add update-mgmt-ncn-cfs-config.sh script to CSM 1.3

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -104,6 +104,8 @@ rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/chrony/" "${BUILDDIR}/chrony/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
+rsync -aq "${ROOTDIR}/update-mgmt-ncn-cfs-config.sh" "${BUILDDIR}/"
+chmod 755 "${BUILDDIR}/update-mgmt-ncn-cfs-config.sh"
 
 # Copy manifests
 rsync -aq "${ROOTDIR}/manifests/" "${BUILDDIR}/manifests/"
@@ -300,8 +302,10 @@ fi
 # Download HPE GPG signing key (for verifying signed RPMs)
 cmd_retry curl -sfSLRo "${BUILDDIR}/hpe-signing-key.asc" "$HPE_SIGNING_KEY"
 
-# Save cray/nexus-setup and quay.io/skopeo/stable images for use in install.sh
-vendor-install-deps "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
+# Use a newer version of cfs-config-util that hasn't rolled out to other products yet
+CFS_CONFIG_UTIL_IMAGE="arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.0.0"
+# Save cray/nexus-setup, quay.io/skopeo/stable, and cfs-config-util images for use in install.sh
+vendor-install-deps --include-cfs-config-util "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
 
 # Scan container images
 parallel -j 75% --halt-on-error now,fail=1 -v \

--- a/update-mgmt-ncn-cfs-config.sh
+++ b/update-mgmt-ncn-cfs-config.sh
@@ -69,10 +69,15 @@ fi
 
 print_stage "Updating CFS configuration(s)"
 
-# Note that recipes with CSM 1.4 still used the site.yml playbook in the
+# Note that recipes with CSM 1.3 still used the site.yml playbook in the
 # default bootprep files, so that playbook must be used here.
+#
+# Also note that in CSM 1.3, separate CFS configurations were used for node
+# personalization of the management NCNs and for image customization of the
+# worker node image. Only the CFS configuration used for image customization
+# used the ncn-initrd.yml playbook, so it is not specified here.
 cfs-config-util update-configs --product "${RELEASE_NAME}:${RELEASE_VERSION}" \
-    --playbook site.yml --playbook ncn-initrd.yml $@
+    --playbook site.yml $@
 rc=$?
 
 if [[ $rc -eq 2 ]]; then

--- a/update-mgmt-ncn-cfs-config.sh
+++ b/update-mgmt-ncn-cfs-config.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This updates the CFS configuration that applies to management NCNs by adding
+# the appropriate layers for this version of the CSM product.
+#
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+source "${ROOTDIR}/lib/install.sh"
+
+# Print a message with extra emphasis to indicate a stage.
+function print_stage(){
+    msg="$1"
+    echo "====> ${msg}"
+}
+
+# Exit with an error message and an exit code of 1.
+function exit_with_error() {
+    msg="$1"
+    >&2 echo "${msg}"
+    exit 1
+}
+
+load-cfs-config-util
+trap "{ print_stage 'Cleaning up dependencies'; clean-install-deps &>/dev/null; }" EXIT
+
+function print_usage() {
+    cat <<EOF
+usage: ${BASH_SOURCE[0]} [options]
+
+Update the CFS configuration for configuring management NCNs by adding or
+updating the layer for ${RELEASE}.
+
+Options:
+
+  -h, --help              Print this usage information.
+
+EOF
+
+    cfs-config-util-options-help
+}
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+print_stage "Updating CFS configuration(s)"
+
+# Note that recipes with CSM 1.4 still used the site.yml playbook in the
+# default bootprep files, so that playbook must be used here.
+cfs-config-util update-configs --product "${RELEASE_NAME}:${RELEASE_VERSION}" \
+    --playbook site.yml --playbook ncn-initrd.yml $@
+rc=$?
+
+if [[ $rc -eq 2 ]]; then
+    print_usage
+    exit_with_error "cfs-config-util received invalid arguments."
+elif [[ $rc -ne 0 ]]; then
+    exit_with_error "Failed to update CFS configurations. cfs-config-util exited with exit status $rc."
+fi
+
+print_stage "Completed update of CFS configuration(s)"


### PR DESCRIPTION
## Summary and Scope

* CASMINST-6697: Modify `update-mgmt-ncn-cfs-config.sh` for CSM 1.3

  There is a slight difference in CSM 1.3 compared to CSM 1.4 in which CSM
  layers will be present in the CFS configuration which is applied to
  management nodes. Specifically, since the Papaya release (CSM 1.3) did
  not yet combine the two CFS configurations used for management node
  image customization and node personalization into a single CFS
  configuration, only the `site.yml` Ansible playbook was used in the CFS
  configuration applied via node personalization. The `ncn-initrd.yml`
  playbook was only used in a separate CFS configuration specifically for
  customization of Kubernetes worker management nodes.

* CASMINST-6597: Add update-mgmt-ncn-cfs-config.sh script

  This script is used to update only the CSM-provided layers of a CFS
  configuration. This is useful during a patch installation when
`sat bootprep` may not be run with a whole set of new products.

  Documentation will be added to the patch procedure to describe how to
  use this script.

  This script was mostly copied from the sat-product-stream repository.
  It uses existing shell functions defined in the hpc-shastarelm-release
  shared library which is already git-vendor'd into this repository. Those
  functions run the `cfs-config-util` container image with `podman`.

  Use version 5.0.0 of cfs-config-util. Eventually, it would be good to
  update the default version in hpc-shastarelm-release, but since it's a
  backwards-incompatible major version change, we would need to announce
  that and help teams migrate.

  (cherry picked from commit 64ef3d60163453e16ad54f6bfb35c8619f12d544)

## Issues and Related PRs

* Resolves [CASMINST-6697](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6697)
* Documentation changes required in https://github.com/Cray-HPE/docs-csm/pull/4369

## Testing

### Tested on:

  * CSM 1.3 development system TBD

### Test description:

Not tested yet. Note that the test description in the cherry-picked commit describes how it was tested for the CSM 1.4.3 release.

## Risks and Mitigations

This should be pretty low risk even if it doesn't work because it's really just adding a script, and if that script doesn't work, then worst case, the admin can just not run it.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
