### PR TITLE
CASMCMS-8830: Update bos for node filtering fixes (1.5)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,13 +128,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.9.0
+    version: 2.10.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.9.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.16.0


### PR DESCRIPTION
## Summary and Scope

Updates BOS to fix issues with node filtering including filtering out disabled nodes and better error messages when there are no valid nodes.

## Issues and Related PRs

* Resolves CASMCMS-8830
* Resolves CASMCMS-8835
* Partially Resolves CASMTRIAGE-6176

## Testing

See individual tickets

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

