### PR TITLE
CASMTRIAGE-6787/SKERN-9239: csm-config: Add passwordless SSH to CN/UAN; do not set tunable that breaks Cilium

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.17.11
+    version: 1.18.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Updates `csm-config` to include changes for:
* [SKERN-9239](https://jira-pro.it.hpe.com:8443/browse/SKERN-9239): Configure passwordless SSH on CN/UAN
* [CASMTRIAGE-6787](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6787): Do not set tunable which breaks Cilium

I did not author these changes. I am just helping out with the manifest PR.

See Jiras and source PRs for details:
* https://github.com/Cray-HPE/csm-config/pull/259
* https://github.com/Cray-HPE/csm-config/pull/258
