### PR TITLE
CASMCMS-8950: Update Python Kubernetes client initialization

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,12 +180,12 @@ spec:
             tag: 2.5.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.14.0
+    version: 3.14.1
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.14.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.14.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.9.0


### PR DESCRIPTION
This fixes a bug in IMS introduced when we updated the version of the `kubernetes` Python module.

[CASMCMS-8950](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8950)

CSM 1.5.1 backport: https://github.com/Cray-HPE/csm/pull/3262

No earlier backports needed