### PR TITLE
CASMCMS-8973: Fix build issue with image-recipes repo

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -171,13 +171,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.5.0
+    version: 2.5.1
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.5.0
+            tag: 2.5.1
   - name: cray-ims
     source: csm-algol60
     version: 3.14.1


### PR DESCRIPTION
This doesn't actually involve a real content change. There was a build issue with the `image-recipes` repo, and this updates CSM so that it uses the version which is buildable. This way it will pick up the nightly security rebuilds.

Backports:
CSM 1.5.2: https://github.com/Cray-HPE/csm/pull/3347
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3348