### PR TITLE
CASMCMS-8978: CFS: Fix broken component patch filtering

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -168,12 +168,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.37/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.12.8
+    version: 1.12.9
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.8/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.9/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.8.0


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3378 for CSM 1.4.5