### PR TITLE
CASMTRIAGE-6370-release-1.5 update csm-config version to 1.16.24

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -193,7 +193,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.23
+    version: 1.16.24
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Update csm-config version to 1.16.24.

This change updates csm.storage.smartmon to use specific ceph image when redeploying node-exporter

## Issues and Related PRs

* Resolves [CASMTRIAGE-6370](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6370)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

