### PR TITLE
CASMHMS-6131: Remove references to unused HSNBoard component in PCS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.5
+    version: 2.0.6
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

This PR removes references to the HSNBoard component in PCS as it is no longer needed.  This
codewas causing issues for a development version of the SAT tool that was replacing its use of
CAPMC with PCS.

CASMHMS-6131

## Issues and Related PRs

Resolves CASMHMS-6131

## Testing

This problem was only present with a development version of the SAT tool with temporary
changes to replace its use of CAPMC with PCS.  The SAT team took my changes via a container
and chart that I provided them to test with their changes.  They tested both sets of changes
together successfully on baldar on 2/26/2024.

Tested on:

  * baldar

## Pull Request Checklist

- [xx] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable