### PR TITLE
CRAYSAT-1798: Update cray-sat container image to 3.27.3

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.27.2
+      - 3.27.3
 
     # XXX update-uas v1.4.0 should include these
     cray-uai-sles15sp3:


### PR DESCRIPTION
## Summary and Scope

This fixes the `sat swap switch/cable` issue reported in CRAYSAT-1798.

## Testing

See https://github.com/Cray-HPE/sat/pull/187

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
