### PR TITLE
Updated hms-hmcollector version to 2.16.4

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -76,7 +76,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.19.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.16.3
+    version: 2.16.4
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Added support for paradise nodes to hmcollector

CASMHMS-6133

## Issues and Related PRs

* Resolves [CASMHMS-6133](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6133)

## Testing

### Tested on:

  * tyr
  * Local development environment

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

