### PR TITLE
CASMSEC-402: Kyverno chart needs to handle a large amount of change requests during CSM upgrade

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,8 +62,9 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
@@ -84,7 +85,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.5.3
+    version: 1.6.0
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Kyverno chart needs to handle a large amount of change requests during CSM upgrade. Hence Kyverno was upgraded to 1.9.5 version in CSM 1.5. The upgraded Kyverno is made available in CSM 1.6 as well with this PR.

Currently the builds are failing as there is lower version of Kyverno in CSM 1.6 compared to CSM 1.5. Hence this PR is required.

## Testing

This change has been tested and submitted for CSM 1.5 version and attaching the logs for reference.


[Kyverno155ReleaseChartUpgradeTstLog.txt](https://github.com/Cray-HPE/csm/files/13885403/Kyverno155ReleaseChartUpgradeTstLog.txt)

Since CSM 1.6 system is unavailable at present this is yet to be tested on it.