### PR TITLE
CASMTRIAGE-6961 -- remove UUID entries from /etc/fstab

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -64,7 +64,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=5.2.55
+COMPUTE_IMAGE_ID=5.2.59
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \


### PR DESCRIPTION
## Summary and Scope

- removes any "UUID=..." entries in /etc/fstab

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6961

## Testing
Tested on tyr and vidar

### Test description:
ARM compute node was successfully booted.

## Risks and Mitigations
None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
