### PR TITLE
CASMNET-2180 - Upgrade PowerDNS to latest version

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -60,7 +60,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.3.0 # update platform.yaml cray-precache-images with this
+    version: 0.3.1 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.25
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15


### PR DESCRIPTION
## Summary and Scope

Upgrade PowerDNS from v4.6.4 to v4.8.x as v4.6 is EOL and no longer receiving updates.

https://doc.powerdns.com/authoritative/appendices/EOL.html

This update requires a database schema change.

This PR also adds the following content
* Enables support for the PowerDNS `lmdb` backed. The PostgreSQL based `gpgsql` backend is still the default.
* Add the `lightningstream` plugin which will be used in a future release to improve the scaling of PowerDNS by eliminating PostgreSQL and synchronising lmdb based instances via an S3 bucket.
*  Adds the `dnscontrol` utility to allow manipulation of zones.

## Issues and Related PRs

* Resolves [CASMNET-2180](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2180)

## Testing

### Tested on:

  * `drax`
  * Local development environment

### Test description:

Installed new release and verified database schema migration occurred.
```
ncn-m001:~/cspiller # kubectl -n services logs cray-dns-powerdns-7cb9c45877-h7qr9
Applying Update 4.3.0_to_4.7.0_schema.pgsql.sql
ALTER TABLE
ALTER TABLE
CREATE INDEX
INSERT 0 1
grep: /etc/pdns/conf.d/03-db-creds.conf: No such file or directory
Jan 15 14:28:03 Guardian is launching an instance
Jan 15 14:28:03 UDP server bound to 0.0.0.0:5053
Jan 15 14:28:03 UDP server bound to [::]:5053
Jan 15 14:28:03 TCP server bound to 0.0.0.0:5053
Jan 15 14:28:03 TCP server bound to [::]:5053
Jan 15 14:28:03 Creating backend connection for TCP
```
Verified DNS service operates as expected.

The `grep: /etc/pdns/conf.d/03-db-creds.conf: No such file or directory` error is not related to this PR, it's an unsuppressed grep that fails in the first loop iteration because the file hasn't been created yet.

## Risks and Mitigations

Automated rollback via Helm isn't possible because the entrypoint script in the previous version fails if the active database schema version is higher than the target version. Because of this, the rollback procedure is to uninstall this version of the Helm chart and re-install the earlier one. The database will be automatically populated next time `cray-dns-powerdns-manager` runs.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable