### PR TITLE
Add smart-mon and cray-node-exporter rpms to embedded repo for UAN (CASMINST-6710)

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -54,3 +54,8 @@ https://artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Bases
   rpms:
     - libcurl4-8.0.1-150400.5.32.1.x86_64
     - curl-8.0.1-150400.5.32.1.x86_64
+
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
+  rpms:
+    - cray-node-exporter-1.5.0.1-1.noarch
+    - smart-mon-1.0.3-1.noarch


### PR DESCRIPTION
### Summary and Scope

Add smart-mon and cray-node-exporter rpms to sp4 repo for use by UAN

### Issues and Related PRs

  * CASMPET-6827: Missing RPMs in CSM 143 for SMARTMON enablement on the UAN causes procedure to fail

### Testing

jenkins
```
[2023-10-25T19:05:44.094Z] 2023-10-25 19:05:43,941	INFO	[200 OK] https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/cray-node-exporter/noarch/cray-node-exporter-1.5.0.1-1.noarch.rpm
[2023-10-25T19:05:44.354Z] noarch/cray-node-exporter-1.5.0.1-1.noarch.rpm
[2023-10-25T19:05:44.354Z] 2023-10-25 19:05:44,187	INFO	[200 OK] https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/smart-mon/noarch/smart-mon-1.0.3-1.noarch.rpm
[2023-10-25T19:05:44.354Z] noarch/smart-mon-1.0.
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

