### PR TITLE
CASMTRIAGE-7019/CASMTRIAGE-6993: BOS fixes/improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.17.7
+    version: 2.18.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.17.7/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.18.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.6

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.17.7-1.noarch
+    - bos-reporter-2.18.1-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch


### PR DESCRIPTION
This PR includes BOS changes for the following two tickets:
* [CASMTRIAGE-6993](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6993) - Avoid OOMKill issues for BOS server processes
* [CASMTRIAGE-7019](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7019) - Fix bug that breaks BOS reporter RPM

metal-provision PR: https://github.com/Cray-HPE/metal-provision/pull/680

CSM 1.5.2 manifest PR: https://github.com/Cray-HPE/csm/pull/3435
CSM 1.4.5 manifest PR: https://github.com/Cray-HPE/csm/pull/3436