### PR TITLE
CASMCMS-9017: cmsdev: Do not fail BOS test if etcd snapshotter pods are running

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.6.8-1.noarch
-    - cray-cmstools-crayctldeploy-1.16.2-1.x86_64
+    - cray-cmstools-crayctldeploy-1.16.3-1.x86_64
     - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.82.15-1.aarch64


### PR DESCRIPTION
This updates the cmsdev BOS test to prevent false failures if it happens to run at the same time that the BOS etcd snapshotter job is running.

Source PR:
https://github.com/Cray-HPE/cms-tools/pull/184

No other manifest PRs needed.