### PR TITLE
CRAYSAT-1795: updating SAT version having snyk issues fixed

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.7
+      - 3.21.8
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.7"
+sat_version="3.21.8"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
IM:CRAYSAT-1795
Reviewer:Ryan

## Summary and Scope

Update the version of cray-sat to 3.21.8 to resolve  CVE reported by Snyk and VTN. See the sat changelog for details.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1795](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1795)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * MUG

### Test description:

Tested for sat commands looks good without any issues


## Risks and Mitigations

Low Risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

