### PR TITLE
CASMPET-7052 Remove unneeded references to pgbouncer and spilo-12 images

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -162,17 +162,6 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
 
-    # XXX Pgbouncer image is weird -- it's in the cray-service base chart at
-    # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L43
-    # XXX but it is not extracted from any charts?
-    registry.opensource.zalan.do/acid/pgbouncer:
-      - master-21
-
-    # XXX Spilo-12 is not properly extracted from cray-postgres-operator, see
-    # XXX https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/Chart.yaml#L21
-    registry.opensource.zalan.do/acid/spilo-12:
-      - 1.6-p3
-
     # Argo images
     quay.io/argoproj/argoexec:
       - v3.3.6


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3451 into `release/1.5` branch.