### PR TITLE
CASMHMS-6182: FAS to 1.32.0 for CSM 1.6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,12 +53,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.4.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: services
     swagger:
     - name: firmware-action
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.31.0/api/docs/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.32.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
     version: 3.1.0


### PR DESCRIPTION
## Summary and Scope

Update FAS to 1.32.0 for release 1.6

## Issues and Related PRs

* CASMHMS-6182

## Testing
### Tested on:

  * Tyr
