### PR TITLE
Change PCS usage of ETCD to reduce size

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -104,6 +104,10 @@ spec:
     source: csm-algol60
     version: 2.0.4
     namespace: services
+    values:
+      global:
+        appVersion: 2.0.0
+        testVersion: 2.0.0
     timeout: 10m
     swagger:
     - name: power-control


### PR DESCRIPTION
## Summary and Scope

PCS is slowing filling up ETCD when there are a large number of transactions. This newer PCS improves record retention and storage size of completed transactions.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6281](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6281)

## Testing

### Tested on:

  * Local development environment

### Test description:

Verified transactions were able to write and be retrieved from ETCD without error.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N - local simulation environment
- Was downgrade tested? If not, why? N - local simulation environment
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Not executed on real hardware.
Reverting to an older PCS after this version is used will temporarily make the transaction table in ETCD un-retrievable. Only newer transactions would be available.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

