### PR TITLE
CASMCMS-8917: Only build barebones test for Python 3.11

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
-    - cray-cmstools-crayctldeploy-1.18.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.19.0-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch


### PR DESCRIPTION
Since all NCNs in CSM 1.6 are running SP5, they'll all have Python 3.11, so there's no need to continue building the CSM 1.6 barebones test for Python 3.10.