### PR TITLE
CASMTRIAGE-6184: Update cray-vaults to 1.6.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

CASMTRIAGE-6184: cray-vaults 1.6.1

Fixes an intermittent startup issue where the init pod runs under a different user context than the vault pod causing EPERM issues.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6184]
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Reference initial pr https://github.com/Cray-HPE/cray-vault/pull/15

### Tested on:

  * beau
  * Local development environment
  * Virtual Shasta

### Test description:

Reference initial pr https://github.com/Cray-HPE/cray-vault/pull/15

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

