### PR TITLE
CASMCMS-8886/CASMCMS-8887/CASMCMS-8888: CFS bug fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -138,12 +138,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.17.2
+    version: 1.18.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.17.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.2


### PR DESCRIPTION
## Summary and Scope

The CFS changes contained here are small, but they resolve three problems:

* [CASMCMS-8887](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8887): Deleting multiple CFS sessions succeeds but returns 500
* [CASMCMS-8888](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8888): Error patching multiple CFS v3 components
* [CASMCMS-8886](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8886): CFS API behavior/spec discrepancies

The first two are fixing things that do not work in CFS v3, but in both cases the fixes are single line, simple fixes.

The last one is correcting CFS API response codes. The reason this should go into CSM 1.5 is because it is the first release that contains CFS v3. Once that goes public, we lose the ability to fix problems in the API so easily, because customers may already be coding to the published spec. And the changes here are small, and have been tested, so pose little risk. I've also discussed it with Ryan B and he is fine with it going into CSM 1.5

## Issues and Related PRs

* Source PRs:
  * https://github.com/Cray-HPE/config-framework-service/pull/100
  * https://github.com/Cray-HPE/config-framework-service/pull/101
  * https://github.com/Cray-HPE/config-framework-service/pull/102
* [1.6 manifest PR](https://github.com/Cray-HPE/csm/pull/3124)

## Testing

This has been tested extensively on mug.

## Risks and Mitigations

Low risk -- all of the changes are very small and contained.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

