### PR TITLE
MTL-2351 Add Broadcom support to fresh installs

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -41,7 +41,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - libcsm-0.0.4-1.noarch
     - manifestgen-1.3.9-1.x86_64
     - metal-basecamp-1.2.4-1.x86_64
-    - metal-ipxe-2.2.14-1.noarch
+    - metal-ipxe-2.2.16-1.noarch
     - pit-init-1.2.43-1.noarch
     - pit-nexus-1.2.1-1.x86_64
     - pit-observability-1.0.6-1.x86_64


### PR DESCRIPTION
Adds broadcom support for fresh installs, includes the Bradcom vendor as an allowed management network interface vendor.

Requires: https://github.com/Cray-HPE/docs-csm/pull/4556