### PR TITLE
CASMPET-7068 Upgrade Nexus to 3.68.1

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.12.1
+    version: 0.12.2
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -81,7 +81,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.67.1-1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Need to upgrade Nexus to 3.68.1 - vulnerability reported for versions up to 3.68.0: https://support.sonatype.com/hc/en-us/articles/29416509323923-CVE-2024-4956-Nexus-Repository-3-Path-Traversal-2024-05-16?_ga=2.111591940.162078004.1716391739-1182997560.1716391642

## Issues and Related PRs

* Resolves [CASMPET-7068](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7068)

## Risks and Mitigations

Low - 1.6 only, will rollback if any issues occur.