### PR TITLE
CASMPET-6835: Change kube-proxy-replacement to cilium-kube-proxy-replacement in CSI

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='5.14.21-150500.55.28.1.26977.2.PTF.1214754-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="5.14.21-150500.55.28.1.26977.2.PTF.1214754"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.43
+KUBERNETES_IMAGE_ID=6.1.44
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.43
+PIT_IMAGE_ID=6.1.44
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.43
+STORAGE_CEPH_IMAGE_ID=6.1.44
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.43
+COMPUTE_IMAGE_ID=6.1.44
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
-    - cray-site-init-1.32.3-1.x86_64
+    - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
     - craycli-0.82.11-1.aarch64


### PR DESCRIPTION
### Summary and Scope

- Fixes:  https://jira-pro.it.hpe.com:8443/browse/CASMPET-6835

#### Issue Type

- Bugfix Pull Request

Changes kube-proxy-replacement to cilium-kube-proxy-replacement to match up with kubernetes-cloudinit.sh.

## Testing

### Tested on:

  * Local development environment

### Test description:

Built CSI binary locally and ran `csi config init` both with and without cilium-kube-proxy-replacement defined in system_config.yaml.   Verified that the correct value was generated in data.json.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

