### PR TITLE
CASMHMS-6146: Generate correct PowerCapURI for Olympus hardware

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.1.3
+    version: 2.1.4
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

PCS has been using the older /Power redfish URL to generate PowerCapURI for /Controls.Deep on all Olympus hardware.  The issue with that is that newer hardware (eg. Blanca Peak, Parry Peak) no longer have the /Power URL.  The fix here is to take one of the Controls URLs (eg. /Controls/NodePowerLimit) and use it to construct the PowerCapURI for /Controls.Deep.  For simplicity and clarity in the code, the fix does this for all Olympus hardware even though older hardware still have the /Power URL.

Additionally, two health checks in the power cap path were converted to check for this newly constructed PowerCapURI rather than key off the older /Power URL that no longer exists.

## Issues and Related PRs

* Resolves CASMHMS-6146

## Testing

Tested on tyr against the Windom, Bard Peak, Blanca Peak, and Parry Peak platforms.

For Windom, Blanca Peak, and Parry Peak I set and cleared a power cap for "Power Node Limit"

For Bard Peak I set and cleared a power cap for "Accelerator3 Power Limit"

I also verified that I could set a Parry Peak power cap for two nodes at the same time with a single command line invocation.

I also tested snapshots for all platforms using '--xnames all' to verify all URI's were valid.

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? Yes
- Was upgrade tested? Yes via 'helm upgrade'
- Was downgrade tested? Yes via 'helm rollback'

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable