### PR TITLE
DVS-2961: Update OPA to allow SLS calls for DVS (generating node map)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.33.2
+    version: 1.33.3
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
Updating version number to pick up the latest changes from cray-opa.

See the PR at: https://github.com/Cray-HPE/cray-opa/pull/104 for more details.