### PR TITLE
CASMCMS-8438/CASMCMS-8186: BOSv2 fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.17.5
+    version: 2.17.6
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.5/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.6/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.5

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.17.4
+    version: 2.17.5
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.4/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.5

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.17.5-1.noarch
+    - bos-reporter-2.17.6-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.0-1.noarch
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.32.7-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
-    - craycli-0.83.2-1.aarch64
-    - craycli-0.83.2-1.x86_64
+    - craycli-0.83.3-1.aarch64
+    - craycli-0.83.3-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.6-1.aarch64
     - csm-node-heartbeat-2.6-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.17.4-1.noarch
+    - bos-reporter-2.17.5-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.0-1.noarch


### PR DESCRIPTION
* CASMCMS-8438: This reduces the default value of the BOS v2 polling frequency, to reduce idle time during BOS sessions.
* CASMCMS-8186: This corrects the description of the `disable_components_on_completion` option

Backports:
CSM 1.5.2: https://github.com/Cray-HPE/csm/pull/3342
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3343