### PR TITLE
CASMNET-2181 - cray-dns-unbound-manager stderr handling can corrupt configuration

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.25 # update platform.yaml cray-precache-images with this
+    version: 0.7.26 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.25
+        appVersion: 0.7.26
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.2
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.25
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.26
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

The code that invokes `kubectl` in manager.py (and coredns.py) merges stdout and stderr.

On an in house system the K8s API was misbehaving and the `kubectl` invoked to read the existing configuration got throttled by the API.
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28476586-jzrdj
2024-02-22 10:04:16,061 - __main__ - INFO - Using interface h0 to build the nid alias
2024-02-22 10:04:16,062 - __main__ - INFO - Querying Kea in the cluster to find any updated records we need to set
2024-02-22 10:04:16,125 - __main__ - INFO - Retrieved Kea data 0s
2024-02-22 10:04:16,125 - __main__ - INFO - Found 75 leases and reservations in Kea globals
2024-02-22 10:04:16,125 - __main__ - INFO - Found 15 subnets in Kea
2024-02-22 10:04:16,125 - __main__ - INFO - Found 51 leases and reservations in Kea local subnets 0s
2024-02-22 10:04:16,126 - __main__ - INFO - Gathered 51 total leases and reservations local and global 0s
2024-02-22 10:04:16,232 - __main__ - INFO - Queried SMD to find any xname records we need to set 0s
2024-02-22 10:04:16,232 - __main__ - INFO - Found 1036 records in SMD
2024-02-22 10:04:16,238 - __main__ - INFO - Merged new SMD xnames into DNS data structure 0s
2024-02-22 10:04:16,308 - __main__ - INFO - Queried SLS to find Management, Application and HSN nid records 0
2024-02-22 10:04:16,308 - __main__ - INFO - Found 1128 SLS Hardware records.
2024-02-22 10:04:16,308 - __main__ - INFO - Merged new SLS Application and Management names into DNS data structure
2024-02-22 10:04:16,326 - __main__ - INFO - Queried SLS to find Network records 0
2024-02-22 10:04:16,326 - __main__ - INFO - Found 13 SLS Network records.
2024-02-22 10:04:16,327 - __main__ - INFO - Merged new static and alias SLS entries into DNS data structure 0
2024-02-22 10:04:16,327 - __main__ - INFO - Found 14 compute node nid definitions in SLS hardware.
2024-02-22 10:04:16,327 - __main__ - INFO - Matched 12 compute node nid definitions in SLS network reservations.
I0222 10:04:17.576432       7 request.go:655] Throttling request took 1.180686863s, request: GET:https://10.16.0.1:443/apis/policy/v1beta1?timeout=32s
apiVersion: v1
binaryData:
  records.json.gz: H4sICLQ/Z2AAA3JlY29yZHMuanNvbgCLjuUCAETSaHADAAAA
```
This error then got merged into the output ConfigMap resulting in invalid YAML so the cray-dns-unbound ConfigMap was deleted without being replacement with new content.
```
2024-02-22 10:04:18,224 - __main__ - INFO -   Applying the configmap
configmap "cray-dns-unbound" deleted
error: error validating "/tmp/tmp5y24hhjn.yaml": error validating data: ValidationError(ConfigMap): unknown field "I0222 10:04:17.576432       7 request.go:655] Throttling request took 1.180686863s, request" in io.k8s.api.core.v1.ConfigMap; if you choose to ignore these errors, turn validation off with --validate=false

2024-02-22 10:04:18,872 - __main__ - ERROR -   Failed to apply the configmap, retrying.
error: error validating "/tmp/tmp5y24hhjn.yaml": error validating data: ValidationError(ConfigMap): unknown field "I0222 10:04:17.576432       7 request.go:655] Throttling request took 1.180686863s, request" in io.k8s.api.core.v1.ConfigMap; if you choose to ignore these errors, turn validation off with --validate=false

