### PR TITLE
CASMHMS-6201: Updated tavern tests to handle Foxconn Paradise ethernet interface names

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.7
+    version: 7.1.8
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Updated regex patterns in the tavern tests to handle the new Foxconn Paradise ethernet interface names.  Without these changes, the SMD functional tests were failing on systems with Foxconn Paradise hardware.

Adopted app version 2.20.0 for CSM 1.6 (helm chart 7.1.8)

## Issues and Related PRs

* Resolves [CASMHMS-6201](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6201)

## Testing

Tested on:

  * tyr

Test description:

Aftur upgrading SMD with changes, verified smoke and functional tests passed when running:

`/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t hsm`

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? :
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

