### PR TITLE
CASMINST-6829 - CSM health checks should detect when Weave has a peer in "sleeve" mode

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.67-1.noarch
-    - goss-servers-1.16.67-1.noarch
+    - csm-testing-1.16.69-1.noarch
+    - goss-servers-1.16.69-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
## Summary and Scope

If Weave has peers running in "sleeve" mode instead of the fast dataplane (fastdp) mode then pod to pod communication errors can occur resulting in strange behaviour from services running in Kubernetes.

The upgrade procedure has a check for this due to an old issue [FN #6636](https://support.hpe.com/hpesc/docDisplay?docLocale=en_US&docId=crsc6636en_us) where the MTU was set incorrectly however the standard CSM health validation tests do not check for this condition.

This PR modifies the `goss-weave-health.yaml` test to check for this condition.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6829](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6829)

## Testing

### Tested on:

  * `surtur`

### Test description:

Verified test works as expected.

```
ncn-m001:/opt/cray/tests/install/ncn/tests # /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
NCN and Kubernetes Checks
------------------------------

DEBUG: cmsdev_test_list='bos cfs conman ims tftp vcs'
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20240328_102745.753883-324520-pzJjmDlk/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-m001.hmn:9001/ncn-kubernetes-tests-master
Test Name: Weave Health
Description: Check that Weave is healthy. Run "weave --local status connections" on any unhealthy node and check the MTU.
Test Summary: Command: k8s_check_weave_status: stdout: patterns not found: [!/.*sleeve/]
Execution Time: 0.000115756 seconds
Node: ncn-m001
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

