### PR TITLE
CASMPET-6860-release-1.6 update csm-config to v1.17.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -193,7 +193,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.17.0
+    version: 1.17.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
Update csm-config to v1.17.1.
This update deploys node-exporter via cephadm shell in ansible play that installs smartmon on storage nodes.
csm-config PR: https://github.com/Cray-HPE/csm-config/pull/217.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6860](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6860)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau

### Test description:

Tested CFS configuration on storage nodes on Beau.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

