### PR TITLE
CASMTRIAGE-6715: Update spire-agent to proper version

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -61,8 +61,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.6.7-1.noarch
     - smart-mon-1.0.3-1.noarch
-    - spire-agent-1.5.5-1.8.aarch64
-    - spire-agent-1.5.5-1.8.x86_64
+    - spire-agent-1.5.5-1.10.aarch64
+    - spire-agent-1.5.5-1.10.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - tpm-provisioner-client-1.0.1-2.x86_64
     - tpm-provisioner-client-1.0.1-2.aarch64


### PR DESCRIPTION
## Summary and Scope

This is needed to put the proper version of spire-agent in the noos repo. The test done to ensure the spire-agent change was only on x86_64 and not aarch64. This caused issues because the correct version was in a different repo and worked without being noticed that the rpm is in the wrong repo. Building ARM images showed the issue that the correct version of the spire-agent was not present for arm. This change only updates the rpm in the release to one that is tested and working.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6715](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6715)
* Relates to [SKERN-9187](https://jira-pro.it.hpe.com:8443/browse/SKERN-9187)

## Testing

### Tested on:

  * Loki
  * Drax
 
### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Risk in changing so late but im working on how to fix current systems.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

