### PR TITLE
CASMCMS-9019/CASMCMS-9020/CASMCMS-9022: BOS: Resolve CVEs, fix minor API spec errors

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.19.0
+    version: 2.20.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.19.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.20.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.6

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.18.2
+    version: 2.19.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.18.2/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.19.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.19.6

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.19.0-1.noarch
+    - bos-reporter-2.20.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.18.2-1.noarch
+    - bos-reporter-2.19.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch


### PR DESCRIPTION
This updates a couple of BOS dependencies in order to resolve the following two CVEs:
* https://snyk.io/vuln/SNYK-PYTHON-CERTIFI-5805047 (CASMCMS-9019)
* https://snyk.io/vuln/SNYK-PYTHON-FLASK-5490129 (CASMCMS-9020)

And also corrects some small errors in the BOS API spec (CASMCMS-9022).

The API spec fix has a backport for CSM 1.5.2: https://github.com/Cray-HPE/csm/pull/3457
