### PR TITLE
CASMTRIAGE-6991 & CASMPET-7058

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -43,8 +43,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch
-    - goss-servers-1.17.26-1.noarch
-    - csm-testing-1.17.26-1.noarch
+    - goss-servers-1.17.28-1.noarch
+    - csm-testing-1.17.28-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
- Fixes `goss-servers.service` not starting automatically after RPM upgrade (CASMTRIAGE-6991).
- Fixes vShasta's DNSMasq test (CASMPET-7058).
