### PR TITLE
CASMNET-2221 - BUG: cray-dhcp-kea node specific boot file override is broken

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -45,7 +45,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.2 # update platform.yaml cray-precache-images with this
+    version: 0.11.3 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.26
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3


### PR DESCRIPTION
## Summary and Scope

The support for aarch64 added by CASMNET-2095 broke the ability to override the Kea boot-file-name parameter on a per-node basis.

This PR restores that functionality.

## Issues and Related PRs

* Resolves [CASMNET-2221](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2221)

## Testing

### Tested on:

  * `surtur`
  * `starlord`

### Test description:

Deployed code and verified service started and configuration was built successfully.

Overrode the boot-file-name parameter for a compute node and verified Kea configuration was modified as expected.

```
ncn-m001:~ # cray hsm inventory ethernetInterfaces update b42e99dfec47 --description="ipxe=ipxe.test"
ID = "b42e99dfec47"
Description = "ipxe=ipxe.test"
MACAddress = "b4:2e:99:df:ec:47"
LastUpdate = "2024-04-25T06:28:34.825112Z"
ComponentID = "x3000c0s17b4n0"
Type = "Node"
[[IPAddresses]]
IPAddress = "10.106.0.15"


ncn-m001:~ #  curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "config-get", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
...
              {
                "boot-file-name": "ipxe.test",
                "client-classes": [],
                "hostname": "nid000004",
                "hw-address": "b4:2e:99:df:ec:47",
                "ip-address": "10.106.0.15",
                "next-server": "0.0.0.0",
                "option-data": [],
                "server-hostname": ""
              }

```
Verified node booted using the new boot-file-name
```
2024-06-05 12:33:18 >>Start PXE over IPv4 on MAC: B4-2E-99-DF-EC-47. Press ESC key to abort PXE boot.
2024-06-05 12:33:26   Station IP address is 10.106.0.15
2024-06-05 12:33:26
2024-06-05 12:33:26   Server IP address is 10.92.100.60
2024-06-05 12:33:26   NBP filename is ipxe.test

```
Set the boot file back to the default and verified the configuration was updated as expected.
```
ncn-m001:~ # cray hsm inventory ethernetInterfaces update b42e99dfec47 --description=""
ID = "b42e99dfec47"
Description = ""
MACAddress = "b4:2e:99:df:ec:47"
LastUpdate = "2024-04-25T06:28:34.825112Z"
ComponentID = "x3000c0s17b4n0"
Type = "Node"
[[IPAddresses]]
IPAddress = "10.106.0.15"

ncn-m001:~ #  curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "config-get", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
...
              {
                "boot-file-name": "",
                "client-classes": [],
                "hostname": "nid000004",
                "hw-address": "b4:2e:99:df:ec:47",
                "ip-address": "10.106.0.15",
                "next-server": "0.0.0.0",
                "option-data": [],
                "server-hostname": ""
              },
```
Verified node booted using the default file name.
```
2024-06-05 12:39:36 >>Start PXE over IPv4 on MAC: B4-2E-99-DF-EC-47. Press ESC key to abort PXE boot.
2024-06-05 12:39:43   Station IP address is 10.106.0.15
2024-06-05 12:39:43
2024-06-05 12:39:43   Server IP address is 10.92.100.60
2024-06-05 12:39:43   NBP filename is ipxe.efi
2024-06-05 12:39:43   NBP filesize is 1045824 Bytes
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

