### PR TITLE
CASMTRIAGE-6813-release-1.5 update iuf-cli version to 1.5.12

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -52,7 +52,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.5.11-1.x86_64
+    - iuf-cli-1.5.12-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update IUF-CLI version to 1.5.12.
This change resolves [CASMTRAIGE-6813](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6813).

