### PR TITLE
CASMINST-6819: external-dns-resolver test improvements/fixes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -43,8 +43,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch
-    - goss-servers-1.17.24-1.noarch
-    - csm-testing-1.17.24-1.noarch
+    - goss-servers-1.17.25-1.noarch
+    - csm-testing-1.17.25-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
Mainly fixed the test so it could handle systems which have multiple LDAP servers configured.
Also makes it do a more thorough job of error checking and providing debug output.

Backports:
CSM 1.5.1: https://github.com/Cray-HPE/csm/pull/3296
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3297