### PR TITLE
CASMTRIAGE-6550: Update spire for dvs-mqtt

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -247,7 +247,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.5.4
+    version: 1.5.5
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

Update cray-spire-server to have the dvs-mqtt-spire-agent workloads so that dvs-mqtt can authenticate with spire. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6550](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6550)
* Resolves. [CASMTRIAGE-6551](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6551)

## Testing

### Tested on:

  * Lemondrop
  * odin
 
### Test description:

Manual installation of changes


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No risks adding features that were present in the old spire chart.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

