### PR TITLE
CASMHMS-6130: Add ability to determine arch for paradise nodes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.1
+    version: 7.1.2
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Paradise nodes are currently not providing architectural information. This change enables HSM to assign an architecture to Paradise nodes based on model number.

## Issues and Related PRs

* Resolves [CASMHMS-6130](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6130)

## Testing

Tested on:

  * `tyr`
  * Local development environment
  * Virtual Shasta

Test description:

Updated the deployment to point at the updated HSM. After it was deployed initiated a rediscovery on the BMC and I observed that the Arch field in State Components changed from UNKNOWN to ARM.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N - helm upgrade didn't work, put container in wrong spot
- Was downgrade tested? If not, why? N - didn't do the upgrade

## Risks and Mitigations

No risk for existing hardware. Only impacts new Paradise hardware.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

