### PR TITLE
CASMHMS-6150: Handle alternative Paradise system model string

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.6
+    version: 7.0.7
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Some Paradise nodes are being shipped from the factory with a non-production Systems Model string.  The change here is to support that non-production string until the FRU data can be reprogrammed in the field.  This way, we don't have issues on customer systems in the field until that reprogramming can be done.

## Issues and Related PRs

* Resolves CASMHMS-6150

## Testing

_List the environments in which these changes were tested._

Tested on:

  * `tyr`

Test description:

Loaded changes with debugging enabled.  Ran discover against a Paradise node with the production string and then reran against a node with the non-production string.  Verified that in both instances, the correct architecture was discovered (ARM).

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Risks and Mitigations

No risk for existing hardware. Only impacts new Paradise hardware.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

