### PR TITLE
CASMTRIAGE-6961 - get new compute image into install package.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -171,13 +171,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.2.1
+    version: 2.2.2
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.2.1
+            tag: 2.2.2
   - name: cray-ims
     source: csm-algol60
     version: 3.14.1


### PR DESCRIPTION
## Summary and Scope

When the new barebones compute image was updated in the csm file, it was not included in the cray-csm-barebones-recipe-install image. That is how it is really delivered as part of the install. This adds the new image to the correct service.

## Issues and Related PRs

* Resolves [CASMTRIAGE-6961](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6961)

## Testing
### Tested on:
  * `Vidar`

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

