### PR TITLE
CASMCMS-8964: CFS: Do not log false schema errors

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -168,12 +168,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.35/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.12.7
+    version: 1.12.8
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.7/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.8/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.8.0


### PR DESCRIPTION
This updates a CFS Python dependency in order to prevent the service from falsely logging schema errors.

CSM 1.5.1 PR: https://github.com/Cray-HPE/csm/pull/3321
CSM 1.6 PR: https://github.com/Cray-HPE/csm/pull/3322