### PR TITLE
CASMCMS-9015: BOS: Instantiate S3 client in a thread-safe manner

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.18.1
+    version: 2.18.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.18.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.18.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.6

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.18.1-1.noarch
+    - bos-reporter-2.18.2-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch


### PR DESCRIPTION
Fixes a bug in which BOS was instantiating its S3 client in a non-thread-safe manner, causing some operations to fail.

Backports:
CSM 1.5.2: https://github.com/Cray-HPE/csm/pull/3442
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3443