### PR TITLE
CASMCMS-8884/CASMTRIAGE-6214: cf-gitea-update: Pin Alpine version to prevent build issues; improve logging

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,8 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.9.0
 
     cf-gitea-update:
-      - 1.0.6
+      - 1.0.8
+      - 1.1.0
 
     cf-gitea-import:
       - 1.9.7


### PR DESCRIPTION
## Summary and Scope

Pins the Alpine version in the docker image to prevent build failures. It is being pinned to the version it had already been using (prior to it automatically trying and failing to build with a newer version), so this is essentially a no-op.

This also pulls in the logging improvements for [CASMTRIAGE-6214](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6214), which was apparently intended to go in several months ago, but somehow slipped through the cracks.

## Issues and Related PRs

* Resolves [https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8884](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8884)
* Resolves [CASMTRIAGE-6214](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6214)
