### PR TITLE
CASM-4696 cray-nexus-setup image update

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -220,7 +220,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Images needed by IUF and possibly non-CSM products
     cray-nexus-setup:
-      - 0.10.1
+      - 0.11.1
 
     # not needed for build/install as it comes packaged as skopeo.tar
     quay.io/skopeo/stable:


### PR DESCRIPTION
## Summary and Scope

updating the version of cray-nexus-setup to 0.11.1

## Issues and Related PRs

* Resolves [CASM-4696](https://jira-pro.it.hpe.com:8443/browse/CASM-4696)
* https://github.com/Cray-HPE/nexus-setup/pull/28
* https://github.com/Cray-HPE/docs-csm/pull/5026

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

