### PR TITLE
CASMINST-6522: Remove now-unnecessary CSM 1.4-style iPXE pod test

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -43,8 +43,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch
-    - goss-servers-1.17.25-1.noarch
-    - csm-testing-1.17.25-1.noarch
+    - goss-servers-1.17.26-1.noarch
+    - csm-testing-1.17.26-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
In CSM 1.5, we had to maintain a version of the iPXE pod check test that could handle the CSM 1.4-style iPXE deployment, because during upgrades from CSM 1.4 to 1.5, we needed to be able to handle that situation.

In CSM 1.6, we will never be upgrading from CSM 1.4 directly, so we will never have the CSM 1.4 style of iPXE deployment.

This PR removes the test for that and updates the Goss test suites to reflect this.
