### PR TITLE
CASM-4348: product catalog enhancements to avoid size limitations

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -212,13 +212,6 @@ artifactory.algol60.net/csm-docker/stable:
       - 1.10.0
 
     # Images needed by IUF and possibly non-CSM products
-    cray-product-catalog-update:
-      - 1.3.1
-      - 1.3.2
-      - 1.8.8
-      - 1.8.12
-      - 1.9.0
-      - 1.10.0
     cray-nexus-setup:
       - 0.10.1
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -168,13 +168,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.4.0
+    version: 2.5.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.4.0
+            tag: 2.5.0
   - name: cray-ims
     source: csm-algol60
     version: 3.12.0
@@ -203,7 +203,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 1.10.0
+            tag: 2.0.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -243,7 +243,7 @@ spec:
     # Unless there is a specific reason not to, this version should be
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
-    version: 1.10.0
+    version: 2.0.0
     namespace: services
 
   # Cray UAS Manager service


### PR DESCRIPTION
## Summary and Scope

I am creating this manifest PR on behalf of @lathanan . This manifest PR updates to a new Cray Product Catalog version, removes the older, now-incompatible versions, and also updates the image importer tool (to a version that is built with the new product catalog version).

The new product catalog version addresses the following jiras:
* [CASM-4348](https://jira-pro.it.hpe.com:8443/browse/CASM-4348)
* [CASM-4350](https://jira-pro.it.hpe.com:8443/browse/CASM-4350)
* [CASM-4367](https://jira-pro.it.hpe.com:8443/browse/CASM-4367)
* [CASM-4368](https://jira-pro.it.hpe.com:8443/browse/CASM-4368)
* [CASM-4427](https://jira-pro.it.hpe.com:8443/browse/CASM-4427)
* [CASM-4474](https://jira-pro.it.hpe.com:8443/browse/CASM-4474)
* [CASM-4475](https://jira-pro.it.hpe.com:8443/browse/CASM-4475)
* [CASM-4501](https://jira-pro.it.hpe.com:8443/browse/CASM-4501)
* [CASM-4504](https://jira-pro.it.hpe.com:8443/browse/CASM-4504)
* [CASM-4545](https://jira-pro.it.hpe.com:8443/browse/CASM-4545)
* [CASM-4546](https://jira-pro.it.hpe.com:8443/browse/CASM-4546)

Source PR:
https://github.com/Cray-HPE/cray-product-catalog/pull/304

No backport PRs needed -- this is for CSM 1.6 only.

## Testing

@lathanan will have to speak to this one, if needed.
