### PR TITLE
CASMCMS-8971: Multi-Tenancy OPA policy: Allow tenant admins to list their BOSv2 sessions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -125,7 +125,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.34.1
+    version: 1.34.2
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
This updates the OPA policies to allow tenants to list their sessions in BOS v2.

CSM 1.5.2 backport: https://github.com/Cray-HPE/csm/pull/3350