### PR TITLE
CASMTRIAGE-6256 IUF output has incorrect log paths

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -51,7 +51,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.4-1.x86_64
+    - iuf-cli-1.6.5-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

This was a bug fix for iuf-cli. So changing iuf-cli version in 
csm/rpm/cray/csm/noos/index.yaml to the latest i.e from 1.6.4 to 1.6.5 .

## Issues and Related PRs

PR link for iuf-cli - https://github.com/Cray-HPE/iuf-cli/pull/167
JIRA link - https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6256


### Tested on:

  * mug

### Test description:


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

