### PR TITLE
CASMHMS-6156: Add POST option to get power states to avoid size limitations with GET parameters

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,13 +105,13 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.7
+    version: 2.0.8
     namespace: services
     timeout: 10m
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.10.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.3.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
This adds the ability to query PCS for power status using a POST request, which doesn't have the same parameter size limitations as GET requests. The back-end code is the same for the POST and the GET, and the GET remains unchanged, so this is fully backward compatible.

CSM 1.6 PR: https://github.com/Cray-HPE/csm/pull/3273