### PR TITLE
Update manifest file as cray-spire chart version is updated

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -272,7 +272,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.5.6
+    version: 1.5.7
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This is related to the CASMPET-6799 where is SBPS marshal agent is added to cray-spire. With this regard the cray-spire chart had been upgraded from 1.5.6 -> 1.5.7. So this had to be updated in the manifest file so that appropriate version of the chart gets installed. 

## Issues and Related PRs

CASMPET-6799

## Testing

Jenkins build/testing.

### Tested on:

N/A

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_ --> Jenkins build/testing.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? 
- Were continuous integration tests run? If not, why? 
- Was upgrade tested? If not, why? - TBD
- Was downgrade tested? If not, why? - TBD
- Were new tests (or test issues/Jiras) created for this change? - NO

## Risks and Mitigations
None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

