### PR TITLE
CASMCMS-9018: cfs-operator: Bump paramiko version to avoid Blowfish deprecation warnings in pod logs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.22.2
+    version: 1.22.3
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
CSM 1.5.2 backport of https://github.com/Cray-HPE/csm/pull/3449