### PR TITLE
MTL-2393 Fix `goss-server` dependencies

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.73-1.noarch
-    - goss-servers-1.16.73-1.noarch
+    - csm-testing-1.16.74-1.noarch
+    - goss-servers-1.16.74-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
Package `goss-servers` now requires `goss` to be provided (by any package).
This was problematic in the NCN image build after
https://github.com/Cray-HPE/metal-provision/pull/675/files#diff-4b8036c5c83ba58cb56e769dfdde82765b1a451a424c8f93e114fa21775cc7f8 because `goss` was no longer explicitly called out, and aarch64 images do not include hpe-csm-goss-package but rely on SUSE's own goss package.

This new `Requires` will allow Zypper to auto-resolve which package to pull in regardless of architecture.
