### PR TITLE
CASMINST-6827 Stop shipping docs-csm with csm tarball

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ organized and how to update components included in a CSM release distribution.
   - [Loftsman Manifests and Docker and Helm Indexes](#loftsman-manifests-and-docker-and-helm-indexes)
     - [Docker Index Format](#docker-index-format)
     - [Helm Index Format](#helm-index-format)
-  - [Vendored Repositories](#vendored-repositories)
   - [Git Workflow](#git-workflow)
     - [Version Tags](#version-tags)
 
@@ -172,68 +171,14 @@ Please keep charts sorted lexicographically and organized according to upstream
 repository.
 
 
-## Vendored Repositories
-
-The following Git repositories are vendored (using [git vendor]) into the
-CSM repository:
-
-- `release` references [SHASTARELM/release] - Shared tooling for generating
-  releases and facilitating installation. Vendor `master` branch:
-
-  ```bash
-  $ git vendor update release master
-  ```
-
-- `shasta-cfg` references [SHASTA-CFG/stable] - Default chart customizations
-  and sealed secrets. Vendor `master` branch:
-
-  ```bash
-  $ git vendor update shasta-cfg master
-  ```
-
-- `docs-csm-install` references [CSM/docs-csm-install] - CSM documentation
-
-  Since the `docs-csm-install` RPM is part of [CSM SLE 15sp2], then the
-  vendored commit ID should reference the same commit ID from the RPM. For
-  example, consider:
-
-  ```bash
-  $ cat rpm/cray/csm/sle-15sp2/index.yaml | docker run --rm -i mikefarah/yq:4 e '.. | select(. == "docs-csm-install-*")' -
-  docs-csm-install-1.7.15-20210311085010_a4626db.noarch
-  ```
-
-  This indicates the `docs-csm-install` RPM is at commit `a4626db`. Therefore
-  the vendored reference should be against commit
-  `a4626dbe9983abf76a4753df50e52a50e321f463`. (Note that the vendored reference
-  has to use the full commit ID.)
-
-  ```bash
-  $ git vendor update docs-csm-install a4626dbe9983abf76a4753df50e52a50e321f463
-  ```
-
-  Although `docs-csm-install` should vendor against a specific commit ID, it is
-  expected that the following CSM mainlines track specific `docs-csm-install`
-  branches as follows:
-
-  - `main` should vendor `docs-csm-install@release/shasta-1.5`
-  - `release/0.9` should vendor `docs-csm-install@release/shasta-1.4`
-
-
 ## Git Workflow
 
 The CSM repository has the following mainline branches:
 
-- `main` - Tracks development of the _next_ CSM release
-- `release/X.Y` - Release branches track the lifespan of a specific _X.Y_ release
+- `release/X.Y` - Release branches track the lifespan of a specific _X.Y_ release, including _next_ CSM release
 
-![release-branch-strategy](docs/release-branch-strategy.png)
-
-By default, pull requests against release branches will be [automatically
-merged] to downstream release branches ending with `main`. Bugfix PRs should
-target the oldest pertinent release branch such that changes may be
-automatically merged downstream. Do not worry, in the event of a conflict Stash
-will automatically create another PR against the impacted branch to be manually
-resolved.
+Bugfix PRs should target the oldest pertinent release branch such that changes may be
+automatically merged downstream.
 
 Use feature branches named after the corresponding JIRA issue(s) (e.g.,
 `CASMINST-123`) to develop enhancements and fixes. PRs will be approved and
@@ -277,19 +222,7 @@ as appropriate:
 
 
 [release.sh]: release.sh
-[CSM SLE 15sp1]: rpm/cray/csm/sle-15sp1/index.yaml
-[CSM SLE 15sp1-compute]: rpm/cray/csm/sle-15sp2-compute/index.yaml
-[CSM SLE 15sp2]: rpm/cray/csm/sle-15sp2/index.yaml
-[CSM SLE 15sp2-compute]: rpm/cray/csm/sle-15sp1-compute/index.yaml
-[Shasta Firmware]: rpm/shasta-firmware/index.yaml
 [customizations.yaml]: https://github.com/Cray-HPE/shasta-cfg/customizations.yaml
 [Docker index]: docker/index.yaml
 [Helm index]: helm/index.yaml
-[git vendor]: https://github.com/brettlangdon/git-vendor
-[SHASTARELM/release]: https://stash.us.cray.com/projects/SHASTARELM/repos/release/browse
-[SHASTA-CFG/stable]: https://github.com/Cray-HPE/shasta-cfg
-[CSM/docs-csm-install]: https://stash.us.cray.com/projects/MTL/repos/docs-csm-install/browse
-[automatically merged]: https://confluence.atlassian.com/bitbucketserver/automatic-branch-merging-776639993.html#Automaticbranchmerging-ordering
-[CASM release process]: https://connect.us.cray.com/confluence/display/CASM/CASM+Merge+and+Release+Process
-[CASM release dashboard]: https://connect.us.cray.com/confluence/display/CASM/CASM+Release+Progress+Dashboard
 [CHANGELOG.md]: CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -131,18 +131,6 @@ embedded-repo: rpms
 $(BUILDDIR)/rpm/embedded:
 	hack/embedded-repo.sh --download
 
-# Unpack docs-csm RPM into build dir
-.PHONY: docs
-docs: rpms
-	$(call header,"Unpacking docs-csm into build dir")
-	@$(MAKE) $(BUILDDIR)/docs
-$(BUILDDIR)/docs:
-	mkdir -p "$(BUILDDIR)/tmp/docs"
-	cd "$(BUILDDIR)/tmp/docs" && \
-		find "$(abspath $(BUILDDIR))/rpm/cray/csm/noos" -type f -name docs-csm-\*.rpm | head -n 1 | xargs -n 1 rpm2cpio | cpio -idvm ./usr/share/doc/csm/*
-	mv "$(BUILDDIR)/tmp/docs/usr/share/doc/csm" "$(BUILDDIR)/docs"
-	rm -Rf "$(BUILDDIR)/tmp"
-
 # Unpack workarounds RPM(s) into build dir
 .PHONY: workarounds
 workarounds: rpms
@@ -158,7 +146,7 @@ $(BUILDDIR)/workarounds:
 
 # Create CSM release tarball
 .PHONY: package
-package: rpms images snyk charts assets docs workarounds
+package: rpms images snyk charts assets workarounds
 	$(call header,"Creating CSM release tarball")
 	@$(MAKE) dist/$(RELEASE).tar.gz
 dist/$(RELEASE).tar.gz:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 This is the CSM release repository. In contains scripts for building and
 installing a CSM release distribution.
 
-See the [release guide](build/README.md) for information about preparing and
-building a release distribution. CSM release distributions are automatically
+CSM release distributions are automatically
 uploaded to the following Artifactory repositories by the CI pipeline:
 
 - [csm-releases](https://artifactory.algol60.net/ui/repos/tree/General/csm-releases/csm)

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -1,10 +1,15 @@
 Installation Instructions
 =========================
 
-Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 
-The `docs` directory includes the complete set of Cray System Management
-(CSM) documentation. See `docs/README.md` to get started with installation.
-This content is the same as what is provided by the docs-csm-install.rpm.
+Please refer to online documentation for actual installation instructions for corresponding release:
 
-NOTE: Docs are also available on the LiveCD at /usr/share/doc/csm/.
+https://cray-hpe.github.io/docs-csm/
+
+Alternatively, documentation is also available as docs-csm RPM package, which can be downloaded from
+release distribution website:
+
+https://release.algol60.net/csm-<CSM_RELEASE>/docs-csm/
+
+Note: you need to replace `<CSM_RELEASE>` in the URL above with actual CSM release (`1.4`, `1.5`, etc).

--- a/docs/README
+++ b/docs/README
@@ -1,22 +1,19 @@
 Cray System Management (CSM)
 ============================
 
-Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 
 
 Package Contents
 ----------------
 
-INSTALL                 - Installation instructions
-README                  - This file
-cray-pre-install-toolkit-*.iso - LiveCD cray-pre-install-toolkit ISO file
+docs/INSTALL            - Installation instructions
+docs/README             - This file
 docker/                 - Container images
-docs/                   - CSM documentation (same as docs-csm-install.rpm)
-firmware/               - Firmware, but newer firmware may be available from HPC Firmware Pack
 hack/                   - Scripts used during installation
 helm/                   - Helm charts
 hpe-signing-key.asc     - Public HPE rpm signing key 
-images/                 - Pre-built operating system images for management nodes
+images/                 - Pre-built operating system images for management nodes and LiveCD cray-pre-install-toolkit ISO file
 install.sh              - Post-Kubernetes-bring-up installation script
 lib/                    - Helper functions for install.sh
 manifests/              - Loftsman manifest files
@@ -31,4 +28,4 @@ workarounds/            - Documentation and scripts to address workarounds
 Installation
 ------------
 
-Refer to the INSTALL file in this package for installation instructions.
+Refer to the INSTALL file in this folder for installation instructions.

--- a/release.sh
+++ b/release.sh
@@ -29,11 +29,11 @@ source "${ROOTDIR}/common.sh"
 source "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh"
 
 # Initialize build directory
-mkdir -p "$BUILDDIR"
+mkdir -p "$BUILDDIR/docs/"
 
 # Process local files
-rsync -aq "${ROOTDIR}/docs/README" "${BUILDDIR}/"
-rsync -aq "${ROOTDIR}/docs/INSTALL" "${BUILDDIR}/"
+rsync -aq "${ROOTDIR}/docs/README" "${BUILDDIR}/docs/"
+rsync -aq "${ROOTDIR}/docs/INSTALL" "${BUILDDIR}/docs/"
 
 # Store cloud-init.yaml
 cp -f "${ROOTDIR}/rpm/cloud-init.yaml" "${BUILDDIR}/rpm/cloud-init.yaml"


### PR DESCRIPTION
## Summary and Scope

With CASMINST-6827, it was decided to stop shipping docs-csm RPM with CSM tarball under `rpm/` folder, and as well stop unpacking it under `docs/`. The reason is that `csm` and `docs-csm` have different release cycles, and customers often end up using outdated version of `docs-csm` from a tarball. This PR stops pulling docs-csm RPM under `rpm/` NOOS repo and unpacking it under `docs/`.

## Issues and Related PRs

* Resolves CASMINST-6827.

## Testing
### Tested on:

* Virtual Shasta

### Test description:

* Ran vShasta fresh install of special csm-1.6.0-nodocs.1, which was prepared specifically for this test by temporarily modifying Jenkinsfile: https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/feature%2Fstrip-docs-csm/6/
* Ran vShasta upgrade of csm-1.5.0 > csm-1.6.0-nodocs.1, to test upgrade code: https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/feature%2Fstrip-docs-csm/13/
