### PR TITLE
CASMTRIAGE-6854: Add update-mgmt-ncn-cfs-config.sh to CSM 1.5+, update it for CSM 1.5+

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,27 @@
 #!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/packaging-tools:0.14.0}
 export RPM_TOOLS_IMAGE=${RPM_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/rpm-tools:1.0.0}
@@ -27,3 +50,6 @@ RELEASE_VERSION_MINOR=$(echo "${RELEASE_VERSION}" | cut -f2 -d.)
 RELEASE=${RELEASE:-${RELEASE_NAME}-${RELEASE_VERSION}}
 BUILDDIR=${BUILDDIR:-${ROOTDIR}/dist/${RELEASE}}
 CSM_BASE_VERSION=${CSM_BASE_VERSION:-}
+
+# Use a newer version of cfs-config-util that hasn't rolled out to other products yet
+CFS_CONFIG_UTIL_IMAGE="artifactory.algol60.net/csm-docker/stable/cfs-config-util:5.0.0"

--- a/release.sh
+++ b/release.sh
@@ -46,6 +46,8 @@ rsync -aq "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/insta
 rsync -aq "${ROOTDIR}/install.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/upgrade.sh" "${BUILDDIR}/"
 rsync -aq "${ROOTDIR}/hack/load-container-image.sh" "${BUILDDIR}/hack/"
+rsync -aq "${ROOTDIR}/update-mgmt-ncn-cfs-config.sh" "${BUILDDIR}/"
+chmod 755 "${BUILDDIR}/update-mgmt-ncn-cfs-config.sh"
 
 # Copy manifests
 rsync -aq "${ROOTDIR}/manifests/" "${BUILDDIR}/manifests/"
@@ -77,8 +79,10 @@ sed -e "s/-0.0.0/-${RELEASE_VERSION}/g" "${ROOTDIR}/nexus-repositories.yaml" \
 mkdir "${BUILDDIR}/shasta-cfg"
 "${ROOTDIR}/vendor/github.com/Cray-HPE/shasta-cfg/package/make-dist.sh" "${BUILDDIR}/shasta-cfg"
 
-# Save cray/nexus-setup and quay.io/skopeo/stable images for use in install.sh
-vendor-install-deps "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
+# Use a newer version of cfs-config-util that hasn't rolled out to other products yet
+CFS_CONFIG_UTIL_IMAGE="arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.0.0"
+# Save cray/nexus-setup, quay.io/skopeo/stable, and cfs-config-util images for use in install.sh
+vendor-install-deps --include-cfs-config-util "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
 
 # Package the distribution into an archive
 tar -C "${BUILDDIR}/.." --owner=0 --group=0 -cvzf "${BUILDDIR}/../$(basename "$BUILDDIR").tar.gz" "$(basename "$BUILDDIR")/" --remove-files

--- a/release.sh
+++ b/release.sh
@@ -79,8 +79,6 @@ sed -e "s/-0.0.0/-${RELEASE_VERSION}/g" "${ROOTDIR}/nexus-repositories.yaml" \
 mkdir "${BUILDDIR}/shasta-cfg"
 "${ROOTDIR}/vendor/github.com/Cray-HPE/shasta-cfg/package/make-dist.sh" "${BUILDDIR}/shasta-cfg"
 
-# Use a newer version of cfs-config-util that hasn't rolled out to other products yet
-CFS_CONFIG_UTIL_IMAGE="arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.0.0"
 # Save cray/nexus-setup, quay.io/skopeo/stable, and cfs-config-util images for use in install.sh
 vendor-install-deps --include-cfs-config-util "$(basename "$BUILDDIR")" "${BUILDDIR}/vendor"
 

--- a/update-mgmt-ncn-cfs-config.sh
+++ b/update-mgmt-ncn-cfs-config.sh
@@ -69,10 +69,8 @@ fi
 
 print_stage "Updating CFS configuration(s)"
 
-# Note that recipes with CSM 1.4 still used the site.yml playbook in the
-# default bootprep files, so that playbook must be used here.
 cfs-config-util update-configs --product "${RELEASE_NAME}:${RELEASE_VERSION}" \
-    --playbook site.yml --playbook ncn-initrd.yml $@
+    --playbook ncn_nodes.yml --playbook ncn-initrd.yml $@
 rc=$?
 
 if [[ $rc -eq 2 ]]; then

--- a/update-mgmt-ncn-cfs-config.sh
+++ b/update-mgmt-ncn-cfs-config.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This updates the CFS configuration that applies to management NCNs by adding
+# the appropriate layers for this version of the CSM product.
+#
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+source "${ROOTDIR}/lib/install.sh"
+
+# Print a message with extra emphasis to indicate a stage.
+function print_stage(){
+    msg="$1"
+    echo "====> ${msg}"
+}
+
+# Exit with an error message and an exit code of 1.
+function exit_with_error() {
+    msg="$1"
+    >&2 echo "${msg}"
+    exit 1
+}
+
+load-cfs-config-util
+trap "{ print_stage 'Cleaning up dependencies'; clean-install-deps &>/dev/null; }" EXIT
+
+function print_usage() {
+    cat <<EOF
+usage: ${BASH_SOURCE[0]} [options]
+
+Update the CFS configuration for configuring management NCNs by adding or
+updating the layer for ${RELEASE}.
+
+Options:
+
+  -h, --help              Print this usage information.
+
+EOF
+
+    cfs-config-util-options-help
+}
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+print_stage "Updating CFS configuration(s)"
+
+# Note that recipes with CSM 1.4 still used the site.yml playbook in the
+# default bootprep files, so that playbook must be used here.
+cfs-config-util update-configs --product "${RELEASE_NAME}:${RELEASE_VERSION}" \
+    --playbook site.yml --playbook ncn-initrd.yml $@
+rc=$?
+
+if [[ $rc -eq 2 ]]; then
+    print_usage
+    exit_with_error "cfs-config-util received invalid arguments."
+elif [[ $rc -ne 0 ]]; then
+    exit_with_error "Failed to update CFS configurations. cfs-config-util exited with exit status $rc."
+fi
+
+print_stage "Completed update of CFS configuration(s)"

--- a/update-mgmt-ncn-cfs-config.sh
+++ b/update-mgmt-ncn-cfs-config.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
The `update-mgmt-ncn-cfs-config.sh` script is missing from CSM 1.5.1 tarballs, but it is needed during updates.
This will also be a problem for CSM 1.6.x releases in the future.
This PR adds it to the relevant release branches, and updates it to account for CFS playbook name changes in CSM 1.5+

CSM 1.6 backport:  https://github.com/Cray-HPE/csm/pull/3324
CSM 1.4.5 backport (just of the changes to address Mikhail's review comments): https://github.com/Cray-HPE/csm/pull/3325