### PR TITLE
Update bitnami container images and chart for CSM 1.6 (CASMPET-6758)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,11 +220,11 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.7.0/api/openapi.yaml
   - name: cray-etcd-defrag
     source: csm-algol60
-    version: 0.4.0
+    version: 0.4.1
     namespace: services
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.5.4
+    version: 0.5.5
     namespace: services
   - name: cray-etcd-migration-setup
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

New util image with boto3, kubectl and awscli

### Issues and Related PRs

  * CASMPET-6758: update bitnami-etcd container with upstream merge

### Testing

beau:
```
pit:~/brad # kubectl get pod/cray-etcd-test-etcd-post-install-nqpd4 -n services -o yaml | grep demis
    image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:pet-utils-csm-1.6
```

```
pit:~/brad # kubectl logs pod/cray-etcd-test-etcd-post-install-nqpd4 -n services
Patching snapshotter cronjob to remove labels to allow scheduling alongside etcd pods..
cronjob.batch/cray-etcd-test-bitnami-etcd-snapshotter patched
cronjob.batch/cray-etcd-test-bitnami-etcd-snapshotter patched
Grabbing keys and S3 endpoint from etcd-backup-s3-credentials...
Download snapshot cray-etcd-test_etcd_migration.snapshot-1.db from http://rgw-vip.nmn...
cray-etcd-test_etcd_migration.snapshot-1.db not found, proceeding without data migration...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-etcd-test-bitnami-etcd-864c9f4d98...
Taking initial snapshot of cluster...
Terminated
etcd 22:15:36.50 WARN  ==> etcd endpoint cray-etcd-test-bitnami-etcd-0.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379 not healthy. Trying a different endpoint
cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379 is healthy: successfully committed proposal: took = 21.195615ms
etcd 22:15:36.57 INFO  ==> Snapshotting the keyspace
{"level":"info","ts":"2023-10-23T22:15:36.610206Z","caller":"snapshot/v3_snapshot.go:65","msg":"created temporary db file","path":"/snapshots/cray-etcd-test-bitnami-etcd/db-2023-10-23_22-15.part"}
{"level":"info","ts":"2023-10-23T22:15:36.611594Z","logger":"client","caller":"v3@v3.5.9/maintenance.go:212","msg":"opened snapshot stream; downloading"}
{"level":"info","ts":"2023-10-23T22:15:36.611672Z","caller":"snapshot/v3_snapshot.go:73","msg":"fetching snapshot","endpoint":"cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379"}
{"level":"info","ts":"2023-10-23T22:15:36.64041Z","logger":"client","caller":"v3@v3.5.9/maintenance.go:220","msg":"completed snapshot read; closing"}
{"level":"info","ts":"2023-10-23T22:15:36.651489Z","caller":"snapshot/v3_snapshot.go:88","msg":"fetched snapshot","endpoint":"cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379","size":"20 kB","took":"now"}
{"level":"info","ts":"2023-10-23T22:15:36.652478Z","caller":"snapshot/v3_snapshot.go:97","msg":"saved","path":"/snapshots/cray-etcd-test-bitnami-etcd/db-2023-10-23_22-15"}
Snapshot saved at /snapshots/cray-etcd-test-bitnami-etcd/db-2023-10-23_22-15
Uploading snapshot db-2023-10-23_22-15 to http://rgw-vip.nmn...
Editing etcd statefulset to existing (instead of new cluster)...
statefulset.apps/cray-etcd-test-bitnami-etcd env updated
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

