### PR TITLE
Updated craycli version to v0.83.2

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.32.7-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
-    - craycli-0.83.0-1.aarch64
-    - craycli-0.83.0-1.x86_64
+    - craycli-0.83.2-1.aarch64
+    - craycli-0.83.2-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.6-1.aarch64
     - csm-node-heartbeat-2.6-1.x86_64


### PR DESCRIPTION
Changes
- hsm inventory redfish update - workaround for the hostname value
- cray artifacts create - fix to check if the file path given as an arg exists

CASMHMS-6154
CASMTRIAGE-6895

## Summary and Scope

Updated craycli version to v0.83.2

Changes
- hsm inventory redfish update - workaround for the hostname value
- cray artifacts create - fix to check if the file path given as an arg exists

## Issues and Related PRs

* Resolves [CASMHMS-6154](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6154)
* Resolves [CASMTRIAGE-6895](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6895)

## Testing

### Tested on:

  * mug
 
### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

