### PR TITLE
CASMTRIAGE-6862: IUF workflows seem to hang around indefinitely in Argo after the workflow completes

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -249,11 +249,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.10
+    version: 4.0.11
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.10
+    version: 4.0.11
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

cray-nls version update from 4.0.10 to 4.0.11

## Issues and Related PRs

* Resolves [CASMTRIAGE-6862](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6862)
* https://github.com/Cray-HPE/cray-nls/pull/212
* https://github.com/Cray-HPE/cray-nls-charts/pull/66

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

