### PR TITLE
CASMINST-6698 Validate RPM signatures during build

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.13.1}
+export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.14.0}
 export RPM_TOOLS_IMAGE=${RPM_TOOLS_IMAGE:-arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/rpm-tools:1.0.0}
 
 if [ -z "${ARTIFACTORY_USER}" ] || [ -z "${ARTIFACTORY_TOKEN}" ]; then

--- a/hack/assets.sh
+++ b/hack/assets.sh
@@ -89,4 +89,3 @@ for arch in "${CN_ARCH[@]}"; do
     done
 done
 
-process_file "$HPE_SIGNING_KEY" "security/hpe-signing-key.asc" ""


### PR DESCRIPTION
## Summary and Scope

While preparing a set of RPMs to be included into CSM release, now we validate RPM signatures against predefined set of GPG keys.

Currently, signature validation fails on a package named `mft` (which stands for "Mellanox Firmware Tools"), which comes from https://arti.hpc.amslabs.hpecorp.net/artifactory/slingshot-host-software-rpm-master-local. Another PR https://github.com/Cray-HPE/dst-sync/pull/15 and corresponding changes at metal build side are expected to take this package from another location, where it has proper signature.

## Issues and Related PRs

* Resolves [CASMINST-6698](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6698)

## Testing
### Tested on:

  * Local development environment

### Test description:

Ran `make rpms` and `make embedded-repo` targets locally

## Risks and Mitigations

Low - only adds additional validation to the build, without changing release tarball contents.
