### PR TITLE
CASMCMS-8865: Fix BOS v2 regression bug in session delete method

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -129,13 +129,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.0
+    version: 2.10.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.17.0


### PR DESCRIPTION
## Summary and Scope

This corrects a regression bug introduced in CSM 1.5 that prevented users from being able to delete multiple BOS v2 sessions in a single request (requests to delete a specific v2 session still worked). This bug does not exist prior to CSM 1.5.

## Issues and Related PRs

* Resolves [CASMCMS-8865](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8865)
* [Source PR](https://github.com/Cray-HPE/bos/pull/229)
* [1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/3027)

## Testing

See source PR for details.

## Risks and Mitigations

This is a regression bug in CSM 1.5. The fix is simple and low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
