### PR TITLE
CASMCMS-9001: IMS: Pin pytest version to prevent unit test failures

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,12 +180,12 @@ spec:
             tag: 2.2.2
   - name: cray-ims
     source: csm-algol60
-    version: 3.14.1
+    version: 3.14.2
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.14.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.14.2/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.4


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3397 for CSM 1.5.2