Error running command
```
## Issues and Related PRs

* Resolves [CASMNET-2181](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2181)

## Testing

### Tested on:

  * `groot`
  * Local development environment

### Test description:

Deployed new code on groot and verified that the coredns job generates the correct configuration in the presence of errors.

```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-coredns-zmr5w
Loading current CoreDNS configmap in namespace kube-system: coredns
Stdout:
.:53 {
    errors
    health {
       lameduck 5s
    }
    ready
    kubernetes cluster.local in-addr.arpa ip6.arpa {
       pods insecure
       fallthrough in-addr.arpa ip6.arpa
       ttl 30
    }
    prometheus :9153
    forward . 10.92.100.225 {
       max_concurrent 10000
    }
    cache 30
    loop
    reload
    loadbalance
}

Stderr:
I0222 14:30:00.651348       7 request.go:655] Throttling request took 1.184358065s, request: GET:https://10.16.0.1:443/apis/apiextensions.k8s.io/v1beta1?timeout=32s

Stdout:

Stderr:

Patching the CoreDNS configmap to forward to: 10.92.100.225

data:
  Corefile: |
    .:53 {
        errors
        health {
           lameduck 5s
        }
        ready
        kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
        }
        prometheus :9153
        forward . 10.92.100.225 {
           max_concurrent 10000
        }
        cache 30
        loop
        reload
        loadbalance
    }


Stdout:
configmap/coredns patched (no change)

Stderr:

Running a rolling restart of the CoreDNS deployment...
Stdout:
deployment.apps/coredns restarted

Stderr:
```
Verified that the cray-dns-unbound-manager cronjob can also successfully generate and update DNS records when the K8s API is throttling requests.
```
ncn-m001:~ # kubectl -n services logs cray-dns-unbound-manager-28476870-tl9vb
2024-02-22 14:30:18,858 - __main__ - INFO - Using interface h0 to build the nid alias
2024-02-22 14:30:18,858 - __main__ - INFO - Querying Kea in the cluster to find any updated records we need to set
2024-02-22 14:30:18,908 - __main__ - INFO - Retrieved Kea data 0s
2024-02-22 14:30:18,908 - __main__ - INFO - Found 75 leases and reservations in Kea globals
2024-02-22 14:30:18,908 - __main__ - INFO - Found 15 subnets in Kea
2024-02-22 14:30:18,908 - __main__ - INFO - Found 51 leases and reservations in Kea local subnets 0s
2024-02-22 14:30:18,908 - __main__ - INFO - Gathered 51 total leases and reservations local and global 0s
2024-02-22 14:30:19,020 - __main__ - INFO - Queried SMD to find any xname records we need to set 0s
2024-02-22 14:30:19,020 - __main__ - INFO - Found 1036 records in SMD
2024-02-22 14:30:19,026 - __main__ - INFO - Merged new SMD xnames into DNS data structure 0s
2024-02-22 14:30:19,101 - __main__ - INFO - Queried SLS to find Management, Application and HSN nid records 0
2024-02-22 14:30:19,101 - __main__ - INFO - Found 1128 SLS Hardware records.
2024-02-22 14:30:19,101 - __main__ - INFO - Merged new SLS Application and Management names into DNS data structure
2024-02-22 14:30:19,132 - __main__ - INFO - Queried SLS to find Network records 0
2024-02-22 14:30:19,132 - __main__ - INFO - Found 13 SLS Network records.
2024-02-22 14:30:19,134 - __main__ - INFO - Merged new static and alias SLS entries into DNS data structure 0
2024-02-22 14:30:19,134 - __main__ - INFO - Found 14 compute node nid definitions in SLS hardware.
2024-02-22 14:30:19,134 - __main__ - INFO - Matched 12 compute node nid definitions in SLS network reservations.
2024-02-22 14:30:19,134 - __main__ - INFO - Running kubectl to retrieve existing records and configuration.
Stdout:
apiVersion: v1
binaryData:
  records.json.gz: H4sICLQ/Z2AAA3JlY29yZHMuanNvbgCLjuUCAETSaHADAAAA
