### PR TITLE
CASMINST-6727: Update to correct product catalog version for CSM 1.6

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -217,6 +217,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.8.8
       - 1.8.12
       - 1.9.0
+      - 1.10.0
     cray-nexus-setup:
       - 0.10.1
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -199,7 +199,11 @@ spec:
       cray-import-config:
         catalog:
           image:
-            tag: 1.8.12
+            # The following version is the cray-product-catalog version.
+            # Unless there is a specific reason not to, this version should be
+            # updated whenever the cray-product-catalog chart version is updated, and
+            # vice versa.
+            tag: 1.10.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -236,7 +240,10 @@ spec:
   # Cray Product Catalog
   - name: cray-product-catalog
     source: csm-algol60
-    version: 1.9.0
+    # Unless there is a specific reason not to, this version should be
+    # updated whenever the csm-config catalog image version is updated, and
+    # vice versa.
+    version: 1.10.0
     namespace: services
 
   # Cray UAS Manager service

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -168,13 +168,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.3.0
+    version: 2.4.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.3.0
+            tag: 2.4.0
   - name: cray-ims
     source: csm-algol60
     version: 3.10.1


### PR DESCRIPTION
This is the CSM 1.6 version of https://github.com/Cray-HPE/csm/pull/3056

It is identical except that it uses the appropriate versions for CSM 1.6.