### PR TITLE
CASMCMS-8914: Use appropriate version of Python kubernetes module for CSM 1.6

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='5.14.21-150500.55.39.1.27360.1.PTF.1215587-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="5.14.21-150500.55.39.1.27360.1.PTF.1215587"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.68
+KUBERNETES_IMAGE_ID=6.1.70
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.68
+PIT_IMAGE_ID=6.1.70
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.68
+STORAGE_CEPH_IMAGE_ID=6.1.70
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.68
+COMPUTE_IMAGE_ID=6.1.70
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -117,11 +117,11 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.11.0
+    version: 1.12.0
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.8
+    version: 1.7.0
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -138,19 +138,19 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.18.0
+    version: 1.19.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.9.2
+    version: 1.10.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.22.1
+    version: 1.23.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
@@ -177,19 +177,19 @@ spec:
             tag: 2.5.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.12.0
+    version: 3.13.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.11.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.13.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
-    version: 1.8.4
+    version: 1.9.0
     namespace: services
   - name: cray-tftp-pvc
     source: csm-algol60
-    version: 1.8.4
+    version: 1.9.0
     namespace: services
   - name: csm-config
     source: csm-algol60
@@ -203,7 +203,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.0.0
+            tag: 2.0.1
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -227,7 +227,7 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.5.6
+    version: 1.6.1
     namespace: services
   - name: gitea
     source: csm-algol60
@@ -243,7 +243,7 @@ spec:
     # Unless there is a specific reason not to, this version should be
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
-    version: 2.0.0
+    version: 2.0.1
     namespace: services
 
   # Cray UAS Manager service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -28,9 +28,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - bos-reporter-2.15.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.7.6-1.x86_64
-    - cf-ca-cert-config-framework-2.6.1-1.noarch
+    - cf-ca-cert-config-framework-2.7.0-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
-    - cfs-trust-1.6.8-1.noarch
+    - cfs-trust-1.7.0-1.noarch
     - cray-cmstools-crayctldeploy-1.19.1-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
@@ -41,8 +41,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.5-1.aarch64
     - csm-node-heartbeat-2.5-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
-    - csm-ssh-keys-1.5.6-1.noarch
-    - csm-ssh-keys-roles-1.5.6-1.noarch
+    - csm-ssh-keys-1.6.1-1.noarch
+    - csm-ssh-keys-roles-1.6.1-1.noarch
     - goss-servers-1.17.20-1.noarch
     - csm-testing-1.17.20-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cfs-debugger-1.6.0-1.x86_64
+    - cfs-debugger-1.7.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - cfs-debugger-1.6.0-1.x86_64
+    - cfs-debugger-1.7.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
-    - cfs-debugger-1.6.0-1.x86_64
+    - cfs-debugger-1.7.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64


### PR DESCRIPTION
Some of the CSM services were being built using non-optimal versions of the Python kubernetes module. This moves them to use the appropriate module version given the Kubernetes version being used in CSM 1.6.

metal-provision manifest PR: https://github.com/Cray-HPE/metal-provision/pull/644

https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8914