### PR TITLE
CASMHMS-5838: Fix bugs that break bulk component role/subrole updates

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.10
+    version: 7.1.11
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.14.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.23.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 2.0.3


### PR DESCRIPTION
Fixes two bugs that prevent bulk updates of component roles or subroles.

CSM 1.5.2 backport: https://github.com/Cray-HPE/csm/pull/3427
CSM 1.4.5 backport: https://github.com/Cray-HPE/csm/pull/3428