### PR TITLE
CASMINST-6840 Include aarch64 versions of docker images if they exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 # Pre-flight checks
 pre-flight-check:
 	$(call header,"Executing pre-flight checks ...")
-	@for t in curl wget skopeo yq jq parallel timeout rsync rpm rpm2cpio cpio docker; do echo -ne "Checking $$t ... "; which $$t; done
+	@for t in curl wget yq jq parallel timeout rsync rpm rpm2cpio cpio docker; do echo -ne "Checking $$t ... "; which $$t; done
 	./get_base.sh
 
 # Validate assets (node images - ISO, squashfs, etc)
@@ -77,14 +77,15 @@ $(BUILDDIR)/docker:
 	cp "build/images/index.txt" "dist/$(RELEASE)-images.txt"
 
 # Snyk scan of images directory
+# Depends on build/images/index.txt file, produced by valudate-images
 .PHONY: snyk
-snyk: images
+snyk: validate-images
 	$(call header,"Performing Snyk scan for container images in $(BUILDDIR)/docker")
 	@$(MAKE) $(BUILDDIR)/scans
 $(BUILDDIR)/scans:
 	parallel -j $(PARALLEL_JOBS) --halt-on-error now,fail=1 -v \
 		--ungroup -a build/images/index.txt --colsep '\t' \
-		hack/snyk-scan.sh '{1}' '{2}' "$(BUILDDIR)/docker" "$(BUILDDIR)/scans/docker"
+		hack/snyk-scan.sh '{1}' '{2}' "$(BUILDDIR)/scans/docker"
 	cp build/images/chartmap.csv "$(BUILDDIR)/scans/docker/"
 	hack/snyk-aggregate-results.sh "$(BUILDDIR)/scans/docker" --helm-chart-map "/data/chartmap.csv" --sheet-name "$(RELEASE)"
 	hack/snyk-to-html.sh "$(BUILDDIR)/scans/docker"

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -104,7 +104,7 @@ function extract-images() {
 
     for image in $images; do
 	    printf "%s\n" "$image" 
-	    ./inspect.sh "$image" | cut -f 1 | sed -e "s|^|$(basename $manifest | cut -d. -f 1),$1/$2:$VER,|g" >> $chartmap
+        echo "$(basename "$manifest" | cut -d. -f 1),$1/$2:$VER,$image" >> "${chartmap}"
     done | tee >(cat -n 1>&2)
 
 }

--- a/build/images/inspect.sh
+++ b/build/images/inspect.sh
@@ -4,27 +4,11 @@ set -euo pipefail
 
 ROOTDIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
 source "${ROOTDIR}/common.sh"
