### PR TITLE
CASMTRIAGE-6794: product_catalog: Alter log messages to avoid tricking IUF

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -206,7 +206,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.0.1
+            tag: 2.1.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -246,7 +246,7 @@ spec:
     # Unless there is a specific reason not to, this version should be
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
-    version: 2.0.1
+    version: 2.1.0
     namespace: services
 
   # Cray UAS Manager service


### PR DESCRIPTION
Some changes to the product catalog in CSM 1.6 resulted in log messages which trick IUF into thinking that some product catalog updates have failed, even though they succeeded. Looking at the logging in question, it makes more sense to change the logs than to change IUF, because the current log messages are fairly easy to misinterpret as errors.

[CASMTRIAGE-6794](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6794)

No backports needed -- this is purely a CSM 1.6 issue.