### PR TITLE
CASMCMS-8920: CFS: Return correct ARA link

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.4/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.19.0
+    version: 1.19.1
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.1/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.10.0


### PR DESCRIPTION
This fixes CFS so that the ARA link it returns is the correct one.

(I'm creating the manifest PR for this, but @rbak-hpe made the fix, so in the unlikely event that there are nuanced questions about it, he may need to answer them)

CSM 1.5.1 backport: https://github.com/Cray-HPE/csm/pull/3305
