### PR TITLE
CASMCMS-8916: Fix bugs with BOS v2 components PATCH/PUT

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='5.14.21-150500.55.39.1.27360.1.PTF.1215587-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="5.14.21-150500.55.39.1.27360.1.PTF.1215587"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.67
+KUBERNETES_IMAGE_ID=6.1.68
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.67
+PIT_IMAGE_ID=6.1.68
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.67
+STORAGE_CEPH_IMAGE_ID=6.1.68
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.67
+COMPUTE_IMAGE_ID=6.1.68
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -129,13 +129,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.14.0
+    version: 2.15.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.14.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.14.0-1.noarch
+    - bos-reporter-2.15.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.7.6-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

This PR corrects the following issues with BOS v2 components PATCH/PUT requests:
* A PATCH API call to the BOS v2 components endpoint results in a 500 internal server error if it includes a filter with a non-existent component ID.
* In addition, if a component filter is specified, the BOS API requires that exactly one of the following is specified: a non-empty ID list or a non-empty session name. However, the API spec does not include this requirement (either verbally or as part of the spec).
* Finally, the API does little to no validation of its inputs for the PATCH or PUT components endpoints.

Other PRs:
* [`metal-provision` 1.6 PR](https://github.com/Cray-HPE/metal-provision/pull/643)
* [1.5.1 backport](https://github.com/Cray-HPE/csm/pull/3181)