### PR TITLE
CASMNET-2177 - cray-dns-unbound should leave existing config in place if it fails to load new config

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.24 # update platform.yaml cray-precache-images with this
+    version: 0.7.25 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.24
+        appVersion: 0.7.25
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.2
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.24
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.25
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

If the `binaryData.records.json.gz` key is missing from the `cray-dns-unbound` ConfigMap then a number of issues can occur.

* The cray-dns-unbound config reloader (initialize.py) fails if it can't open `/configmap/records.json.gz` causing the cray-dns-unbound pods to go into CLBO resulting in a DNS outage.
* manager.py cannot recover from a missing `records.json.gz` without manual intervention.

This PR introduces the following changes
* If `initialize.py` cannot open either `records.json.gz` or the unbound config then it logs an error and exits cleanly leaving the existing configuration in place so the DNS service is preserved.
* If `manager.py` is unable to read `records.json.gz` from the ConfigMap then it sets the value to the gzipped, base64 encoded representation of `[]` so that all the records are added to the new ConfigMap.
* If the `kubectl replace --force` command fails to apply the new ConfigMap it is retried.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-2177](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2177) [CASMNET-2176](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2176) [CAST-34692](https://jira-pro.it.hpe.com:8443/browse/CAST-34692)

## Testing

### Tested on:

  * `surtur`

### Test description:

#### Test 1 - cray-dns-unbound initialize.py crashes if records.json.gz is missing from the configmap.

Suspended cray-dns-unbound-manager cronjob and deleted records.json.gz
```
# kubectl -n services get cm cray-dns-unbound -o yaml | yq d - 'binaryData."records.json.gz"' | kubectl replace --force -f -
configmap "cray-dns-unbound" deleted
configmap/cray-dns-unbound replaced
```
Verified that existing configuration is left intact and config reloader loop continues to run.
```
+ sleep 90
+ true
+ /srv/unbound/initialize.py
2023-Dec-08 17:17

Starting check for updates to DNS records
ID for loaded data	..2023_12_08_17_14_54.517874601
ID for mounted data	..2023_12_08_17_17_22.147195099

Difference in IDs between mounted and loaded data detected

Copying data from mounted folder to Unbound config folder.
Unable to load config and records from ConfigMap. Leaving existing configuration in place
+ sleep 90
```
Pods also continue to run and DNS is functional
```
# kubectl get pod -n services -l app.kubernetes.io/name=cray-dns-unbound
NAME                               READY   STATUS    RESTARTS   AGE
cray-dns-unbound-dc7994cc9-62mss   3/3     Running   0          8m42s
cray-dns-unbound-dc7994cc9-9lz4r   3/3     Running   0          8m43s
cray-dns-unbound-dc7994cc9-ml5ds   3/3     Running   0          8m47s

# host api-gw-service-nmn.local 10.92.100.225
Using domain server:
Name: 10.92.100.225
Address: 10.92.100.225#53
Aliases:

api-gw-service-nmn.local has address 10.92.100.71
```
#### Test 2 - cray-dns-unbound-manager cannot heal from a missing records.json.gz without manual intervention.

Deleted records.json.gz from the cray-dns-unbound configmap.
```
# kubectl -n services get cm cray-dns-unbound -o yaml | yq d - 'binaryData."records.json.gz"' | kubectl replace --force -f -
configmap "cray-dns-unbound" deleted
configmap/cray-dns-unbound replaced
```
Verified manager.py now repopulates the ConfigMap with all records instead of terminating because the binaryData key is missing.
```
2023-12-08 17:24:26,935 - __main__ - ERROR - Key 'binaryData' missing from ConfigMap. Setting to [] to force rebuild of records.
2023-12-08 17:24:26,936 - __main__ - INFO - Loaded current DNS entries from configmap 0
2023-12-08 17:24:26,936 - __main__ - INFO - Number of existing records 0
2023-12-08 17:24:26,937 - __main__ - INFO - Number of new records (including duplicates) 18356
2023-12-08 17:24:26,937 - __main__ - INFO - Comparing new and existing DNS records 0
2023-12-08 17:24:26,937 - __main__ - INFO -     Differences found.  Writing new DNS records to our configmap.
2023-12-08 17:24:27,179 - __main__ - INFO -   Applying the configmap
configmap "cray-dns-unbound" deleted
configmap/cray-dns-unbound replaced

2023-12-08 17:24:27,796 - __main__ - INFO - Merged records and reloaded configmap 0
```

#### Test 3 - Verify ConfigMap update is retried in the event of a problem
```
2023-12-08 17:41:33,715 - __main__ - INFO - Number of new records (including duplicates) 18356
2023-12-08 17:41:33,715 - __main__ - INFO - Comparing new and existing DNS records 0
2023-12-08 17:41:33,715 - __main__ - INFO -     Differences found.  Writing new DNS records to our configmap.
2023-12-08 17:41:33,960 - __main__ - INFO -   Applying the configmap
configmap "cray-dns-unbound" deleted
error: timed out waiting for the condition

2023-12-08 17:46:34,531 - __main__ - ERROR -   Failed to apply the configmap, retrying.
configmap "cray-dns-unbound" deleted
configmap/cray-dns-unbound replaced

2023-12-08 17:46:41,203 - __main__ - INFO - Merged records and reloaded configmap 307
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable



