### PR TITLE
CASMCMS-8913/CASMTRIAGE-6578: cmstools fix and packaging change

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
-    - cray-cmstools-crayctldeploy-1.18.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.18.1-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,6 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
+    - cray-cmstools-crayctldeploy-1.18.0-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -24,6 +24,5 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-debugger-1.6.0-1.x86_64
-    - cray-cmstools-crayctldeploy-1.17.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -24,6 +24,5 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
     - cfs-debugger-1.6.0-1.x86_64
-    - cray-cmstools-crayctldeploy-1.17.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64


### PR DESCRIPTION
## Summary and Scope

Includes changes for two Jiras.

* [CASMCMS-8913](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8913): Basically a packaging change to the cmstools RPM so that it contains multiple Python virtual environments, and when the test is run, it selects the appropriate one to use based on the Python versions installed on the system. This allows us to have it be a `noos` RPM.
* [CASMTRIAGE-6578](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6578): Updated cray-tftp-upload script to handle more than one ipxe pod
