### PR TITLE
CASMTRIAGE-6333: Update velero goss test description

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.62-1.noarch
-    - goss-servers-1.16.62-1.noarch
+    - csm-testing-1.16.63-1.noarch
+    - goss-servers-1.16.63-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
## Summary and Scope

This changes the description of the Velero Check for no failed backup tests to have the remedy be more accurate to what the test is running. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6333](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6333)

## Testing

Made a fake output to mimic a failed velero backup and tested the output to ensure the output is the same

### Tested on:

  * Drax

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

No Risk only change in description


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