+source "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh"
 
 function usage() {
     echo >&2 "usage: ${0##*/} IMAGE..."
     exit 255
-}
-
-function skopeo-inspect() {
-    local img="docker://$1"
-    local creds=""
-    [[ "${1}" == artifactory.algol60.net/* ]] && creds="${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}"
-    echo >&2 "+ skopeo inspect $img"
-    skopeo \
-        --command-timeout 60s \
-        --override-os linux \
-        --override-arch amd64 \
-        inspect \
-        --retry-times 5 \
-        ${creds:+--creds "${creds}"} \
-        --format "{{.Name}}@{{.Digest}}" \
-        "$img"
-
 }
 
 function resolve_canonical() {
@@ -92,7 +76,7 @@ while [[ $# -gt 0 ]]; do
     fi
 
     if [[ -z "$ref" ]]; then
-        ref=$(skopeo-inspect "$image_mirror")
+        ref=$(skopeo-inspect "docker://$image_mirror")
     fi
 
     # Output maps "logical" refs to "physical" digest-based refs

--- a/build/images/sync.sh
+++ b/build/images/sync.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOTDIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
 source "${ROOTDIR}/common.sh"
+source "${ROOTDIR}/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh"
 
 function usage() {
     echo >&2 "usage: ${0##*/} LOGICAL_IMAGE PHYSICAL_IMAGE DIR"
@@ -16,43 +17,6 @@ logical_image="${1}"
 physical_image="${2}"
 destdir="${3%/}/$logical_image"
 
-function skopeo-copy() {
-    sha="${physical_image/*:}"
-    if test -f "${destdir}/manifest.json" && echo "${sha}" "${destdir}/manifest.json" | sha256sum -c -; then
-        echo >&2 "+ Valid checksum found for ${destdir}/manifest.json, skip copy"
-    else
-        echo >&2 "+ skopeo copy docker://$physical_image dir:$destdir"
-
-        # Sync to temporary working directory in case of error
-        workdir="$(mktemp -d .skopeo-copy-XXXXXXX)"
-        trap "rm -fr '$workdir'" EXIT
-
-        creds=""
-        [[ "${physical_image}" == artifactory.algol60.net/* ]] && creds="${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}"
-
-        skopeo \
-            --command-timeout 60s \
-            copy \
-            --override-os linux \
-            --override-arch amd64 \
-            --retry-times 5 \
-            ${creds:+--src-creds "${creds}"} \
-            "docker://$physical_image" \
-            "dir:${workdir}" \
-            >&2 || exit 255
-
-        # Ensure intermediate directories exist
-        mkdir -p "$(dirname "$destdir")"
-
-        # Ensure destination directory is fresh, which is particularly important
-        # if there was a previous run
-        [[ -e "$destdir" ]] && rm -fr "$destdir"
-
-        # Move image to destination directory
-        mv "$workdir" "$destdir"
-    fi
-}
-
 if [ -n "${CSM_BASE_VERSION:-}" ]; then
     base_image_dir="${ROOTDIR}/dist/csm-${CSM_BASE_VERSION}/docker/${logical_image}/"
     if [ -d "${base_image_dir}" ]; then
@@ -60,8 +24,13 @@ if [ -n "${CSM_BASE_VERSION:-}" ]; then
         echo >&2 "+ rsync -aq ${base_image_dir} ${destdir%/}/"
         rsync -aq "${base_image_dir}" "${destdir%/}/"
     else
-        skopeo-copy
+        sha="${physical_image/*:}"
+        if test -f "${destdir}/manifest.json" && echo "${sha}" "${destdir}/manifest.json" | sha256sum -c -; then
+            echo >&2 "+ Valid checksum found for ${destdir}/manifest.json, skip copy"
+        else
+            skopeo-copy "docker://$physical_image" "dir:${destdir}"
+        fi
     fi
 else
-    skopeo-copy
+    skopeo-copy "docker://$physical_image" "dir:${destdir}"
 fi

--- a/hack/snyk-scan.sh
+++ b/hack/snyk-scan.sh
@@ -45,32 +45,20 @@ function retry_snyk() {
     exit 255
 }
 
-if [[ $# -ne 4 ]]; then
+if [[ $# -ne 3 ]]; then
     usage
 fi
 
 logical_image="${1#docker://}"
 physical_image="${2#docker://}"
-srcdir="${3#dir:}/${logical_image}"
-destdir="${4#dir:}/${logical_image}"
+destdir="${3#dir:}/${logical_image}"
 
 # Save results to temporary working directory in case of error
 workdir="$(mktemp -d .snyk-container-test-XXXXXXX)"
-tmpfile=$(mktemp)
-trap 'rm -rf ${workdir} ${tmpfile}' EXIT
+trap 'rm -rf ${workdir}' EXIT
 
 echo >&2 "+ snyk container test ${physical_image}"
-
-skopeo \
-    copy \
-    --quiet \
-    --all \
-    --remove-signatures \
-    "dir:$srcdir" \
-    "oci-archive:${tmpfile}" \
-    >&2 || exit 255
-
-retry_snyk "${workdir}" "oci-archive:${tmpfile}"
+retry_snyk "${workdir}" "${physical_image}"
 
 # Fix-up JSON results
 results="$(mktemp)"


### PR DESCRIPTION
## Summary and Scope

We now include images built for all available platforms in CSM tarball, and upload them into Nexus at target environment. For this purpose, all `skopeo` invocations in CSM build and install are changed to refer to wrappers in vendored https://github.hpe.com/hpe/hpc-shastarelm-release repo. In turn, in these wrapper functions `skopeo copy` and 1skopeo sync` are invoked with `--all` CLI option, which ensures that images for all provided platforms are copied to destination.

## Issues and Related PRs

* Resolves CASMINST-6840

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

* Created temporary build from a tag
* Installed this build on vShasta environment
* Ensured that images for all platforms are present in k8s Nexus.

Before:
![Screenshot 2024-04-11 at 11-56-49 Browse - Nexus Repository Manager](https://github.com/Cray-HPE/csm/assets/320082/70729e97-7499-4b6b-83c0-5f22c97633f2)

After:
![Screenshot 2024-04-11 at 11-59-18 Browse - Nexus Repository Manager](https://github.com/Cray-HPE/csm/assets/320082/b61f5e64-af07-4c68-84bf-abd13b0ced01)


