### PR TITLE
CASMPET-6823:  Add ncn-cilium-migrate-tests suite

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - goss-servers-1.17.12-1.noarch
-    - csm-testing-1.17.12-1.noarch
+    - goss-servers-1.17.14-1.noarch
+    - csm-testing-1.17.14-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

We need a health check during the cilium live migration workflow to make sure that critical services are healthy before moving on to migrate the next node.   I first looked at the ncn-upgrade-tests-* suites for worker and master but they include several tests (e.g. goss-check-static-routes, goss-check-mounts-worker) that are not necessary because we are not rebooting the nodes at this point.   This new test has a subset of the union of both the ncn-upgrade-tests-worker and ncn-upgrade-tests-master tests.

## Issues and Related PRs


* Resolves [CASMPET-6823](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6823)

## Testing


### Tested on:

  * Virtual Shasta - cilium cluster

### Test description:

Used this test as a step in the live migration workflow.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

