### PR TITLE
CASMPET-6899: Update trustedcerts-operator for memory limit

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -137,7 +137,7 @@ spec:
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
-    version: 0.8.1
+    version: 0.8.2
     namespace: pki-operator
   - name: cray-s3
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Updates the memory limits to a higher value to prevent OOM Kills. 

## Issues and Related PRs

* Resolves [CASMPET-6899](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6899)
* Resolves [CASMPET-6761](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6761)

## Testing

### Tested on:

  * Slice

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

On downgrade to a previous version it is possible the chart will revert to the old memory limits and not keep the updated values. This can not be fixed only workaround would be to manually change the values on charts before version 0.8.2


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

