### PR TITLE
CASMCMS-8959: Correct errors in CFS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.4/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.19.1
+    version: 1.19.2
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.2/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.10.0


### PR DESCRIPTION
This fixes several minor errors in the CFS API spec. It has no functional impact on the service itself (it is bringing the API spec in alignment with the actual CFS behavior).

Backports:
CSM 1.5: https://github.com/Cray-HPE/csm/pull/3308
CSM 1.4: https://github.com/Cray-HPE/csm/pull/3309

(these backports only update the API link used to autogenerate the API docs)