### PR TITLE
CASMTRIAGE-6864 - Test "ca-certs patched into data.json" displays error.

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.70-1.noarch
-    - goss-servers-1.16.70-1.noarch
+    - csm-testing-1.16.71-1.noarch
+    - goss-servers-1.16.71-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
## Summary and Scope

The goss-ca-certs-check.yaml test was modified to use a variable rather than a hard-coded path however the syntax of the jq command and the type of the variable used in the updated test were incorrect resulting in a test failure.

This was already fixed in CSM 1.6 ([CASMTRIAGE-6708](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6708)) but not backported to CSM 1.5.0 because the problem wasn't evident there however it appears #564 incorporated the bad version of the test into the release/1.5 branch so the bad test is now present in CSM 1.5.1

## Issues and Related PRs

* Resolves [CASMTRIAGE-6864](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6864)

## Testing

### Tested on:

  * `fanta`

### Test description:

Deployed fixed test on fanta PIT node.

#### Before
```
fanta-pit:/var/www/ephemeral/configs # csi pit validate --livecd-preflight
Running LiveCD preflight checks (may take a few minutes to complete)...
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20240405_090158.805616-32494-jMivxGzL/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: /opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Firmware and BIOS versions and baseline
Description: Validates the correct versions of BIOS and firmware; Validates BIOS settings (when available; dependent on vendor). If this test fails, run "/opt/cray/tests/install/livecd/scripts/check_bios_firmware_versions.sh -b" for more information on the failure. On GigaByte NCNs, a value of "null" may indicate that the BIOS/Firmware needs to be reflashed or that a hard AC power cycle is needed.
Test Summary: Command: firmware_bios_versions: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000014301 seconds
Node: fanta-pit


Result: FAIL
Source: /opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: ca-certs patched into data.json
Description: Validate that - csi patch ca - command executed. ca-certs are patched into data.json file on PIT node.
Test Summary: Command: ca_certs_check: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000098250 seconds
Node: fanta-pit



GRAND TOTAL: 190 passed, 2 failed
ERROR: There was at least one test failure

FAILED

2024/04/05 09:02:09 exit status 1
```
#### After - Test now passes as expected
```
fanta-pit:/var/www/ephemeral/configs # csi pit validate --livecd-preflight
Running LiveCD preflight checks (may take a few minutes to complete)...
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20240405_090952.978342-34376-linShCwK/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: /opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Firmware and BIOS versions and baseline
Description: Validates the correct versions of BIOS and firmware; Validates BIOS settings (when available; dependent on vendor). If this test fails, run "/opt/cray/tests/install/livecd/scripts/check_bios_firmware_versions.sh -b" for more information on the failure. On GigaByte NCNs, a value of "null" may indicate that the BIOS/Firmware needs to be reflashed or that a hard AC power cycle is needed.
Test Summary: Command: firmware_bios_versions: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000054263 seconds
Node: fanta-pit



GRAND TOTAL: 191 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

