### PR TITLE
CASMTRIAGE-6708 - Fix CA and Ceph health test

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -43,8 +43,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch
-    - goss-servers-1.17.20-1.noarch
-    - csm-testing-1.17.20-1.noarch
+    - goss-servers-1.17.21-1.noarch
+    - csm-testing-1.17.21-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The `goss-ca-certs-check.yaml` test was modified to use a variable rather than a hard-coded path however the syntax of the `jq` command and the type of the variable used in the updated test were incorrect resulting in a test failure.

The `ceph-service-status.sh` was using an incorrect key name when querying the number of storage nodes. This appears to work in previous CSM versions but not in CSM 1.6.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6708](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6708)

## Testing

### Tested on:

  * `surtur`

### Test description:

Deployed new RPM to the PIT and NCNs on surtur, both tests now pass.

```
surtur-pit:~ # PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no" pdcp -w ncn-m00[2-3],ncn-w00[1-5],ncn-s00[1-3] csm-testing-1.17.20~1~g6cc4a58-1.noarch.rpm /root/
surtur-pit:~ # PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no" pdsh -w ncn-m00[2-3],ncn-w00[1-5],ncn-s00[1-3] rpm -ivh /root/csm-testing-1.17.20~1~g6cc4a58-1.noarch.rpm --force
ncn-s002: Preparing...                          ########################################
ncn-s002: Updating / installing...
ncn-s003: Preparing...                          ########################################
ncn-s001: Preparing...                          ########################################
ncn-s003: Updating / installing...
ncn-s001: Updating / installing...
ncn-s002: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-s001: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-s003: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-m002: Preparing...                          ########################################
ncn-m002: Updating / installing...
ncn-m002: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-m003: Preparing...                          ########################################
ncn-m003: Updating / installing...
ncn-m003: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-w004: Preparing...                          ########################################
ncn-w004: Updating / installing...
ncn-w004: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-w003: Preparing...                          ########################################
ncn-w005: Preparing...                          ########################################
ncn-w003: Updating / installing...
ncn-w005: Updating / installing...
ncn-w001: Preparing...                          ########################################
ncn-w001: Updating / installing...
ncn-w005: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-w003: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-w001: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
ncn-w002: Preparing...                          ########################################
ncn-w002: Updating / installing...
ncn-w002: csm-testing-1.17.20~1~g6cc4a58-1      ########################################
surtur-pit:~ #
surtur-pit:~ #
surtur-pit:~ # csi pit validate --livecd-preflight
Running LiveCD preflight checks (may take a few minutes to complete)...
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20240229_110117.558227-12888-22J6IEhN/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: /opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Firmware and BIOS versions and baseline
Description: Validates the correct versions of BIOS and firmware; Validates BIOS settings (when available; dependent on vendor). If this test fails, run "/opt/cray/tests/install/livecd/scripts/check_bios_firmware_versions.sh -b" for more information on the failure. On GigaByte NCNs, a value of "null" may indicate that the BIOS/Firmware needs to be reflashed or that a hard AC power cycle is needed.
Test Summary: Command: firmware_bios_versions: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000045585 seconds
Node: surtur-pit



GRAND TOTAL: 191 passed, 1 failed
ERROR: There was at least one test failure

FAILED

2024/02/29 11:01:28 exit status 1
(failed reverse-i-search)`ceph': CEPH_VERSION="$(find ${CSM_PATH}/images/storage-^Cph -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $(NF-1)}')"
surtur-pit:~ # csi pit validate --ceph
Storage Node Automated Tests
----------------------------
List of storage NCNs: ncn-s001 ncn-s002 ncn-s003
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20240229_110150.165791-13723-Eaiqk4uF/out

Running tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 15 passed, 0 failed

PASSED
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

