### PR TITLE
CASMCMS-8880: Update etcd base chart version; Pin Alpine version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -129,13 +129,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.1
+    version: 2.10.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.17.2


### PR DESCRIPTION
## Summary and Scope

* Pins the Alpine version in the docker image to prevent build failures. It is being pinned to the version it had already been using (prior to it automatically trying and failing to build with a newer version), so this is essentially a no-op.
* Updates the etcd base chart version to address [CASMPET-6876](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6876)

## Issues and Related PRs

* Resolves [CASMCMS-8880](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8880) -- which is the ticket to cover the BOS portion of [CASMPET-6876](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6876)
* [CSM 1.6 backport](https://github.com/Cray-HPE/csm/pull/3102)
* [CSM 1.6 metal-provision PR](https://github.com/Cray-HPE/metal-provision/pull/599)
* [CSM 1.5 metal-provision PR](https://github.com/Cray-HPE/metal-provision/pull/600)