### PR TITLE
CASMCMS-8924: csm_config: Fixed typo in ansible/ims_computes.yml

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -193,7 +193,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.17.8
+    version: 1.17.10
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
This updates `csm_config` to fix a typo in a filename inside one of the plays, breaking it.

Source PR: https://github.com/Cray-HPE/csm-config/pull/251

Addresses [CASMCMS-8924](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8924)

CSM 1.5.1 backport: https://github.com/Cray-HPE/csm/pull/3201

No other backports needed.