### PR TITLE
CASMCMS-8875: Fix CFS configuration bugs (1.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -138,12 +138,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.17.1
+    version: 1.17.2
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.17.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.17.2/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.1


### PR DESCRIPTION
## Summary and Scope

Fixes two issues
- Fixes an issue when using clone_urls only rather than sources with the v3 api
- Fixes an issue updating commit ids from branches in existing configurations using the v2 api.

## Issues and Related PRs

* Resolves CASMCMS-8875
* Resolves CASMCMS-8876

## Testing

### Tested on:

  * Mug

### Test description:

Validated test cases that were previously failing

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

