### PR TITLE
CASMMON-345-and-346(release1.6)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.28.11
+    version: 0.28.12
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

CASMMON-345: CSM 1.5: Grafana dashboard for smartmon , instances name is not listing instead ip is listing
CASMMON-346: CSM 1.5: Grafan TimescaleDB dashboard ALL option is not available for list of postgres pods
CASMMON-347: CSM 1.5: Grafan TimescaleDB dashboard variable name is mentioned as cluster instead of pod

version bump for cray-sysmgmt-health chart from 0.28.11 to 0.28.12

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves: 
* CASMMON-345: https://jira-pro.it.hpe.com:8443/browse/CASMMON-345
* CASMMON-346: https://jira-pro.it.hpe.com:8443/browse/CASMMON-346
* CASMMON-347: https://jira-pro.it.hpe.com:8443/browse/CASMMON-347

## Testing

_List the environments in which these changes were tested._

### Tested on:
Starlord

Smartmon Dashboard:

<img width="960" alt="grafana_smartmon_starlord_0" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/f2b77315-7bc1-41b7-932a-386285270d95">

<img width="959" alt="grafana_smartmon_starlord_1" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/14310102-59f1-4443-8b67-b44f5f5ba4f6">

TimescaleDB dashboard:

<img width="964" alt="grafana_timescaledb_starlord_0" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/7bf047fc-68b2-47fc-8591-b8a2472bd473">

<img width="959" alt="grafana_timescaledb_starlord_1" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/b423b8c5-5305-47d6-93a3-d5217521eb43">

<img width="960" alt="grafana_timescaledb_starlord_2" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/45f5a8f6-f68f-47ab-baa2-85155c09d600">

