### PR TITLE
CASMTRIAGE-6687: increase timeout for charts using etcd

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -38,6 +38,7 @@ spec:
     source: csm-algol60
     version: 3.1.5
     namespace: services
+    timeout: 10m
     swagger:
     - name: bss
       version: v1
@@ -62,6 +63,7 @@ spec:
     source: csm-algol60
     version: 3.0.4
     namespace: services
+    timeout: 10m
     swagger:
     - name: hbtd
       version: v1
@@ -70,6 +72,7 @@ spec:
     source: csm-algol60
     version: 4.0.2
     namespace: services
+    timeout: 10m
     swagger:
     - name: hmnfd
       version: v1
@@ -230,6 +233,7 @@ spec:
     source: csm-algol60
     version: 1.23.2
     namespace: services
+    timeout: 10m
     swagger:
     - name: uas-mgr
       version: v1


### PR DESCRIPTION
## Summary and Scope

Some charts using etcd cluster take more than 5 minutes (the default timeout setting) for deployment during the install or upgrade. This PR increases the timeout setting for those charts to 10 minutes.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6687](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6687)
* Change will also be needed in `release/1.6`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `slice`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

