### PR TITLE
CASMTRIAGE-6804: Fixed concurrency issue associated with RedisActivePipeline

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -114,12 +114,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.17.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
-    version: 3.0.1
+    version: 3.0.3
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
-    version: 3.0.1
+    version: 3.0.3
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

The fix for this issue in CSM 1.4 is just a chart change (3.0.3).  The app change (1.24.0) was previously made in CSM 1.5 and CSM 1.6 by way of CASMTRIAGE-6698.  It was later reported by a customer that we also need that change in CSM 1.4.  For CSM 1.4, we simply pull that previously made app fix (1.24.0) into CSM 1.4 with this chart change (3.0.3).  When the CSM 1.4 manifest is updated (will change chart 3.0.1 -> 3.0.3 and app 1.22.0 -> 1.24.0), this will also pull in the chart change 3.0.2 and app change 1.23.0 into CSM 1.4.  These were changes for VSHA-267 and only affect vShasta, so are safe.  I confirmed with Eric Lund that this should not be an issue.

In snmpSwitch.go:RunPeriodic() we construct a list of all network switches and spawn off Go routines for each them. Every one of these Go routines calls into helper.initDevice() to initialize the network switch. In this function, they use a shared helper.RedisHelper.RedisActivePipeline variable to create a Redis pipeline. At the end of its use it is reset to nil. This opens a race condition resulting in a potential bad pointer dereference.

The fix here is to protect the use of helper.RedisHelper.RedisActivePipeline with a mutex, serialized access to the Redis pipeline.

Adopted chart version 3.0.3 and app version 1.24.0 for CSM >= 1.4.1

## Issues and Related PRs

* Resolves CASMTRIAGE-6804
* Prior changes to CSM 1.5 and 1.6 were made by way of CASMTRIAGE-6698

## Testing

This change was tested on surtur.

Tested on:

  * surtur

Test description:

This change was tested on internal system surtur which was running CSM 1.4.4.  I upgraded both cray-hms-rts and cray-hms-rts-snmp from this new chart (they are both deployed from the same chart).  I looked through each pods logs and did not see any issues compared to the logs of the old versions of these services.  The changed code is exercised when the cray-hms-rts-snmp service is started, but neither surtur or any other internal system is large enough to replicate the issue reported by the customer.  This identical change was previously tested on the customer system venado though, which was large enough and demonstrated that it resolved the issue.

- Were the install/upgrade-based validation checks/tests run Y
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable