### PR TITLE
CASMTRIAGE-6716

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.7-1.x86_64
+    - iuf-cli-1.6.9-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

This is a bug fix for CASMTRIAGE-6716 . iuf not exiting with an error when failed.
Giving message "The stage failed, but argo must run to the completion of the stage." 
But not exitng after stage completion.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
yes

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6716
* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6554

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * beau 
  * Starlord


### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
* yes
- Was downgrade tested? If not, why?
* yes
- Were new tests (or test issues/Jiras) created for this change?
* yes

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

