### PR TITLE
CASMPET-7061 update cray-nls and cray-iuf versions to 4.0.12

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -249,11 +249,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.11
+    version: 4.0.12
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.11
+    version: 4.0.12
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

Update cray-nls and cray-iuf versions to 4.0.12.

Cray-nls 4.0.12 has updated the versions of the cray-service chart. This change was made by [this PR](https://github.com/Cray-HPE/cray-nls-charts/pull/67/files).

This change is required for the cert-manager upgrade happening in CSM 1.6.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

