### PR TITLE
CASMPET-7062 bump cray-sts to 0.8.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -213,12 +213,12 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.8.0
+    version: 0.8.1
     namespace: services
     swagger:
     - name: sts
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.7.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.8.1/api/openapi.yaml
   - name: cray-etcd-defrag
     source: csm-algol60
     version: 0.4.1


### PR DESCRIPTION
## Summary and Scope

Changes, introduced in version `0.8.0` cause import errors in runtime. Version 0.8.1 is a rebuild of 0.7.1 (tested in runtime), with `cray-service` dependency updated as per CASMPET-7062 requirement.

## Issues and Related PRs

* Resolves CASMPET-7062
* Resolves CASMPET-7000

## Testing
### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

* Build is happy
* Image is uploaded to vShasta environment and functionality tested