### PR TITLE
CASMHMS-6163: Discover Paradise node MACs using correct redfish endpoint

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.8
+    version: 7.0.9
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Paradise hardware lacks the standard /redfish/v1/Systems/system/EthernetInterfaces redfish endpoint for network interfaces attached to the in-band node.  Instead, they've provided multiple locations that must be scanned underneath the /redfish/v1/Systems/system/Oem/Insyde/Ncsi endpoint.  This PR includes a new redfish-foxconn.go file with all the associated data structures and code necessary to parse through this tree for all of the network interfaces attached to the host node.

A sample output of 'cray hsm inventory' is as follows:

> ncn-m001:~ # cray hsm inventory componentEndpoints describe x3000c0s33b4n0 --format json | jq .RedfishSystemInfo.EthernetNICInfo
[
  {
    "RedfishId": "ncsi1-p1-c0-primary_eth",
    "@odata.id": "/redfish/v1/Systems/system/Oem/Insyde/Ncsi/1/Package/1",
    "Description": "Foxconn NCSI Interface (discovered)",
    "MACAddress": "04:d9:c8:5d:54:f0"
  }
]

RedfishId must be unique across all interfaces discovered on the node and uses the following naming convention:

> ncsi<NCSI NUMBER>-p<PACKAGE_NUMBER>-c<CHANNEL_NUMBER>

The interface detected as the primary ethernet interface will have a "-primary_eth" appended to the ID as seen above.  The code that does this detection relies upon the PCIDID (found in /redfish/v1/Systems/system/Oem/Insyde/#.VersionID.PCIDID) being unique across all ethernet interfaces attached to the node, and being set to "0x6315" or "0x1563" (Foxconn has different IDs in different BMC fw versions).  If for some reason a different PCIDID is detected, an error message will be sent to smd's log so we can more easily determine why the detection failed.

Prior code was merged into smd that generates the node MAC address to be +2 of the BMC eth0 MAC address if the necessary redfish endpoint is not present.  This has occurred with various BMC fw versions combined with different power states for the node.  We have the autogenerated MAC to fall back on if this happens.

Adopted app version 2.11.6 for CSM 1.5.1 (helm chart 7.0.9)

## Issues and Related PRs

* Resolves CASMHMS-6163

## Testing

Tested on:

  * tyr

Test description:

Removed an interface from a Paradise node via 'cray hsm inventory ethernetInterfaces delete' and verified that it was recreated after running 'cray hsm inventory discover create'.  Additionally verified that after discover was run, 'cray hsm inventory componentEndpoints describe' looked correct.

Attempted discovery of a Paradise BMC with missing /redfish/v1/Systems/system/Oem/Insyde/Ncsi members.  Obviously no ethernet interfaces were detected but it confirmed that smd correctly handled the missing members and continued without crashing.

Attempted discovery of non-Paradise BMCs to ensure discovery continues to operate on them.

The DataCenter temporarily put a CX7 card into s33c1 on tyr so that I could test with multiple ethernet interfaces present.  The code detected all interfaces correctly.

Also tested when combined with the autogenerated +2 MAC code.  I verified that when the redfish endpoint is present the code here will detect the MAC addresses correctly.  When the redfish endpoint is not present the autogenerating +2 MAC code works properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Risks and Mitigations

The greatest risk here is if Foxconn changes the value for PCIDID again.  They have said that it is a unique identifier tied to the PCI device however their BMC fw has already changed it on us once.  They state it will never change again so let's hope that stays true.  We have code to log if this happens though so we can more easily diagnose it.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

