### PR TITLE
CASMTRIAGE-6662/CASMPET-6924: ncnHealthChecks.sh: Improvements and fixes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -57,7 +57,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-ipxe-2.4.7-1.noarch
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
-    - platform-utils-1.6.9-1.noarch
+    - platform-utils-1.6.10-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -57,7 +57,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-ipxe-2.4.7-1.noarch
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
-    - platform-utils-1.6.8-1.noarch
+    - platform-utils-1.6.9-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
## Summary and Scope

* [CASMTRIAGE-6662](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6662) - Don't warn about pods that are expected to be non-Running/Completed.
* [CASMPET-6924](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6924) - Fix syntax error; remove superfluous Kubernetes calls to improve script speed

Backports:
* CSM 1.5.1: https://github.com/Cray-HPE/csm/pull/3244
* CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3245

Other PRs:
* CSM 1.6 `metal-provision` PR: https://github.com/Cray-HPE/metal-provision/pull/650
* CSM 1.6 `node-images` PR: https://github.com/Cray-HPE/node-images/pull/1085
* CSM 1.5 `metal-provision` PR: https://github.com/Cray-HPE/metal-provision/pull/655
* CSM 1.5 `node-images` PR: https://github.com/Cray-HPE/node-images/pull/1086