### PR TITLE
Updated hms-discovery to version 3.0.1

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -39,7 +39,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 3.0.0
+    version: 3.0.1
     namespace: services
 
   # Cray DHCP Kea


### PR DESCRIPTION
## Summary and Scope

hms-discovery was changed to not overwrite existing creds in vault with the default creds

CASMHMS-6129

## Issues and Related PRs

* Resolves [CASMHMS-6129](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6129)


## Testing

### Tested on:

  * tyr
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

