### PR TITLE
CASMTRIAGE-6368/6292 - fix sftp use in IMS customize jobs and increase job memory limits.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -177,12 +177,12 @@ spec:
             tag: 2.4.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.10.1
+    version: 3.11.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.10.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.11.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.4


### PR DESCRIPTION
## Summary and Scope

Integrate the changes from ims-sshd to fix sftp use on customize jobs, and increase the default memory requirements / limits to handle bigger images work without changing IMS defaults.

Code PR's:
https://github.com/Cray-HPE/ims/pull/100
https://github.com/Cray-HPE/ims-sshd/pull/39

## Issues and Related PRs
* Resolves [CASMTRIAGE-6368](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6368)
* Resolves [CASMTRIAGE-6292](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6292)

## Testing
### Tested on:
  * `Mug`

### Test description:

I did a clean helm install of the new IMS service and tested the ssh/sftp access on jobs, and verified the new updated memory settings are present.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

The changes are small, so the only risks are the normal ones associated with last-minute changes to a release.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
