### PR TITLE
CASMTRIAGE-6195: Update cfs-operator to fix session config limit (1.5)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -149,7 +149,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.22.0
+    version: 1.22.1
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the cfs-operator to fix an issue creating sessions when the configuration limit is specified for layer 0.

## Issues and Related PRs

* Resolves CASMTRIAGE-6195

## Testing

### Tested on:

  * beau

### Test description:

Unblocked a previously failing session

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

