### PR TITLE
CASMINST-6834 - CSI generates blank CAN dnsmasq configuration if system configured for CHN

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
     - cray-cmstools-crayctldeploy-1.16.1-1.x86_64
-    - cray-site-init-1.32.3-1.x86_64
+    - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.82.13-1.aarch64
     - craycli-0.82.13-1.x86_64


### PR DESCRIPTION
## Summary and Scope

If a system is configured for CHN then the dnsmasq.d/statics.conf file generated by `csi config init` contains CAN entries with a blank IP address.

```
# DHCP Entries for ncn-s001
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,10.1.1.4,ncn-s001,20m # MTL
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,10.252.1.6,ncn-s001,20m # Bond0 Mac0/Mac1
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,10.254.1.8,ncn-s001,20m # HMN
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,,ncn-s001,20m # CAN
dhcp-host=5c:ed:8c:3c:b6:76,10.254.1.7,ncn-s001-mgmt,20m #HMN
# Host Record Entries for ncn-s001
host-record=ncn-s001,ncn-s001.can,
host-record=ncn-s001,ncn-s001.hmn,10.254.1.8
host-record=ncn-s001,ncn-s001.nmn,10.252.1.6
host-record=ncn-s001,ncn-s001.mtl,10.1.1.4
host-record=x3100c0s19b0n0,ncn-s001.nmn,10.252.1.6
host-record=ncn-s001-mgmt,ncn-s001-mgmt.hmn,10.254.1.7
# Override root-path with ncn-s001's xname
dhcp-option-force=tag:ncn-s001,17,x3100c0s19b0n0
```
This has the side effect of DHCP handing out IP addresses from the poll rather than the assigned IP address.

## Issues and Related PRs

* Resolves [CASMINST-6834](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6834)

## Testing

### Tested on:

  * `surtur`
  * Local development environment

### Test description:

Tested on surtur and verified generated configuration was as expected.

#### CAN case
```
# DHCP Entries for ncn-w005
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.1.1.12,ncn-w005,20m # MTL
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.252.1.14,ncn-w005,20m # Bond0 Mac0/Mac1
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.254.1.24,ncn-w005,20m # HMN
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.102.193.143,ncn-w005,20m # CAN
dhcp-host=5c:ba:2c:4a:19:76,10.254.1.23,ncn-w005-mgmt,20m #HMN
# Host Record Entries for ncn-w005
host-record=ncn-w005,ncn-w005.can,10.102.193.143
host-record=ncn-w005,ncn-w005.hmn,10.254.1.24
host-record=ncn-w005,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005,ncn-w005.mtl,10.1.1.12
host-record=x3000c0s31b0n0,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005-mgmt,ncn-w005-mgmt.hmn,10.254.1.23
# Override root-path with ncn-w005's xname
dhcp-option-force=tag:ncn-w005,17,x3000c0s31b0n0
```
 
#### CHN case
```
# DHCP Entries for ncn-w005
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.1.1.12,ncn-w005,20m # MTL
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.252.1.14,ncn-w005,20m # Bond0 Mac0/Mac1
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.254.1.24,ncn-w005,20m # HMN
dhcp-host=5c:ba:2c:4a:19:76,10.254.1.23,ncn-w005-mgmt,20m #HMN
# Host Record Entries for ncn-w005
host-record=ncn-w005,ncn-w005.hmn,10.254.1.24
host-record=ncn-w005,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005,ncn-w005.mtl,10.1.1.12
host-record=x3000c0s31b0n0,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005-mgmt,ncn-w005-mgmt.hmn,10.254.1.23
# Override root-path with ncn-w005's xname
dhcp-option-force=tag:ncn-w005,17,x3000c0s31b0n0
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

