### PR TITLE
New SLS to pick 1.0.4 postgres chart

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.4
     namespace: services
     swagger:
     - name: sls


### PR DESCRIPTION

## Summary and Scope

Updated SLS version, which contains the updated postgres chart 1.0.4

## Issues and Related PRs

* Resolves [CASMHMS-6110](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6110)

## Testing

### Tested on:

### Test description:

Tested by SLS github actions

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

