### PR TITLE
CASMCMS-8919: Fix bug setting RPM Python requirements

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
-    - cray-cmstools-crayctldeploy-1.19.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.19.1-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch


### PR DESCRIPTION
This fixes the cmstools RPM to address the breaking problem documented in [CASMCMS-8919](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8919)

```text
# rpm -qpR cray-cmstools-crayctldeploy-1.19.1-1.x86_64.rpm | grep python311
(python311-base or (python3-base >= 3.11 and python3-base < 3.12))
```