### PR TITLE
CASMCMS-8790: Update CFS to support external repo sources (1.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -137,19 +137,19 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.9.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.16.0
+    version: 1.17.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.16.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.17.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.21.0
+    version: 1.22.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the CFS api and operator to pull in support for external CFS sources.  Also includes a new option for creating configurations and a small fix for session creation.

## Issues and Related PRs

* Resolves CASMCMS-8790
* Resolves CASMCMS-8794
* Resolves CASMTRIAGE-6158

## Testing

### Tested on:

  * Mug

### Test description:

See individual tickets


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

