### PR TITLE
Updated cray-hms-rts version to 4.0.1

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -88,12 +88,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.17.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
-    version: 4.0.0
+    version: 4.0.1
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
-    version: 4.0.0
+    version: 4.0.1
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

Updated cray-hms-rts version to 4.0.1
Added a large time to live config setting to the rts init job

CASMHMS-6099

## Issues and Related PRs

* Resolves [CASMHMS-6099](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6099)

## Testing

### Tested on:

  * mug

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

