### PR TITLE
CASMCMS-8872: cmsdev: Add no-cleanup option to assist in test debug

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
-    - cray-cmstools-crayctldeploy-1.14.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.16.0-1.x86_64
     - cray-site-init-1.32.3-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.82.11-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Add an option to the cmsdev test tool that stops it from deleting the temporary files it creates during execution. This helps greatly with debug, and is a tiny change.

## Issues and Related PRs

* [Source PR](https://github.com/Cray-HPE/cms-tools/pull/153)
* [CASMCMS-8872](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8872)
* [1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/3063)

## Testing

Tested on starlord.

## Risks and Mitigations

Very small change and very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
