### PR TITLE
CASM-4703: During management-nodes-rollout workflow fails while doing node reboot

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.10-1.x86_64
+    - iuf-cli-1.6.11-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.6-1.noarch


### PR DESCRIPTION
## Summary and Scope

updating iuf-cli version to 1.6.11

## Issues and Related PRs

* Resolves [CASM-4703](https://jira-pro.it.hpe.com:8443/browse/CASM-4703)
* https://github.com/Cray-HPE/iuf-cli/pull/181

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

