### PR TITLE
CASMINST-6735: Make BGP test more easily debugged

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - goss-servers-1.17.18-1.noarch
-    - csm-testing-1.17.18-1.noarch
+    - goss-servers-1.17.19-1.noarch
+    - csm-testing-1.17.19-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Add additional output to Goss BGP test to make it easier to debug.

## Issues and Related PRs

* Inspired by having to debug a BGP test failure for [CASMTRIAGE-6378](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6378).
* Resolves [CASMINST-6735](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6735)
* [`metal-provision` manifest PR](https://github.com/Cray-HPE/metal-provision/pull/585)

## Testing

Tested on mug and starlord.

## Risks and Mitigations

Very low risk -- changes are very small and do not alter the test logic.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
