### PR TITLE
CASMNET-2170 - Increase cray-dhcp-kea-init job backoffLimit

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -45,7 +45,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.1 # update platform.yaml cray-precache-images with this
+    version: 0.11.2 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3


### PR DESCRIPTION
## Summary and Scope

vshasta deployments have been failing as the cray-dhcp-kea-init job reaches its backoffLimit before the cray-smd service is up.

This PR increases the job backoffLimit to 10 (default is 6) and adds support for configuring it via the Helm chart.

## Issues and Related PRs

* Resolves [CASMNET-2170](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2170)

## Testing

### Tested on:

  * `surtur`

### Test description:

Deployed new chart and checked that backoffLimit was set to the new value.
```
ncn-m002:~ # kubectl -n services get job cray-dhcp-kea-init-2 -o yaml | yq r - spec.backoffLimit
10
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

