### PR TITLE
CASMNET-2175 - make interface used for NID alias configurable.

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.23 # update platform.yaml cray-precache-images with this
+    version: 0.7.24 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.23
+        appVersion: 0.7.24
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.2
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.23
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.24
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

`cray-dns-unbound` manager associates all HSN NICs with the nid alias.

```bash
ncn-m001:~ # host nid001046
nid001046 has address 10.150.0.45
nid001046 has address 10.150.0.126
nid001046 has address 10.150.0.142
nid001046 has address 10.150.0.141
```
Some WLMs handle this poorly and some customers desire WLM communication with a node to happen over a single HSN interface.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CAST-33693](https://jira-pro.it.hpe.com:8443/browse/CAST-33693) [CASMNET-2175](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2175)
* Merge with/before/after `https://github.com/Cray-HPE/docs-csm/pull/4513`

## Testing

### Tested on:

  * `surtur`

### Test description:

#### Test 1 - Default options (hsnNicAlias 0)

Deployed chart with default options.

Verified HSN_NIC_ALIAS setting in the CronJob 
```
            env:
            - name: HSN_NIC_ALIAS
              value: "0"
```
Verified generated DNS record only points to -hsn0
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28344168-rjgqd | head
2023-11-22 10:48:07,972 - __main__ - INFO - Using interface h0 to build the nid alias

ncn-m001:~ # host nid100005
nid100005 has address 10.253.0.6
ncn-m001:~ # host nid100005-hsn0
nid100005-hsn0 has address 10.253.0.6
```

#### Test 2 - hsnNicAlias set to 1

Deployed chart with hsnNicAlias set to 1
```
 yq w -i customizations.yaml spec.kubernetes.services.cray-dns-unbound.hsnNicAlias 1
```
Verified HSN_NIC_ALIAS setting in the CronJob 
```
            env:
            - name: HSN_NIC_ALIAS
              value: "1"
```
Verified generated DNS record only points to -hsn1
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28344170-tzxxs | head
2023-11-22 10:50:10,049 - __main__ - INFO - Using interface h1 to build the nid alias

ncn-m001:~ # host nid100005
nid100005 has address 10.253.0.5
ncn-m001:~ # host nid100005-hsn1
nid100005-hsn1 has address 10.253.0.5
```

#### Test 3 - hsnNicAlias set to all

Deployed chart with hsnNicAlias set to all
```
 yq w -i customizations.yaml spec.kubernetes.services.cray-dns-unbound.hsnNicAlias all
```
Verified HSN_NIC_ALIAS setting in the CronJob 
```
            env:
            - name: HSN_NIC_ALIAS
              value: all
```
Verified generated DNS record only points to both interfaces.
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28344174-p75c8
2023-11-22 10:54:08,211 - __main__ - INFO - Using all interfaces to build the nid alias

ncn-m001:~ # host nid100005
nid100005 has address 10.253.0.5
nid100005 has address 10.253.0.6
```

#### Test 4 - hsnNicAlias set to badvalue

Deployed chart with hsnNicAlias set to badvalue
```
 yq w -i customizations.yaml spec.kubernetes.services.cray-dns-unbound.hsnNicAlias badvalue
```
Verified HSN_NIC_ALIAS setting in the CronJob 
```
            env:
            - name: HSN_NIC_ALIAS
              value: badvalue
```
Verified generated DNS record only points to both interfaces.
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28344178-4qjsd | head
2023-11-22 10:58:08,510 - __main__ - ERROR - HSN_NIC_ALIAS is not numeric or all, defaulting to all nics for alias

ncn-m001:~ # host nid100005
nid100005 has address 10.253.0.5
nid100005 has address 10.253.0.6
```

#### Test 5 - Remove HSN_NIC_ALIAS environment variable from CronJob

Deleted the HSN_NIC_ALIAS variable from the cronjob
```
ncn-m001:~ # kubectl -n services get cronjob cray-dns-unbound-manager -o yaml | yq r - spec.jobTemplate.spec.template.spec.containers[0].env
- name: KEA_API_ENDPOINT
  value: http://cray-dhcp-kea-api:8000
- name: SMD_API_ENDPOINT
  value: http://cray-smd
- name: SLS_API_ENDPOINT
  value: http://cray-sls
- name: KUBERNETES_UNBOUND_CONFIGMAP_NAME
  value: cray-dns-unbound
- name: KUBERNETES_NAMESPACE
  value: services
- name: KUBERNETES_UNBOUND_DEPLOYMENT_NAME
  value: cray-dns-unbound
- name: LOG_LEVEL
  value: INFO
```
Verified generated DNS record points to both interfaces.
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28344180-742bz
2023-11-22 11:00:10,609 - __main__ - ERROR - HSN_NIC_ALIAS environment variable not set, defaulting to all nics for alias

ncn-m001:~ # host nid100005
nid100005 has address 10.253.0.5
nid100005 has address 10.253.0.6
```

## Risks and Mitigations

`cray-dns-unbound-manager` currently has no way of knowing how many HSN interfaces a node has as that data comes from the SLS HSN network that is populated by the Slingshot fabric manager.

If `hsnNicAlias` is set to a value that doesn't exist for a node, for example `hsnNicAlias` is set to `4` on a node that only has one HSN NIC then the top level alias simply won't get created therefore hsnNicAlias should be set to a value that corresponds to a HSN NIC number that all nodes have. This limitation will be covered by the supporting documentation.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

