### PR TITLE
CASMCMS-8947/CASMCMS-7329: Remove BOS v1; avoid plugin error

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.16.0
+    version: 2.17.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.16.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.15.4
+    version: 2.16.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.15.4/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.16.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.15.4-1.noarch
+    - bos-reporter-2.16.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.7.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.0-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,13 +25,13 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.16.0-1.noarch
+    - bos-reporter-2.17.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.7.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.0-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.7.0-1.noarch
-    - cray-cmstools-crayctldeploy-1.19.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.20.0-1.x86_64
     - cray-site-init-1.32.5-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch


### PR DESCRIPTION
* [CASMCMS-7329](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-7329) - Remove BOS v1
* [CASMCMS-8947](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8947) - In CSM 1.6, BOS moved to using Alpine 3.19, and I noticed some errors in the server logs when it started up. This PR addresses those. There should be no functional changes.

No backports needed as the move to Alpine 3.19 only happened in CSM 1.6, and we are only removing BOS v1 from CSM 1.6.

* `metal-provision` PR: https://github.com/Cray-HPE/metal-provision/pull/651
* `node-images` PR: https://github.com/Cray-HPE/node-images/pull/1085