### PR TITLE
CASMCMS-8959: Correct errors in CFS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -146,7 +146,7 @@ spec:
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.2/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.2


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3307 (just the portion to autogenerate the API docs)