### PR TITLE
CASMPET-6997 Fix rebuilds for cray-node-discovery

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
-    version: 1.2.4
+    version: 1.2.5
     namespace: services
   - name: cray-shared-kafka
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bump version of `cray-node-discovery` chart to `1.2.5`.

## Issues and Related PRs

* Resolves CASMPET-6997

## Testing
### Tested on:

  * Local development environment
  * Jenkins

### Test description:

Build completed successfully.

## Risks and Mitigations

None known.