### PR TITLE
CASMHMS-6148: Paradise discovery enhancements (including fixed power capping)

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.5
+    version: 7.1.6
     namespace: services
     values:
       cray-service:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -45,7 +45,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.26.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 4.0.2
+    version: 4.0.3
     namespace: services
     swagger:
     - name: capmc
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.1.5
+    version: 2.1.6
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

The purpose of this change is to improve discovery for Foxconn Paradise nodes and fix power capping on those nodes.  The changes span three services; SMD, PCS, and CAPMC

### SMD Changes

There are a number of discovery changes in this PR related to Foxconn Paradise discovery.

The Paradise redfish Power endpoint presents the consumed watts value as a float. All prior platforms have presented it as an integer value and thus the smd data structure for holding it declared it as an int. This caused json.Unmarshal() to fail on Paradise because it enforces strict type checking.  The fix here is to change the int type to an interface{} type so that it can hold a value of any type. We then convert any floats we read to an int (by rounding). We chose to do this rather than simply changing the type from an int to a float so that we don't break any customer code that may be doing the same thing we were doing (expecting an int rather than a float).

During chassis discovery, we now skip discovery of power supplies for all chassis except Baseboard_0 as it contains everything necessary.  The PSU0 and PSU1 chassis contain redundant data.  When node power is off, due to a regression described in PRDIS-198, the Power endpoint becomes inaccessible and cause long timeouts.  Since the only chassis we need to query for power supplies is Baseboard_0, we skip all the others and avoid all but one of the timeouts.

For power capping, we query the Power endpoint in the Processor_Module_0 chassis during the Systems discovery phase.  It is the control provided to us by Foxconn.  Power capping will only be allowed when node power is on.  If a power cap is in place when the node is powered off, it will be reset when the node is powered back on again.

We use the Baseboard_0 chassis for discovery of assemblies and network adapters for Foxconn Paradise.

Adopted app version 2.18.0 for CSM 1.6 (helm chart 7.1.6)

### PCS Changes

The Paradise redfish Power endpoint presents the consumed watts value as a float. All prior platforms have presented it as an integer value and thus the PCS data structure for holding it declared it as an int. This caused json.Unmarshal() to fail on Paradise because it enforces strict type checking.

The fix here is to change the int type to an interface{} type so that it can hold a value of any type. We then convert any floats we read to an int (by rounding). We chose to do this rather than simply changing the type from an int to a float so that we don't break any customer code that may be doing the same thing we were doing (expecting an int rather than a float).

Additionally, this PR contains a fix to initialize the power cap min/max values to -1. This is necessary in order for requests against non-oem platforms to work properly in doPowerCapTask() where checks are made against these values.

Adopted app version 2.4.0 for CSM 1.6 (helm chart 2.1.6)

### CAPMC Changes

The Paradise redfish Power endpoint presents the consumed watts value as a float. All prior platforms have presented it as an integer value and thus the capmc data structure for holding it declared it as an int. This caused json.Unmarshal() to fail on Paradise because it enforces strict type checking.

The fix here is to change the int type to an interface{} type so that it can hold a value of any type. We then convert any floats we read to an int (by rounding). We chose to do this rather than simply changing the type from an int to a float so that we don't break any customer code that may be doing the same thing we were doing (expecting an int rather than a float).

Adopted app version 3.6.0 for CSM 1.6 (helm chart 4.0.3)

## Issues and Related PRs

* Resolves CASMHMS-6148

## Testing

### SMD Testing

Tested on:

  * tyr

Test description:

Ran discovery against Paradise, DL325, and Bard Peak node/BMC types with power on and power off.

Verified both capmc and PCS can now power cap Paradise nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y

### PCS Testing

Tested on:

- tyr

Test description:

With a patched SMD in place, verified that PCS would convert floats to ints properly when ran against Paradise nodes. Then verified that PCS could power cap both Paradise and Bard Peak compute nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

### CAPMC Testing

Tested on:

- tyr

Test description:

With a patched SMD in place, verified that capmc would convert floats to ints properly when ran against Paradise nodes. Then verified that capmc could power cap both Paradise and Bard Peak compute nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable