### PR TITLE
CASMPET-6915: change cray-opa to daemonset and use a newer image

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -66,7 +66,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5
       # OPA
-      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.26
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.26
@@ -125,7 +125,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.32.9
+    version: 1.32.10
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Due to limitations of server-side load balancing in kubernetes, especially with OPA as it uses GRPC protocol leveraging persistent connections, we often run into situations where only 1 or 2 OPA ingressgateway pods are used. This has exposed OPA memory leakage bug found in older OPA envoy plugin versions. This PR uses a cray-opa chart by changing OPA deployment to daemonset, using a kubernetes beta feature that improves load balancing, with a newer OPA envoy plugin version v0.62.0 that has fixes for a memory leakage issue (https://github.com/open-policy-agent/opa/issues/5320).

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6915
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

