### PR TITLE
CASMPET-7021 - Investigate duplicates cray-dhcp-kea

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -55,9 +55,6 @@ artifactory.algol60.net/csm-docker/stable:
     cray-capmc:
       - 2.7.0
 
-    cray-dhcp-kea:
-      - 0.10.25
-
     product-deletion-utility:
       - 1.0.0
 


### PR DESCRIPTION
## Summary and Scope

Remove duplicate Kea image that was introduced by CASMHMS-6069

The correct version (0.10.26) is pulled in by the Helm chart.

## Issues and Related PRs

* Resolves [CASMPET-7021](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7021)

## Testing

N/A

### Tested on:

  * Local development environment

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

