### PR TITLE
Rebuilds of HMS charts to pull in new ETCD chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.1.4
+    version: 3.1.5
     namespace: services
     swagger:
     - name: bss
@@ -52,7 +52,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.3.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.0.4
+    version: 3.0.5
     namespace: services
     swagger:
     - name: firmware-action
@@ -60,7 +60,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.29.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.0.2
+    version: 3.0.4
     namespace: services
     swagger:
     - name: hbtd
@@ -68,7 +68,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.19.1/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 4.0.0
+    version: 4.0.2
     namespace: services
     swagger:
     - name: hmnfd
@@ -102,7 +102,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.4
+    version: 2.0.5
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Bump version numbers to rebuild and pull in new etcd base chart.

## Issues and Related PRs

* Resolves [CASMHMS-6117](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6117)
* Resolves [CASMHMS-6118](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6118)
* Resolves [CASMHMS-6119](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6119)
* Resolves [CASMHMS-6120](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6120)
* Resolves [CASMHMS-6121](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6121)

## Testing

Tested on:

  * Virtual Shasta - beau

Test description:

Verified the newly built charts contained the updated etcd base chart. Deployed all charts on vShasta sytem Beau and all upgrades worked as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

No known risks

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable