### PR TITLE
CASMCMS-8924: csm_config: Fixed typo in ansible/ims_computes.yml

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -193,7 +193,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.26
+    version: 1.16.27
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
CSM 1.5.1 backport of https://github.com/Cray-HPE/csm/pull/3200