### PR TITLE
CASM-4679: Lock down cloud init endpoints in OPA

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -125,7 +125,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.34.2
+    version: 1.34.3
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This change locks down the cloud init endpoints to only the locations and methods used.

## Issues and Related PRs

* Resolves [CASM-4679](https://jira-pro.it.hpe.com:8443/browse/CASM-4679)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