data:
  unbound.conf: |-
    server:
        module-config: "iterator"
        chroot: ""
        interface: 127.0.0.1
        interface: 0.0.0.0
        port: 5053
        so-reuseport: yes
        do-ip6: no
        do-daemonize: no
        use-syslog: no
        logfile: ""
        access-control: 127.0.0.1/32 allow
        num-threads: 2
        verbosity: 0
        log-queries: no
        statistics-interval: 0
        statistics-cumulative: no
        # Minimum lifetime of cache entries in seconds
        cache-min-ttl: 180
        # Maximum lifetime of cached entries
        cache-max-ttl: 3600
        # Maximum lifetime of negative responses
        cache-max-negative-ttl: 5
        prefetch: yes
        prefetch-key: yes
        # Optimisations
        msg-cache-slabs: 2
        rrset-cache-slabs: 2
        infra-cache-slabs: 2
        key-cache-slabs: 2
        # increase memory size of the cache
        rrset-cache-size: 1024m
        msg-cache-size: 512m
        infra-cache-numhosts: 1000000
        # increase buffer size so that no messages are lost in traffic spikes
        so-rcvbuf: 5m
        # Set this to no for compatibility with PBSPro which requires deterministic ordering of rrsets.
        rrset-roundrobin: no
        # Continue to health check down DNS servers so they aren't offline longer than necessary
        infra-keep-probing: yes
        infra-host-ttl: 30

        local-data: "health.check.unbound A 127.0.0.1"
        local-data-ptr: "127.0.0.1 health.check.unbound"
        include: /etc/unbound/records.conf
        access-control: 10.0.0.0/8 allow
        access-control: 127.0.0.0/8 allow

        local-zone: "local" static
        local-zone: "nmn." static
        local-zone: "hmn." static
        local-zone: "mtl." static
        local-zone: "hsn." static
        local-zone: "can." static
        local-zone: "cmn." static
        local-zone: "chn." static
        local-zone: "10.in-addr.arpa." nodefault

    forward-zone:
        name: .
        forward-addr: 10.92.100.85
        forward-first: yes

    stub-zone:
        name: groot.hpc.amslabs.hpecorp.net
        stub-addr: 10.92.100.85

    stub-zone:
        name: 10.in-addr.arpa.
        stub-addr: 10.92.100.85

     remote-control:
        control-enable: yes
        control-use-cert: no
        control-interface: 0.0.0.0
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: cray-dns-unbound
    meta.helm.sh/release-namespace: services
  creationTimestamp: "2024-02-22T14:29:41Z"
  labels:
    app.kubernetes.io/instance: cray-dns-unbound
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cray-dns-unbound
    helm.sh/chart: cray-dns-unbound-0.7.26-20240222140316_07373cd
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:binaryData:
        .: {}
        f:records.json.gz: {}
      f:data:
        .: {}
        f:unbound.conf: {}
      f:metadata:
        f:annotations:
          .: {}
          f:meta.helm.sh/release-name: {}
          f:meta.helm.sh/release-namespace: {}
        f:labels:
          .: {}
          f:app.kubernetes.io/instance: {}
          f:app.kubernetes.io/managed-by: {}
          f:app.kubernetes.io/name: {}
          f:helm.sh/chart: {}
    manager: helm
    operation: Update
    time: "2024-02-22T14:29:41Z"
  name: cray-dns-unbound
  namespace: services
  resourceVersion: "877128599"
  uid: 00a1d069-62f5-446f-a964-91346eb945b1

Stderr:
I0222 14:30:20.427715       7 request.go:655] Throttling request took 1.183305697s, request: GET:https://10.16.0.1:443/apis/wgpolicyk8s.io/v1alpha2?timeout=32s

2024-02-22 14:30:21,058 - __main__ - INFO - Loaded current DNS entries from configmap 1
2024-02-22 14:30:21,058 - __main__ - INFO - Number of existing records 0
2024-02-22 14:30:21,058 - __main__ - INFO - Number of new records (including duplicates) 478
2024-02-22 14:30:21,058 - __main__ - INFO - Comparing new and existing DNS records 0
2024-02-22 14:30:21,058 - __main__ - INFO -     Differences found.  Writing new DNS records to our configmap.
2024-02-22 14:30:21,067 - __main__ - INFO -   Applying the configmap
Stdout:
configmap "cray-dns-unbound" deleted
configmap/cray-dns-unbound replaced

Stderr:

2024-02-22 14:30:21,706 - __main__ - INFO - Merged records and reloaded configmap 0
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

