### PR TITLE
MTL-2390 -- 1.4.5

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,7 +40,7 @@ pipeline {
     environment {
         DOCS_CSM_BRANCH = "release/1.4"
         CSM_VSHASTA_DEPLOY_ENVIRONMENT = "vex"
-        CSM_BASE_VERSION = "1.4.2"
+        CSM_BASE_VERSION = "1.4.4-rc.3"
         ARTIFACTORY = credentials('artifactory-algol60-readonly')
     }
 

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -231,7 +231,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.29
+    version: 1.15.30
     namespace: services
     values:
       cray-import-config:

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,6 +35,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.15.60-1.noarch
+    - dracut-metal-mdsquash-2.3.2-1.noarch
     - goss-servers-1.15.60-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - iuf-cli-1.4.6-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Add dracut-metal-mdsquash to csm tarball. dracut-metal-mdsquash-2.3.2-1 sets the xfs mount options to 'defaults'

- https://jira-pro.it.hpe.com:8443/browse/MTL-2390

### Tested on:

- tyr

### Test description:

xfs mounts were mounted with 'defaults' successfully

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable