### PR TITLE
CASMINST-6727: Update to correct product catalog version for CSM 1.5

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -199,7 +199,11 @@ spec:
       cray-import-config:
         catalog:
           image:
-            tag: 1.8.12
+            # The following version is the cray-product-catalog version.
+            # Unless there is a specific reason not to, this version should be
+            # updated whenever the cray-product-catalog chart version is updated, and
+            # vice versa.
+            tag: 1.9.0
   - name: csm-ssh-keys
     source: csm-algol60
     version: 1.5.6
@@ -215,6 +219,9 @@ spec:
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
+    # Unless there is a specific reason not to, this version should be
+    # updated whenever the csm-config catalog image version is updated, and
+    # vice versa.
     version: 1.9.0
     namespace: services
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -168,13 +168,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.2.0
+    version: 2.2.1
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.2.0
+            tag: 2.2.1
   - name: cray-ims
     source: csm-algol60
     version: 3.10.1


### PR DESCRIPTION
I noticed that when the product catalog version was updated in the cray-product-catalog chart, it was not also updated in the `csm-config` stanza. Unless there is a good reason for these to differ (and in this case there is not), they should match.

I also noticed that `cray-import-kiwi-recipe-image` (which pulls in the product catalog image) had not been updated to reflect the current version of the product catalog for CSM 1.5. This in turn meant that `image-recipes` was also using the wrong version, since it includes `cray-import-kiwi-recipe-image`.

This PR bumps the version of the product catalog in `csm-config` and the version of `image-recipes` so that they are all using the correct version of the product catalog for CSM 1.5.

(This also incidentally addressed a CVE in the version of `ims-load-artifacts` being used by `image-recipes`.)