### PR TITLE
CASMPET-7093 Adjust image extraction to cover cray-service/pgbouncer

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -94,7 +94,8 @@ function extract-images() {
 
     ## Second: attempt to extract images from fully templated manifests (avoiding CRDs)
 
-    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition") | .. | .image? | select(.)' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
+    # cray-service chart refers to postgresql.connectionPooler image as .dockerImage
+    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition") | .. | (.image?, .dockerImage?) | select(.)' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
 
     images="$(cat "$IMAGE_LIST_FILE" | sort -u | xargs)"
 


### PR DESCRIPTION
## Summary and Scope

It appears image `pgbouncer:master-21`, removed with CASMPET-7010, is still used by `spire` and `cray-spire` charts. The reason why it's not detected automatically by csm build is:

* It's coming from cray-service dependency, not directly from spire/cray-spire chart - this is why annotation properly set on cray-service chart is not being used.
* In helm template, it's set into custom "posgresql" resource, not into one of k8s standard resources, which is using non standard field "dockerImage" instead of just "image": 

      apiVersion: "acid.zalan.do/v1"
      kind: postgresql
      ...
      spec:
      ...
        enableConnectionPooler: true
        connectionPooler:
          numberOfInstances: 3
          mode: "session"
          dockerImage: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21" 

Instead of referring image explicitly in `docker/index.yaml`, we adjust image extraction logic to look not only `image:` field in output of `helm template`, but also `dockerImage:`. This way image introcued by cray-service chart is detected.

## Issues and Related PRs

* Resolves CASMPET-7093

## Testing
### Tested on:

  * Local development environment

### Test description:

After `make validate-images` local run, image `pgbouncer:master-21` is successfully recorded along with `pgbouncer:master-22`:

    $ grep pgbouncer build/images/chartmap.csv
    platform,csm-algol60/cray-postgres-operator:1.8.5,artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-22
    sysmgmt,csm-algol60/cray-spire:1.6.1,artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
    sysmgmt,csm-algol60/spire:2.15.1,artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21