### PR TITLE
CASMCMS-8899 - Console changes for Paradise compatibility.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -157,16 +157,16 @@ spec:
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 2.0.0
+    version: 2.1.0
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.7.0
+    version: 1.8.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.0.0
+    version: 2.2.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

The Paradise nodes have firmware written by Foxconn and the console services were not able to connect to them in the same way it does to the other nodes they work with. This change adds the ability to connect through password driven ssh, and identifies the Paradise nodes to connect through this mechanism. All other nodes connect through passwordless ssh (keys added to the bmc), or password driven ipmi.

## Issues and Related PRs
* Resolves [CASMCMS-8899](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8899)

## Testing
### Tested on:

  * `Tyr`

### Test description:

Installed the new services via helm and tested to insure that proper connections are made to the Paradise nodes, while other river and mountain nodes still connect correctly through existing mechanisms.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change as it impacts the workflow for all node types, but is required for Paradise nodes to work with the console logging and interaction.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
