### PR TITLE
CASMCMS-8953/CASMCMS-8954: BOSv2: CFS-related fixes and improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.11
+    version: 2.10.12
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.11/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.12/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.10.11-1.noarch
+    - bos-reporter-2.10.12-1.noarch
     - cani-0.3.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch


### PR DESCRIPTION
* CASMCMS-8954: The current method BOS v2 uses to patch CFS components results in sending requests that are more than 10x larger than they need to be (and which take longer to generate than necessary). This corrects both.
* CASMCMS-8953: Make BOS v2 use CFS v3 to avoid a breaking change in CFS v2 introduced in CSM 1.5.