### PR TITLE
CASMTRIAGE-6426 bump ims to v3.12.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -177,7 +177,7 @@ spec:
             tag: 2.2.1
   - name: cray-ims
     source: csm-algol60
-    version: 3.11.0
+    version: 3.12.0
     namespace: services
     swagger:
     - name: ims


### PR DESCRIPTION
## Summary and Scope
Needed to increase the size of PVC for IMS due to resource constraints when building large images.

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6426

## Testing

Drax

### Tested on:

Development system

### Test description:
Tested change to configmap on drax system to unblock developers running into PVC sizing issues.

## Risks and Mitigations
No risks

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

