### PR TITLE
CASMTRIAGE-6625: Update TTL on cray-spire-update-bss job

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -247,7 +247,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.5.5
+    version: 1.5.6
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope
 
Extends the TTL of the update-bss job to 1 month if there are delays on the installation process. This allows for installation to be done over a weekend or week if there are some issues getting through the install in one step.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6625](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6625)

## Testing
### Tested on:

  * mug
  * vidar

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No risk just extending the TTL on a job.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

