### PR TITLE
CASMCMS-8966: CFS: Add missing special_parameters property to V3ConfigurationLayer schema

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.13/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.18.4
+    version: 1.18.5
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.4/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.5/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.2


### PR DESCRIPTION
When CFS v3 was added, it accidentally failed to include the special_parameters property as part of the configuration layer schema. That prevents CFS v3 from being able to create configurations which contain these. This PR fixes that.

CSM 1.6 backport:
https://github.com/Cray-HPE/csm/pull/3336