### PR TITLE
CASMPET-7000 Fix build for cray-sts 0.7.x

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -213,12 +213,12 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.7.0
+    version: 0.7.1
     namespace: services
     swagger:
     - name: sts
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.7.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.7.1/api/openapi.yaml
   - name: cray-etcd-defrag
     source: csm-algol60
     version: 0.4.0


### PR DESCRIPTION
## Summary and Scope

Version 0.7.1 is a rebuild of 0.7.0 with some dependencies frozen/updated to make build possible.

## Issues and Related PRs

* Resolves CASMPET-7000

## Testing
### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

* Build is happy
* Image is uploaded to vShasta environment and functionality tested