### PR TITLE
CASMPET-6946 Remove old cephcsi version in CSM release

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -75,10 +75,6 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/ceph/ceph-grafana:
       - 9.4.7
 
-    # Requried to support hybrid mode during upgrade
-    quay.io/cephcsi/cephcsi:
-      - v3.5.1
-
     quay.io/prometheus/prometheus:
       - v2.43.0
 
@@ -165,9 +161,6 @@ artifactory.algol60.net/csm-docker/stable:
     k8s.gcr.io/pause:
       - 3.4.1
       - 3.5
-    # Requried to support hybrid mode during upgrade
-    k8s.gcr.io/sig-storage/csi-resizer:
-      - v1.3.0
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
 


### PR DESCRIPTION
## Summary and Scope

This reverts commit fd40e21e179c736ae424abc7610449e8dd98ac59.
It's unclear what is "hybrid upgrade mode" and why we need to have old cephcsi. I'm going to propose to remove old versions of `cephcsi`, and if this causes troubles during upgrade, we'll need to find a way to fix them without using this image (which was not rebuilt for 2.5 years and accumulated a lot of CVE's).

## Issues and Related PRs

* Resolves [CASMPET-6946](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6946)
* Resolves [CASMPET-6988](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6988)

## Testing
### Tested on:

Currently not tested. Will see how upgrade on vShasta passes.

## Risks and Mitigations

Low - 1.6.x alpha stage.

