### PR TITLE
CASMTRIAGE-6698: Fixed concurrency issue associated with RedisActivePipeline

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -91,12 +91,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.17.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
-    version: 4.0.1
+    version: 4.0.2
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
-    version: 4.0.1
+    version: 4.0.2
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

In snmpSwitch.go:RunPeriodic() we construct a list of all network switches and spawn off Go routines for each them.  Every one of these Go routines calls into helper.initDevice() to initialize the network switch.  In this function, they use a shared helper.RedisHelper.RedisActivePipeline variable to create a Redis pipeline.  At the end of its use it is reset to nil.  This opens a race condition resulting in a potential bad pointer dereference.

The fix here is to protect the use of helper.RedisHelper.RedisActivePipeline with a mutex, serialized access to the Redis pipeline.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-6698
* Change will be needed in:  CSM 1.6 and CSM 1.5.1

## Testing
These changes were rolled out and tested on venado.

Tested on:

  * venado

Test description:

Redeploy cray-hms-rts-snmp pod and verify elimination of seg fault.

- Were continuous integration tests run? Y (via pushed changes to GitHub)
- Was upgrade tested? Y (on venado)
- Was downgrade tested? Y (on venado)

## Pull Request Checklist

- [ x] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [ x] License file intact
- [ x] Target branch correct
- [ x] CHANGELOG.md updated
- [ x] Testing is appropriate and complete, if applicable