### PR TITLE
CASMCMS-9018: cfs-operator: Bump paramiko version to avoid Blowfish deprecation warnings in pod logs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.24.0
+    version: 1.25.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
No functional change -- just a small dependency version bump to prevent unsightly warnings in the pod logs.

CSM 1.5.2 backport: https://github.com/Cray-HPE/csm/pull/3450