### PR TITLE
CASMPET-7058 Bump csm-testing

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -24,6 +24,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - cray-node-exporter-1.5.0.1-1.noarch
-    - csm-testing-1.15.60-1.noarch
-    - goss-servers-1.15.60-1.noarch
+    - csm-testing-1.15.61-1.noarch
+    - goss-servers-1.15.61-1.noarch
     - smart-mon-1.0.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

Bump version of `csm-testing` and `goss-servers`.

## Issues and Related PRs

* Resolves [CASMPET-7058](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7058)
