### PR TITLE
CRAYSAT-1767: Fix sysmgmt.yaml loftsman manifest

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -219,7 +219,7 @@ spec:
             command: ['/bin/sh']
             args:
             - -c
-            - mkdir -p /shared/roles/csm.ncn.sat/vars/ && echo "sat_container_image_version: $CRAY_SAT_VERSION" > /shared/roles/csm.ncn.sat/vars/main.yml
+            - 'mkdir -p /shared/roles/csm.ncn.sat/vars/ && echo "sat_container_image_version: $CRAY_SAT_VERSION" > /shared/roles/csm.ncn.sat/vars/main.yml'
 
   - name: csm-ssh-keys
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Loftsman or Helm wants the second arg value to be fully quoted. I think it is because it contains a colon, and it interprets it as a dictionary instead of a string.

Test Description:
Copied and pasted the `csm-config` chart into a
`csm-config-manifest.yaml` file on mug. Downloaded the required helm chart and container image onto mug and modified several values in the manifest to isolate the impact of testing this change. Then shipped the manifest with `lofstman ship --manifest-path `csm-config-manifest.yaml`. Confirmed that the `loftsman` command succeeded, and the K8s job succeeded as well. Inspected resulting content in VCS to ensure `cray-sat` container version was set correctly.

## Issues and Related PRs

* Resolves an issue discovered with [CRAYSAT-1767]()

## Testing

### Tested on:

  * mug

### Test description:

Copied and pasted the `csm-config` chart into a
`csm-config-manifest.yaml` file on mug. Downloaded the required helm chart and container image onto mug and modified several values in the manifest to isolate the impact of testing this change. Then shipped the manifest with `lofstman ship --manifest-path `csm-config-manifest.yaml`. Confirmed that the `loftsman` command succeeded, and the K8s job succeeded as well. Inspected resulting content in VCS to ensure `cray-sat` container version was set correctly.## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
