### PR TITLE
MTL-2350 PTF Kernel and Marvell Driver MTL-2363 dracut typo

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -31,17 +31,17 @@ NCN_ARCH='x86_64'
 CN_ARCH=("x86_64")
 
 # All images must use the same, exact kernel version.
-KERNEL_VERSION='5.14.21-150500.55.28.1.26977.2.PTF.1214754-default'
+KERNEL_VERSION='5.14.21-150500.55.39.1.27360.1.PTF.1215587-default'
 # NOTE: The kernel-default-debuginfo package version needs to be aligned
 # to the KERNEL_VERSION. Always verify and update the correct version of
 # the kernel-default-debuginfo package when changing the KERNEL_VERSION
 # by doing a zypper search for the corresponding kernel-default-debuginfo package
 # in the SLE-Module-Basesystem update_debug repo
 # zypper --plus-repo=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update_debug se -s kernel-default-debuginfo
-KERNEL_DEFAULT_DEBUGINFO_VERSION="5.14.21-150500.55.28.1.26977.2.PTF.1214754"
+KERNEL_DEFAULT_DEBUGINFO_VERSION="5.14.21-150500.55.39.1.27360.1.PTF.1215587"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.53
+KUBERNETES_IMAGE_ID=6.1.54
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.53
+PIT_IMAGE_ID=6.1.54
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.53
+STORAGE_CEPH_IMAGE_ID=6.1.54
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.53
+COMPUTE_IMAGE_ID=6.1.54
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \


### PR DESCRIPTION
[MTL-2350](https://jira-pro.it.hpe.com:8443/browse/MTL-2350): New PTF Kernel and Marvell driver.
- `kernel-default-5.14.21-150500.55.39.1.27360.1.PTF.1215587`
- `qlgc-fastlinq-kmp-default=8.74.1.0_k5.14.21_150500.53-1.sles15sp5`

[MTL-2363](https://jira-pro.it.hpe.com:8443/browse/MTL-2363) "one one" typo