### PR TITLE
Updated scsd to version 2.1.6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -80,12 +80,12 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 2.1.5
+    version: 2.1.6
     namespace: services
     swagger:
     - name: scsd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.17.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.19.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
     version: 4.0.0


### PR DESCRIPTION

## Summary and Scope

Updated scsd to version 2.1.6

scsd was changed to return 404 status codes when the vault information is not available.

## Issues and Related PRs

* Resolves [CASMHMS-6125](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6125)
* Resolves [CASMTRIAGE-6464](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6464)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * mug
  * docker compose environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

