### PR TITLE
Revert "MTL-2390 -- 1.4.5"

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -231,7 +231,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.30
+    version: 1.15.29
     namespace: services
     values:
       cray-import-config:

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -35,7 +35,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
     - csm-testing-1.15.60-1.noarch
-    - dracut-metal-mdsquash-2.3.2-1.noarch
     - goss-servers-1.15.60-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - iuf-cli-1.4.6-1.x86_64


### PR DESCRIPTION
Reverts Cray-HPE/csm#3370:

    Error: chart "csm-config" matching 1.15.30 not found in csm-algol60 index. (try 'helm repo update'): no chart version found for csm-config-1.15.30