### PR TITLE
CASMINST-6699: Ensure test RPMs are updated on masters

### DIFF
--- a/rpm/cloud-init.yaml
+++ b/rpm/cloud-init.yaml
@@ -29,8 +29,10 @@ packages:
   - cani
   - canu
   - cray-cmstools-crayctldeploy
+  - craycli
   - csm-testing
   - goss-servers
+  - hpe-csm-goss-package
   - iuf-cli
   - libcsm
   - platform-utils


### PR DESCRIPTION
Per @rustydb 's comments in [my original PR](https://github.com/Cray-HPE/docs-csm/pull/4373), this is the better way to handle this ticket for CSM 1.5+