### PR TITLE
CASMCMS-8978: CFS: Fix broken component patch filtering

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.6/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.19.5
+    version: 1.19.6
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.5/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.6/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.10.0


### PR DESCRIPTION
This fixes 2 bugs in the CFS v2 components patching code.

Backports:
CSM 1.5.2: https://github.com/Cray-HPE/csm/pull/3379
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3380