### PR TITLE
FAS to 1.31 for release 1.5.1 - CASMHMS-6184

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,12 +53,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.4.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.0.6
+    version: 3.0.7
     namespace: services
     swagger:
     - name: firmware-action
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.30.0/api/docs/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.31.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
     version: 3.0.4


### PR DESCRIPTION
## Summary and Scope

FAS to 1.31 for fix of loading .zip files

## Issues and Related PRs

CASMHMS-6184

## Testing

Tested on Tyr

### Test description:

Tested by updating loader and manually uploading zip files

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

