### PR TITLE
CASMINST-1960 Ship and install GPG keys for RPM checks

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -72,4 +72,24 @@ for arch in "${CN_ARCH[@]}"; do
     \)
 done
 
-HPE_SIGNING_KEY=https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key.asc
+# Public keys for RPM signature validation.
+# NB! If updating this list, also update install.sh, which installs keys into k8s secret during CSM installation.
+#
+# hpe-signing-key.asc - for all packages signed by HPE Code Signing
+# hpe-sdr-signing-key.asc - older HPE key used by SDR repos (Qlogic driver - qlgc-fastlinq-kmp-default)
+# google-package-key.asc - for kubelet/kubeadm/kubectl from https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+# suse-package-key.asc - for most SUSE packages in embedded repo
+# opensuse-obs-filesystems.asc - for packages copied into /csm-rpms/stable from OpenSUSE filesystems (such as csm-rpms/hpe/stable/sle-15sp5/ceph-common-17.2.6.865+g60870edfe2e-lp155.1.1.x86_64.rpm): https://download.opensuse.org/repositories/filesystems:/ceph:/quincy:/upstream/openSUSE_Leap_15.5/repodata/repomd.xml.key
+# opensuse-obs-backports.asc - for packages in /sles-mirror/Backports/SLE-15-SP5_x86_64 (dkms, perl-File-BaseDir)
+# opensuse-obs-backports-2024-02-04.asc - for packages in /sles-mirror/Backports/SLE-15-SP2_x86_64 (haproxy, tmux, keepalived - https://jira-pro.it.hpe.com:8443/browse/MTL-2384)
+# suse_ptf_key.asc - for SUSE PTF kernel packages, see https://www.suse.com/support/kb/doc/?id=000018545
+HPE_RPM_SIGNING_KEYS=(
+    https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/hpe-sdr-signing-key.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/google-package-key.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/suse-package-key.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-filesystems-15-sp5.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-backports-15-sp5.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-backports-15-sp2.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/suse_ptf_key.asc
+)

