### PR TITLE
CASMTRIAGE-6208:  Add alpine/git container image required by several argo workflows

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -83,8 +83,13 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/prometheus/alertmanager:
       - v0.25.0
 
+    # Required by argo workflows
     docker.io/portainer/kubectl-shell:
       - latest-v1.21.1-amd64
+
+    # Required by argo workflows
+    docker.io/alpine/git:
+      - 2.32.0
 
     # cray-sysmgmt-health required for platform
     docker.io/ghostunnel/ghostunnel:


### PR DESCRIPTION

## Summary and Scope

The artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0 container image was previously pulled into the CSM tarball in the cfs-operator helm chart.   That chart no longer uses that container but there are several argo workflows that still use that image.   Therefore, we need to pull it explicitly into the tarball.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6208](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6208)

## Testing

### Tested on:

  * Virtual Shasta - cilium cluster

### Test description:

Pulled in the image, verified that update_tags.sh runs successfully and no longer hitting IPBO on workflows that need this image.


