### PR TITLE
CASMCMS-8905: Removed unintended ability to update all BOS v2 session fields

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -129,13 +129,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.13.0
+    version: 2.14.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.12.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.14.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.8.0-1.noarch
+    - bos-reporter-2.14.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.7.6-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch
@@ -34,8 +34,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
-    - craycli-0.82.11-1.aarch64
-    - craycli-0.82.11-1.x86_64
+    - craycli-0.82.12-1.aarch64
+    - craycli-0.82.12-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.5-1.aarch64
     - csm-node-heartbeat-2.5-1.x86_64


### PR DESCRIPTION
## Summary and Scope

The current BOS API (in both spec and actual behavior) allows the v2 sessions PATCH call to modify pretty much any field of the session. This is not the intended behavior. In practice, this call should only be used by BOS internally, and even then it should only ever be modifying the components and status fields.

This PR modifies the BOS API spec to reflect this, as well as the actual API behavior. In addition, it modifies the CLI to remove the "v2 update sessions" command path, as it is not intended to be used by administrators.

Right now I have only made a CSM 1.5.1 backport PR for this. However, this problem also exists in CSM 1.3 and CSM 1.4. Ideally this change would be backported to those, because the change is very simple, and any administrator who modifies BOS v2 sessions is very likely to run into very strange issues. But this isn't such a critical problem that we should make a patch release JUST to pull it in. I don't know how we keep track of "things to include in patches if/when we make them", but this should be on such a list for CSM 1.3 and CSM 1.4.

## Issues and Related PRs

* [`metal-provision` manifest PR](https://github.com/Cray-HPE/metal-provision/pull/636)
* [CSM 1.5.1 backport manifest PR](https://github.com/Cray-HPE/csm/pull/3166)
* Resolves [CASMCMS-8905](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8905)
* [BOS source PR](https://github.com/Cray-HPE/bos/pull/245)
* [Cray CLI source PR](https://github.com/Cray-HPE/craycli/pull/135)

## Testing

I tested the updated BOS and CLI on mug.

## Risks and Mitigations

Low risk -- the changes are very small in scope.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
