### PR TITLE
CASMHMS-6130: Add ability to determine arch for paradise nodes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,12 +20,9 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.5
+    version: 7.0.6
     namespace: services
     values:
-      global:
-        appVersion: 2.11.1
-        testVersion: 2.11.1
       cray-service:
         sqlCluster:
           resources:


### PR DESCRIPTION
## Summary and Scope

Updated previously checked in support for determining Paradise arch to account for final contents of FRU data for the Model and Manufacturer strings.

Note that the previous app version 2.11.1 was never deployed in CSM 1.5 via a new chart. Instead that app version was manually added to the CSM manifest. This PR includes removal of the specified app version from the manifest so that the new helm chart can be used to set the app version.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-6130

## Testing

Tested on:

  * tyr

Test description:

Completed a helm upgrade of the cray-hms-smd service on tyr.  Ran discover against a Paradise node without the FRU changes and observed that the arch was set to UNKNOWN.  Rand discover against a paradise node with the FRU changes and observed that the arch was set to ARM.  During testing I had extensive debug statements in place to verify the correct code paths were taken.  When done testing, I used helm to rollback to the previously deployed cray-hms-smd service.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why ? y

## Risks and Mitigations

No risk for existing hardware. Only impacts new Paradise hardware.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable