### PR TITLE
CASMHMS-6199: Pick appropriate chassis to act as node enclosure for Paradise

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.14
+    version: 7.0.15
     namespace: services
     values:
       cray-service:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.13
+    version: 7.0.14
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

On Paradise systems, the Baseboard_0 chassis represents the closest thing to a node enclosure abstraction that Paradise has.  It contains the FPGA_0, ProcessorModule_0, CPU_0, CPU_1, ERoT_CPU_0, and ERoT_CPU_1 chassis.  Its ChassisType is "Zone", which is a new chassis type that SMD has never dealt with before.  In order to detect it as the node enclosure, getChassisHMSType() had to be updated to look for it and return NodeEnclosure if the target chassis is in a Foxconn BMC.

Additionally, getChassisHMSType() was updated to return HSMTypeInvalid for Foxconn chassis types of RackMount.  This chassis type was previously used on River systems to denote the node enclosure.  There are multiple chassis of type RackMount on Foxconn systems, none of which should be treated as the node enclosure.  Only Baseboard_0 plays that part.

The final change in this PR is an updated isFoxconnChassis() routine that first checks if the Manufacturer is set to "Foxconn" in the manager for the chassis.  Only if that does not yet exist (which happens during early discovery), does it do string comparisons against known unique Foxconn chassis names.

Adopted app version 2.11.10 for CSM 1.5.2 (helm chart 7.0.14)

## Issues and Related PRs

* Resolves: CASMHMS-6199

## Testing

Tested on:

  * tyr

Test description:

Ran discover against Paradise BMCs both powered on and powered off.  Used 'sat hwinv --list-node-enclosures' and 'cray hsm inventory hardware describe' to ensure the proper enclosure data was being constructed.  Also ran discover against non-Paradise to ensure no regressions on non-Paradise hardware.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

