### PR TITLE
CRAYSAT-1789: Update cray-sat to 3.27.0

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.26.2
+      - 3.27.0
 
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:


### PR DESCRIPTION
## Summary and Scope

Update the version of the cray-sat container image from 3.26.2 to 3.27.0. This adds the ability to specify `additional_inventory` in CFS configurations created by `sat bootprep` per a customer request.

## Issues and Related PRs

* Resolves [CRAYSAT-1789](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1789)

## Testing

See https://github.com/Cray-HPE/sat/pull/178 for details on how the new `sat bootprep` functionality was tested.

## Risks and Mitigations

Pretty low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
