### PR TITLE
CASMPET-7052 Remove unneeded references to pgbouncer and spilo-12 images

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -168,17 +168,6 @@ artifactory.algol60.net/csm-docker/stable:
     product-deletion-utility:
       - 0.0.1
 
-    # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
-    # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L43
-    # XXX but it is not extracted from any charts?
-    registry.opensource.zalan.do/acid/pgbouncer:
-      - master-21
-
-    # XXX Spilo-12 is not properly extracted from cray-postgres-operator, see
-    # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21
-    registry.opensource.zalan.do/acid/spilo-12:
-      - 1.6-p3
-
     # Argo images
     quay.io/argoproj/argoexec:
       - v3.3.6


### PR DESCRIPTION
## Summary and Scope

Some images were previously described directly in `docker/index.yaml`, because they were pulled in by base (dependency) chart `cray-service`, but annotations are not inherited from dependency to parent chart. Since then, we started to use `helm template` output instead of annotations to evaluate images. So inclusion of images into `docker/index.yaml` is not necessary.

## Issues and Related PRs

* Resolves CASMPET-7052
* Resolves CASMPET-7010

## Testing
### Tested on:

  * Will be tested in Virtual Shasta

### Test description:

Automated fresh install and upgrade will be performed once new CSN distro is built.

## Risks and Mitigations

None known.
