### PR TITLE
CRAYSAT-1792: updating sat version addressing security fixes

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.26.0
+      - 3.26.2
 
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:


### PR DESCRIPTION
IM:CRAYSAT-1785, CRAYSAT-1792
Reviewer:Ryan

## Summary and Scope

Two of the critical security vulnerability updates have been done. One is for the urllib3 and other one is cryptography.
Hence adding the latest version of SAT to the release branch.


## Issues and Related PRs

* Resolves [CRAYSAT-1785](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1785)
* Resolves [CRAYSAT-1792](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1792)
* Change will also be needed in `1.5` as well, but since SAT is fully available from 1.6 onwards, I will raise a separate PR to address it 


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `MUG`


### Test description:

The version is tested against various SAT commands and looks good without any issues.

## Risks and Mitigations

Updating the SAT version

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

