### PR TITLE
MTL-2351 Broadcom support in fresh installs

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -56,7 +56,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.6-1.noarch
-    - metal-ipxe-2.4.4-1.noarch
+    - metal-ipxe-2.4.7-1.noarch
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.6.7-1.noarch


### PR DESCRIPTION
Adds broadcom support for fresh installs, includes the Bradcom vendor as an allowed management network interface vendor.

Requires another PR with new images.