### PR TITLE
CASMCMS-8946: Update base BOSv2 operator to handle case where all nodes to act on have exceeded their retry limit

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.15.3
+    version: 2.15.4
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.3/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.4/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.15.3-1.noarch
+    - bos-reporter-2.15.4-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.7.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.0-1.noarch


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/csm/pull/3234