### PR TITLE
CASMTRIAGE-6843 1.4 : postgres_replication_lag.sh -p destroys replica with unknown lag when State=creating replica

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.74.0-1.x86_64
-    - csm-testing-1.15.58-1.noarch
-    - goss-servers-1.15.58-1.noarch
+    - csm-testing-1.15.59-1.noarch
+    - goss-servers-1.15.59-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,8 +34,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.58-1.noarch
-    - goss-servers-1.15.58-1.noarch
+    - csm-testing-1.15.59-1.noarch
+    - goss-servers-1.15.59-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - iuf-cli-1.4.6-1.x86_64
     - libcsm-0.0.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_  Critical bug for for case when the postgres cluster member is currently in the state of creating the replica.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6843](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6843)
* Change will also be needed in `release/1.5, release/1.4, release/1.3`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable