### PR TITLE
CASMPET-6996: Update cray-keycloak to use latest image

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -197,7 +197,7 @@ spec:
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.0.3
+    version: 5.0.4
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the keycloak setup container to use the latest image, also releases a change that adds ttl to keycloak-setup job that was never added to 1.5

## Issues and Related PRs

* Resolves [CASMPET-6996](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6996)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

