### PR TITLE
Sync metal-init

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -54,10 +54,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - iuf-cli-1.6.3-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
+    - metal-init-1.4.6-1.noarch
     - metal-ipxe-2.4.4-1.noarch
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
-    - pit-init-1.4.2-1.noarch
     - platform-utils-1.6.7-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.8.aarch64


### PR DESCRIPTION
pit-init was renamed to metal-init.
the version in the tar is behind the version baked into the image.
