### PR TITLE
CASMCMS-9027: Resolve CVEs in console-node

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -166,7 +166,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.2.0
+    version: 2.2.1
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
This resolves three CVEs in `console-node`:
* [CVE-2021-43565](https://github.com/advisories/GHSA-gwc9-m7rh-j2ww)
* [CVE-2022-27191](https://github.com/advisories/GHSA-8c26-wmh5-6g9v)
* [CVE-2023-48795](https://github.com/advisories/GHSA-45x7-px36-x8w8)

Backports:
* 1.5.2: https://github.com/Cray-HPE/csm/pull/3465
* 1.4.5: https://github.com/Cray-HPE/csm/pull/3466