### PR TITLE
CASMCMS-8951: BOS: Use POST instead of GET when querying PCS for node power status

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.17.2
+    version: 2.17.3
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.2/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.3/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.17.2-1.noarch
+    - bos-reporter-2.17.3-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.0-1.noarch


### PR DESCRIPTION
This modifies BOS so that when it asks PCS for node power status, it will use a POST request instead of a GET request. This will avoid failures when BOS tries to request power status for a large number of nodes (which exceed the allowable size of GET parameters, but not the allowable size of arguments passed in the body of the POST request).

CSM 1.5.1 backport: https://github.com/Cray-HPE/csm/pull/3275