### PR TITLE
CASMTRIAGE-6152-change-cf-gitea-import-version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -50,7 +50,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.0.6
 
     cf-gitea-import:
-      - 1.9.6
+      - 1.9.7
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
## Summary and Scope

 Update cf-gitea-import-version to 1.9.7 (https://github.com/Cray-HPE/cf-gitea-import/pull/108)
 Bug: copy files to target only if files exist in /shared directory in cf-gitea-import(CASMTRIAGE-6152)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-6152

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

