### PR TITLE
CASMHMS-6108 new heartbeat image add xname to url

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -39,8 +39,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.82.11-1.aarch64
     - craycli-0.82.11-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.3-1.aarch64
-    - csm-node-heartbeat-2.3-1.x86_64
+    - csm-node-heartbeat-2.3.1-1.aarch64
+    - csm-node-heartbeat-2.3.1-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

When there is API GW filtering, the only valid URLs allowed through the gateway require an xname to be present at the end of the URL. Change the csm-node-heartbeat.sh script to include the xname on the URL. cray-hms-hbtd accepts both a URL with and without the xname in it.

## Issues and Related PRs

* Resolves [CASMHMS-6108](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6108)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `lemondrop`

### Test description:

Manually deployed the updated csm-node-heartbeat.sh file onto nid 18 and restarted csm-node-heartbeat service, resulting service status included the xname in the URL and HBTD received the heartbeat notification and the node went from On to Ready.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N - really a poc, deployment requires RPM build and image rebuild.
- Was downgrade tested? If not, why? N - really a poc, deployment requires RPM build and image rebuild.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

