### PR TITLE
CASMCMS-8885: Fix bug in version sorting in cf-gitea-import

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -50,7 +50,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.0.6
 
     cf-gitea-import:
-      - 1.9.7
+      - 1.9.8
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
## Summary and Scope

This fixes a bug in the version sorting algorithm used by `cf-gitea-import` (the tool used to load repo data into VCS). The bug can cause new branches to be based off of the incorrect existing branch, which can in turn lead to merge failures when updating products.

## Issues and Related PRs

* Resolves [CASMCMS-8885](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8885)
* [1.6 backport PR](https://github.com/Cray-HPE/csm/pull/3111)

## Testing

Tested on slice on a variety of different products, verifying that the updated algorithm chooses the correct base branch.

## Risks and Mitigations

Low risk. The updated code is simpler, and the changes are isolated to a single function -- for both reasons, it made it easier to test.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

