### PR TITLE
CASMCMS-8948/CASMCMS-8949: BOS v2 improvements/fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,13 +159,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.31
+    version: 2.0.32
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.31/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.32/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.4

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.74.0-1.x86_64
-    - bos-reporter-2.0.31-1.x86_64
+    - bos-reporter-2.0.32-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.31-1.x86_64
+    - bos-reporter-2.0.32-1.x86_64

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - bos-reporter-2.0.31-1.x86_64
+    - bos-reporter-2.0.32-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.0.31-1.x86_64
+    - bos-reporter-2.0.32-1.x86_64
     - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64


### PR DESCRIPTION
* [CASMCMS-8948](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8948) - Backport the following BOSv2 fixes into CSM 1.4.5:
  * [CASMCMS-8617](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8617): Remove failed nodes from session status phase
  * [CASMCMS-8614](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8614): Remove on_hold components from session status phases
  * [CASMCMS-8830](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8830): Fix return type error
  * [CASMCMS-8835](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8835): Do not prematurely filter out disabled nodes
* [CASMCMS-8949](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8949) - Improves debug logging for BOS v2

The changes for CASMCMS-8948 are already in CSM 1.5 and 1.6, but there are manifest PRs to backport the CASMCMS-8949 changes into CSM 1.5.1 and CSM 1.6.
* CSM 1.5.1: https://github.com/Cray-HPE/csm/pull/3259
* CSM 1.6: https://github.com/Cray-HPE/csm/pull/3260
