### PR TITLE
CASMCMS-8938: Correct 2 small errors in BOS API spec description fields

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -138,7 +138,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.0


### PR DESCRIPTION
This updates only the URL for the BOS API spec, so that the auto-generated docs contain some fixes that were made to it. This won't impact the actual build itself.

Backports:
1.5: https://github.com/Cray-HPE/csm/pull/3221
1.4: https://github.com/Cray-HPE/csm/pull/3222