### PR TITLE
CASMHMS-6219: Re-discover Power data in the system endpoint when the node power on event is received 

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.12
+    version: 7.1.13
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

It is expected behavior on the Foxconn Paradise platform that when a node is discovered when the node power is off, the discover process will not collect the information necessary for power capping.  This is because the /Power endpoint is unavailable on the BMC until after the node is actually powered on.  With support for power events in BMC fw 1.15 and 1.16, we expected that the minimal discover process that runs in response to receiving a node power on event would now collect this information.  However, this does not actually occur because the node on discover process is minimal and does not rescan the chassis that contains the /Power endpoint.  The following functional changes were necessary to support this:

- Scan the ProcessorModule_0 chassis after receiving a node on event to collect the URL of the /Power endpoint
- Read the /Power endpoint to collect the necessary power cap information
- It was observed that the /Power endpoint is not available immediately after a node powers on.  The BMC firmware will not return data for it for a period of time after power is applied, after we receive the node on event.  The function that reads redfish endpoints (GETRelative) retries up to 3 times.  The information was returned within 3 retries only about 90% of the time so the GETRelative() function had to be modified to support an option retry argument so that we could ask it to retry a 4the time in this particular case.  If the 4th retries fails (which has never been observed), then the discover will continue without retrieving the necessary power cap information.  A manual discover should be able to work around this if it ever occurs.
- The retry logging in GETRelative() was updated to be more informative
- Now that the power cap information was correctly collected during system discovery, the system cep needs to be pushed to the db.  FoxconnAlertSystemPowerOnParser() was modified to call a new go function that, in addition to calling s.doUpdateCompHWInv(), also pushes the collected data to the db by first calling s.DiscoverCompEndpointSystem() and then calling s.db.UpsertCompEndpoints()
- The logging in doHandleEvent() was updated to indicate the update type

Adopted app version 2.25.0 for CSM 1.6 (helm chart 7.1.13)

## Issues and Related PRs

* Resolves [CASMHMS-6219](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6219)

## Testing

Tested on:

  * tyr

Test description:

Ran discover multiple times with power on and with power off.  After running discover with power off, PowerURL and PowerControl disappear from the node's component endpoint (as expected with current BMC behavior).  I then powered the node on, confirmed reception of the node on event, and watched an instrumented smd correctly discover the PowerURL and PowerControl data.  Doubly confirmed by looking at 'cray hsm inventory componentEndpoints describe x3000c0s33b1n0' that they did indeed get discovered correctly.  Also confirmed that no other endpoint data appeared corrupt.

I only tested Foxconn Paradise as all code that has functional changes of any significance are constrained to that hardware platform.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
