### PR TITLE
CASMINST-6819: external-dns-resolver test improvements/fixes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.69-1.noarch
-    - goss-servers-1.16.69-1.noarch
+    - csm-testing-1.16.70-1.noarch
+    - goss-servers-1.16.70-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
CSM 1.5.1 backport of https://github.com/Cray-HPE/csm/pull/3295