### PR TITLE
CASMHMS-6161: Clean up heartbeat send messaging

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -38,8 +38,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.83.0-1.aarch64
     - craycli-0.83.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.5-1.aarch64
-    - csm-node-heartbeat-2.5-1.x86_64
+    - csm-node-heartbeat-2.6-1.aarch64
+    - csm-node-heartbeat-2.6-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Heartbeat was logging the message "send_message: ERROR: Failed to aquire token Success" which was confusing people because it reported both an error and success.  The underlying problem was that the code was referencing errno in a print statement several calls after the failing libc call that set it during a failure.  The change here is to move the printing of errno immediately after the failing libc call.

Additionally, it was requested that a message be printed after heartbeat successfully started as there are usually some initial failures to send after a boot.  The change here does that, in addition to printing a message that heartbeating successfully resumed if there are ever any failures to send after boot.  This is sent to stderr rather than stdout so that it is apparent to everyone looking at logs.

Updated csm-node-heartbeat RPM version from 2.5-1 to 2.6-1.

## Issues and Related PRs

* Resolves CASMHMS-6161

## Testing

### Tested on:

  * drax

### Test description:

Tested on drax compute node x3000c0s19b1n0.  Moved installed hb_ref out of the way and replaced it with my own.  Generated an artificial compile time failure for the getline() call by passing in NULL and verified print to stderr included correct errno message.

Verified that "Heartbeat successfully started/resumed communication" message is sent to the log after first started and after a series of induced failed sends.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N - service is packaged in rpm and not helm chart
- Were continuous integration tests run? If not, why? N - No CI tests for this code
- Was upgrade tested? If not, why? N - Service is packaged in an rpm and not a helm chart
- Was downgrade tested? If not, why? N - Service is packaged in an rpm and not a helm chart
- Were new tests (or test issues/Jiras) created for this change? N

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [n/a] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

