### PR TITLE
CASMCMS-8958-1.6: Update cmsdev test tool to be CFSv3-aware

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.7.0-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.7.0-1.noarch
-    - cray-cmstools-crayctldeploy-1.20.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.21.0-1.x86_64
     - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch


### PR DESCRIPTION
Currently the cmsdev test tool will fail its CFS subtest on systems with large numbers of nodes. This PR corrects that, and also improves its CFS test coverage overall.

CSM 1.5.1 backport:
https://github.com/Cray-HPE/csm/pull/3303

No earlier backports, as this is a new problem in CSM 1.5.