--- a/hack/rpms.sh
+++ b/hack/rpms.sh
@@ -12,6 +12,7 @@ if [ $# -ne 1 ] || ([ "${1}" != "--validate" ] && [ "${1}" != "--download" ]); t
 fi
 
 [ "${1}" == "--validate" ] && VALIDATE=1 || VALIDATE=0
+SIGNING_KEYS=""
 
 function rpm-sync() {
     index="${1}"
@@ -25,9 +26,9 @@ function rpm-sync() {
         docker run ${REPO_CREDS_DOCKER_OPTIONS} --rm -i -u "$(id -u):$(id -g)" \
             -v "$(realpath "${index}"):/index.yaml:ro" \
             -v "$(realpath "${destdir}"):/data" \
-            -v "$(realpath "${BUILDDIR}/security/"):/keys" \
+            -v "$(realpath "${BUILDDIR}/security/keys/rpm/"):/keys" \
             "${PACKAGING_TOOLS_IMAGE}" \
-            rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -n 1 -s -v -k /keys/hpe-signing-key.asc -d /data /index.yaml
+            rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -n 1 -s -v ${SIGNING_KEYS} -d /data /index.yaml
     fi
 }
 
@@ -75,10 +76,28 @@ function createrepo() {
         createrepo --verbose /data
 }
 
-if [ "${VALIDATE}" != "1" ] && ! [ -f "${BUILDDIR}/security/hpe-signing-key.asc" ]; then
-    echo "Downloading HPE signing key"
-    mkdir -p "${BUILDDIR}/security"
-    acurl -Ss -o "${BUILDDIR}/security/hpe-signing-key.asc" "${HPE_SIGNING_KEY}"
+if [ "${VALIDATE}" != "1" ]; then
+    # Special processing for docs-csm, as we don't know exact version before build starts, so can't include it into rpm indexes.
+    # Can't include docs-csm-latest either, because it is not unique. Get version from right docs-csm-latest, then download actual rpm file.
+    DOCS_CSM_MAJOR_MINOR="${DOCS_CSM_MAJOR_MINOR:-${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}}"
+    DOCS_CSM_VERSION=$(acurl -sSL "https://artifactory.algol60.net/artifactory/api/storage/csm-rpms/hpe/stable/noos/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-latest.noarch.rpm?properties" | jq -r '.properties["rpm.metadata.version"][0]')
+    echo "Downloading docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm ..."
+    mkdir -p "${BUILDDIR}/rpm/cray/csm/noos/noarch"
+    acurl -sSL -o "${BUILDDIR}/rpm/cray/csm/noos/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" \
+        "https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm"
+
+    # Download and store RPM signing keys.
+    mkdir -p "${BUILDDIR}/security/keys/rpm"
+    for key_url in "${HPE_RPM_SIGNING_KEYS[@]}"; do
+        key=$(basename "${key_url}")
+        if [ -f "${BUILDDIR}/security/keys/rpm/${key}" ]; then
+            echo "Signing key ${key} is already downloaded"
+        else
+            echo "Downloading ${key} signing key"
+            acurl -Ss -o "${BUILDDIR}/security/keys/rpm/${key}" "${key_url}"
+        fi
+        SIGNING_KEYS="${SIGNING_KEYS} -k /keys/${key}"
+    done
 fi
 
 rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp2"
@@ -91,15 +110,6 @@ if [ "${VALIDATE}" == "1" ]; then
     echo "RPM indexes validated successfully"
 else
     echo "RPM indexes synchronized successfully"
-    # Special processing for docs-csm, as we don't know exact version before build starts, so can't include it into rpm indexes.
-    # Can't include docs-csm-latest either, because it is not unique. Get version from right docs-csm-latest, then download actual rpm file.
-    DOCS_CSM_MAJOR_MINOR="${DOCS_CSM_MAJOR_MINOR:-${RELEASE_VERSION_MAJOR}.${RELEASE_VERSION_MINOR}}"
-    DOCS_CSM_VERSION=$(acurl -sSL "https://artifactory.algol60.net/artifactory/api/storage/csm-rpms/hpe/stable/noos/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-latest.noarch.rpm?properties" | jq -r '.properties["rpm.metadata.version"][0]')
-    mkdir -p "${BUILDDIR}/rpm/cray/csm/noos/noarch"
-    acurl -sSL -o "${BUILDDIR}/rpm/cray/csm/noos/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" \
-        "https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/docs-csm/${DOCS_CSM_MAJOR_MINOR}/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm"
-    rpm -qpi "${BUILDDIR}/rpm/cray/csm/noos/noarch/docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm" | grep -q -E "Signature\s*:\s*\(none\)" && (echo "ERROR: RPM package docs-csm-${DOCS_CSM_VERSION}-1.noarch.rpm is not signed"; exit 1)
-
     # Fix-up cray directories by removing misc subdirectories
     {
         find "${BUILDDIR}/rpm/cray" -name '*-team' -type d


### PR DESCRIPTION
## Summary and Scope

As part of "embedded" repo, we ship some RPM packages, signed by their respective keys. For GPG key validation to pass for these packages, we also need to ship public GPG keys. Previously, we did auto-import of all keys from RPM repos configured on NCN node images. Also we did not ship those keys (except `hpe-signing-key.asc`). With this change, we:
* Use static list of keys, which allows more precise control of what is being included into embedded repo
* Ship these keys under `/security/keys/rpms` folder and install into Kubernetes secret, for pickup by `csm-config`. Previously only `hpe-signing-key.asc` was shipped this way.

## Issues and Related PRs

* Needed by CASMINST-1960

## Testing
### Tested on:

  * Local development environment
  * Jenkins: branch temporarily modified to perform download and signature verification: https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm/detail/feature%2Frpm-keys/16/pipeline

### Test description:

Ensured RPM packages download and signature validation.

## Risks and Mitigations

Low - build change and install change will be verified by vShasta.

