### PR TITLE
CASMPET-7062 udpate cray-sts chart to 0.8.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -213,7 +213,7 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.7.0
+    version: 0.8.0
     namespace: services
     swagger:
     - name: sts


### PR DESCRIPTION
## Summary and Scope

Updated the cray-sts chart version from 0.7.0 to 0.8.0. The change in cray-sts was the latest cray-service chart was picked up. This is required for the cert-manager upgrade in CSM 1.6.

Tested deploying this chart on Beau and validated that a temporary token could be retrieved.


## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

