### PR TITLE
CASM-4557 bump cray-nls and cray-iuf version to 4.0.5

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -248,11 +248,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.4
+    version: 4.0.5
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.4
+    version: 4.0.5
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

Bump cray-nls and cray-iuf version to 4.0.5.
This bump includes changes to the IUF backend to be able to get the ncn-m001 upgrade workflow if ncn-m001 is supplied as an argument to --limit-management-rollout. As part of the effort to upgrade CSM 'as a product', the ncn-m001 upgrade was automated. 

## Issues and Related PRs

Resolves [CASM-4557](https://jira-pro.it.hpe.com:8443/browse/CASM-4557)

## Testing

### Tested on:

  * Tested on Mug



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

