### PR TITLE
CASMNET-2171 - Revert HA Kea changes for CSM 1.5

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -52,7 +52,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.1 # update platform.yaml cray-precache-images with this
+    version: 0.10.26 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.26
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3


### PR DESCRIPTION
## Summary and Scope

The cray-dhcp-kea HA changes have not been load tested on a large system. While synthetic testing was promising there is a performance penalty when using PostgreSQL for the lease database and the impact of this has not been measured on a real system so we would rather not include them in CSM 1.5 until boot testing can be done on shandy.

This PR reverts cray-dhcp-kea to the non-HA implementation.

## Issues and Related PRs

* Resolves [CASMNET-2171](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2171)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/4419

## Testing

### Tested on:

  * `fanta`

### Test description:

Helm chart and image were deployed on fanta during a CSM 1.5 fresh install, PIT was successfully redeployed using the older non-HA cray-dhcp-kea implementation

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

