### PR TITLE
CASMCMS-8885: Fix bug in version sorting in cf-gitea-import

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -51,7 +51,7 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.1.0
 
     cf-gitea-import:
-      - 1.9.7
+      - 1.10.0
 
     cray-capmc:
       - 2.7.0


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/csm/pull/3110