### PR TITLE
CASMINST-6821: goss-k8s-pods-ips-in-nmn-pool: Backport test fixes to CSM 1.4.5

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -24,6 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - cray-node-exporter-1.5.0.1-1.noarch
-    - csm-testing-1.15.57-1.noarch
-    - goss-servers-1.15.57-1.noarch
+    - csm-testing-1.15.58-1.noarch
+    - goss-servers-1.15.58-1.noarch
     - smart-mon-1.0.3-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.74.0-1.x86_64
-    - csm-testing-1.15.57-1.noarch
-    - goss-servers-1.15.57-1.noarch
+    - csm-testing-1.15.58-1.noarch
+    - goss-servers-1.15.58-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,8 +34,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.57-1.noarch
-    - goss-servers-1.15.57-1.noarch
+    - csm-testing-1.15.58-1.noarch
+    - goss-servers-1.15.58-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - iuf-cli-1.4.6-1.x86_64
     - libcsm-0.0.4-1.noarch


### PR DESCRIPTION
This just backports a couple Goss test fixes to CSM 1.4.5, because we are seeing the tests fail because of these on the UKMet systems running CSM 1.4

No other manifest PRs -- these fixes are already in the more recent CSM versions.