### PR TITLE
CASMINST-6730: Add Goss test to verify that all Kubernetes NCNs are at the same level

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - goss-servers-1.17.17-1.noarch
-    - csm-testing-1.17.17-1.noarch
+    - goss-servers-1.17.18-1.noarch
+    - csm-testing-1.17.18-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Add a test to CSM health checks to catch situations where Kubernetes NCNs are not running the same image.

## Issues and Related PRs

* [Source PR](https://github.com/Cray-HPE/csm-testing/pull/559)
* [1.5 manifest PR](https://github.com/Cray-HPE/csm/pull/3071)
* [1.5 `metal-provision` PR](https://github.com/Cray-HPE/metal-provision/pull/583)
* [1.6 `metal-provision` PR](https://github.com/Cray-HPE/metal-provision/pull/582)

## Testing

Tested on mug, starlord, and wasp.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
