### PR TITLE
CASMHMS-6157: Update CAPMC API spec to document get_xname_status limitation on large systems

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -50,7 +50,7 @@ spec:
     swagger:
     - name: capmc
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.3.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.4.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
     version: 3.1.0


### PR DESCRIPTION
https://github.com/Cray-HPE/csm/pull/3265