### PR TITLE
CASMCMS-8086/CASMCMS-8592/CASMCMS-8890: Update CMS tests for BOS v1 removal in CSM 1.6

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
-    - cray-cmstools-crayctldeploy-1.16.0-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,5 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-debugger-1.6.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.17.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,5 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
     - cfs-debugger-1.6.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.17.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64


### PR DESCRIPTION
## Summary and Scope

Contains 3 changes to the CMS tests in preparation for the removal of BOS v1 in CSM 1.6:
* [CASMCMS-8890](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8890): Install barebones test in a Python virtual environment
  * This should have been done a long time ago, really. This part isn't related to BOS v1 removal.
* [CASMCMS-8086](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8086): Overhaul the barebones boot test. Among other things, changes it to use BOS v2.
* [CASMCMS-8592](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8592): Remove BOSv1 tests from `cmsdev` test tool

## Issues and Related PRs

* [Source PR for CASMCMS-8890](https://github.com/Cray-HPE/cms-tools/pull/157)
* [Source PR for CASMCMS-8086](https://github.com/Cray-HPE/cms-tools/pull/158)
* [Source PR for CASMCMS-8592](https://github.com/Cray-HPE/cms-tools/pull/159)

## Testing

I tested the changes on drax and mug.
