### PR TITLE
CRAYSAT-1800: Update cray-sat to 3.27.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.27.0
+      - 3.27.2
 
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:


### PR DESCRIPTION
## Summary and Scope
Update the version of cray-sat to 3.27.2. This includes fixes for the following:

* CRAYSAT-1795: fix for Python paramiko security vulnerability
* CRAYSAT-1800: fix for traceback and improved filter parser

## Issues and Related PRs

* CRAYSAT-1795
* CRAYSAT-1800

## Testing

See PRs in sat repo.

## Risks and Mitigations

See PRs in sat repo.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable