### PR TITLE
MTL-2364, MTL-2384

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='5.14.21-150500.55.52-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.75
+KUBERNETES_IMAGE_ID=6.1.77
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.75
+PIT_IMAGE_ID=6.1.77
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.75
+STORAGE_CEPH_IMAGE_ID=6.1.77
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.75
+COMPUTE_IMAGE_ID=6.1.77
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -75,6 +75,10 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/ceph/ceph-grafana:
       - 9.4.7
 
+    # Requried to support hybrid mode during upgrade
+    quay.io/cephcsi/cephcsi:
+      - v3.5.1
+
     quay.io/prometheus/prometheus:
       - v2.43.0
 
@@ -161,6 +165,9 @@ artifactory.algol60.net/csm-docker/stable:
     k8s.gcr.io/pause:
       - 3.4.1
       - 3.5
+    # Requried to support hybrid mode during upgrade
+    k8s.gcr.io/sig-storage/csi-resizer:
+      - v1.3.0
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
 


### PR DESCRIPTION
## Summary and Scope

- Add older container image versions to support hybrid mode during upgrade. These images are no
longer baked into the k8s image. They are now required to be in Nexus for the k8s image to pull them via cloud-init.
- stop pulling packages from our artifactory SP2 repo and update to newer package versions

## Issues and Related PRs

[MTL-2364](https://jira-pro.it.hpe.com:8443/browse/MTL-2364)
[MTL-2384](https://jira-pro.it.hpe.com:8443/browse/MTL-2384)

### Tested on:

- Fanta ncn-w004

### Test description:

The images were manually added to Nexus and ncn-w004 was able to pull them via cloud-init on boot.

## Risks and Mitigations

None known