### PR TITLE
CASMTRIAGE-6164-release-1.5 update iuf-cli to version 1.5.7

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -52,7 +52,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.5.6-1.x86_64
+    - iuf-cli-1.5.7-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

CASMTRIAGE-6164-release-1.5 update iuf-cli to version 1.6.4.

This fixes a warning message in the iuf-cli.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6164](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6164)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

