### PR TITLE
CASMPET-6998: Remove Postgres Backup from spire

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -268,11 +268,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.14.2
+    version: 2.15.1
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.5.6
+    version: 1.6.1
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

Small change to remove unused docker images from spire charts.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6998](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6998)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

