### PR TITLE
CASMCMS-8451: Update bos for multitenancy session warnings

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -129,7 +129,7 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.1
+    version: 2.11.0
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Updates bos so that it returns warnings when one tenant attempts to run a session on another tenant's nodes.

## Issues and Related PRs

* Resolves CASMCMS-8451

## Testing

See PR for details

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

