### PR TITLE
Bump loftsman timeout for cray-power-control (CASMTRIAGE-6226)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -104,6 +104,7 @@ spec:
     source: csm-algol60
     version: 2.1.1
     namespace: services
+    timeout: 10m
     swagger:
     - name: power-control
       version: v1


### PR DESCRIPTION
### Summary and Scope

Bump loftsman timeout for cray-power-control

### Issues and Related PRs

  * CASMTRIAGE-6226: cray-power-control v2.0.4 post-upgrade hook failed due to timeout during CSM upgrade

### Testing

slice 
```
^[[90m2023-10-26T21:26:47Z^[[0m ^[[32mINF^[[0m Running helm install/upgrade with arguments: upgrade --install cray-power-control helm/cray-power-control-2.0.4.tgz --namespace services --create-namespace --set global.chart.name=cray-power-control --set global.chart.version=2.0.4 --timeout 10m ^[[36mchart=^[[0mcray-power-control ^[[36mcommand=^[[0mship ^[[36mnamespace=^[[0mservices ^[[36mversion=^[[0m2.0.4
^[[90m2023-10-26T21:32:51Z^[[0m ^[[32mINF^[[0m Release "cray-power-control" has been upgraded. Happy Helming!
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

