### PR TITLE
CASMHMS-6181: Added workaround for the mac on paradise XD224 nodes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.7
+    version: 7.0.8
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

    Added workaround for the mac on paradise XD224 nodes
    
    Changed to calculate the node MAC by adding 2 to the BMC MAC

This also includes a change to ignore the /redfish/v1/Chassis/ERoT_CPU_0 and /redfish/v1/Chassis/ERoT_CPU_1 redfish endpoints when disovering Paradise nodes.  These were observed to return data too slowly, causing timeouts during discover which led it to fail.

## Issues and Related PRs

* Resolves [CASMHMS-6181](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6181)

## Testing

Tested on:

  * Local development environment
  * tyr

Test description:

- Performed a helm upgrade with SMD_PARADISE_MAC set to "false" and verified the workaround was not performed.
- Performed a helm upgrade with SMD_PARADISE_MAC_INC set to 4 and verified MAC was calculated to be +4 of BMC eth0 MAC when discover was ran
- Performed a helm upgrade with default settings and verified MAC was calculated to be +2 of BMC eth0 MAC when discover was ran
- Verified correct MAC was being calculated when discover was ran with both node power on and node power off

Template answers:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

