### PR TITLE
CASMCMS-8997/CASMCMS-8998: BOS v2 fixes/improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.15
+    version: 2.10.16
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.15/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.16/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.6

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.10.15-1.noarch
+    - bos-reporter-2.10.16-1.noarch
     - cani-0.3.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3394 for CSM 1.5.2