### PR TITLE
CASMHMS-6129: hms-discovery stopped overwriting creds

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -46,7 +46,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 2.0.5
+    version: 2.1.1
     namespace: services
 
   # Cray DHCP Kea


### PR DESCRIPTION
## Summary and Scope

hms-discovery changed to not overwrite the existing creds in vault with the default creds

## Issues and Related PRs

* [CASMHMS-6129](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6129)

## Testing

### Tested on:

These changes were tested when they were submitted to 1.5 and 1.6

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

