### PR TITLE
CRAYSAT-1824:Update cray-sat version to 3.21.10

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.9
+      - 3.21.10
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.9"
+sat_version="3.21.10"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

This will Backport cray-sat 3.27.4 through 3.27.9
- Update the version of jinja2 from 3.0.3 to 3.1.3
- Update the version of cryptography from 41.0.6 to 42.0.0
- Remove unnecessary queries to BOS to get the name of the session template for every single node component in the output of sat status
- Changed the WARNING messages about the deleted BOS sessions to DEBUG messages for sat status
- Changed the "Most Recent Image" column to show the IMS image ID instead of image name for sat status
- Update the version of cryptography from 42.0.0 to 42.0.2
- Update the version of cryptography from 42.0.2 to 42.0.4

## Issues and Related PRs

[CRAYSAT-1816](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1816)
[CRAYSAT-1819](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1819)
[CRAYSAT-1820](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1820)
[CRAYSAT-1764](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1764)
[CRAYSAT-1821](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1821)
[CRAYSAT-1823](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1823)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  baldar, drax

### Test description:

_Test went fine without issues, SAT commands were tested on it._

## Risks and Mitigations

_Low_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
