### PR TITLE
rename sma-dashboards chart name

### DIFF
--- a/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
+++ b/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml
@@ -678,7 +678,7 @@ spec:
                 requests:
                   cpu: "1"
                   memory: 2Gi
-      sma-dashboards:
+      sma-opensearch-dashboards:
         externalAuthority: sma-dashboards.cmn.{{ network.dns.external }}
         cray-service:
           containers:


### PR DESCRIPTION
## Summary and Scope

While trying to access the `sma-dashboard` via the external URL (e.g., https://sma-dashboards.cmn.slice.hpc.amslabs.hpecorp.net/), I encounter an error that prevented the access. Upon investigating the issue, I discovered that the wrong chart name was used in the customization.yaml, which was the cause of the problem. 

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMSMF-7177
https://jira-pro.it.hpe.com:8443/browse/CAST-34125
https://github.hpe.com/hpe/hpc-car-sma-opensearch/pull/51

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

csm 1.5.0-beta.55 

### Tested on:

  * slice

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

