### PR TITLE
CASMNET-2207 - csi handoff bss-metadata should ignore Cilium lxc interfaces

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.7.0-1.noarch
     - cray-cmstools-crayctldeploy-1.21.0-1.x86_64
-    - cray-site-init-1.32.6-1.x86_64
+    - cray-site-init-1.32.7-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
     - craycli-0.83.0-1.aarch64


### PR DESCRIPTION
## Summary and Scope

csi already ignores Weave veth interfaces when populating HSM ethernetInterfaces with NCN MAC addresses.

A similar exclusion is required for Cilium lxc interfaces to avoid cluttering up ethernetInterfaces with unnecessary records.

This PR also disables the kube-proxy replacement by default as there are problems with it and TFTP ([CASMPET-6763](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6763))

## Issues and Related PRs

* Resolves [CASMNET-2207](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2207)

## Testing

### Tested on:

  * `surtur`

### Test description:

This was tested on surtur and had the desired effect however the system was reinstalled before I could preserve the output and I cannot test this change again until the next CSM 1.6 fresh install with Cilium as the default CNI.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

