### PR TITLE
CRAYSAT-1780: Update cray-sat version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -24,7 +24,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.25.5
+      - 3.25.6
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.25.5"
+sat_version="3.25.6"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

Update the cray-sat container image version to 3.25.6 to pull in the fix for a `sat bootprep` issue where IMS images lost their `arch` field value when images were customized.

## Issues and Related PRs

* Resolves [CRAYSAT-1780](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1780)

## Testing

See https://github.com/Cray-HPE/sat/pull/171

## Risks and Mitigations

See https://github.com/Cray-HPE/sat/pull/171

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

