### PR TITLE
CASMPET-7020 Investigate duplicates cray-capmc

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -53,9 +53,6 @@ artifactory.algol60.net/csm-docker/stable:
     cf-gitea-import:
       - 1.10.0
 
-    cray-capmc:
-      - 2.7.0
-
     # Utility to help make changes for adding river cabinets
     hardware-topology-assistant:
     - 0.2.0

--- a/helm/index.yaml
+++ b/helm/index.yaml
@@ -1,3 +1,5 @@
+# NOT IN USE - use lofstman manifest files under ../manifests instead.
+#
 # Packaging index for Helm charts not listed in Loftsman manifests. Format is:
 #
 #   <repo>:
@@ -6,14 +8,3 @@
 #       - <version>
 #       - ...
 #
-# The ../release.sh script uses ../hack/gen-helm-index.sh to parse Helm charts
-# specified in all Loftsman manifests under ../manifests and update this file.
-# Therefore there is no need to list charts in this index that are already
-# specified in a Loftsman manifest.
-
-artifactory.algol60.net/csm-helm-charts/stable:
-  charts:
-    cray-hms-capmc:
-      - 3.0.8
-    cray-dhcp-kea:
-      - 0.10.25


### PR DESCRIPTION
## Summary and Scope

Remove outdated and unused image `artifactory.algol60.net/csm-docker/stable/cray-capmc:2.7.0` from `docker/index.yaml`. Chart which uses this image was added to `helm/index.yaml` - this file is not being processed for a long time, so the chart was not shipped anyway. Also cleanup `helm/index.yaml`.

## Issues and Related PRs

* Resolves CASMPET-7020

## Testing
### Tested on:

  * Jenkins build

### Test description:

Will test install/upgrade procedure ob vShasta upon build completion.

## Risks and Mitigations

None known.
