### PR TITLE
CASMTRIAGE-6318: restore cray-hms-reds

### DIFF
--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -543,9 +543,10 @@ spec:
         cephNodeExporter:
           endpoints: '{{ network.netstaticips.nmn_ncn_storage }}'
           enabled: true
-      cray-hms-discovery:
-        sealedSecrets:
-          - '{{ kubernetes.sealed_secrets.cray_reds_credentials | toYaml }}'
+      cray-hms-reds:
+        cray-service:
+          sealedSecrets:
+            - '{{ kubernetes.sealed_secrets.cray_reds_credentials | toYaml }}'
       cray-rm-pals:
         cray-service:
           sealedSecrets:


### PR DESCRIPTION
## Summary and Scope

A change meant only for 1.6 leaked into 1.5 with this PR: https://github.com/Cray-HPE/csm/pull/3031

This PR restores cray-hms-reds.

This is being committed directly to vendored code because we're going to stop vendoring shasta-cfg.