### PR TITLE
CASMUSER-3330: Remove UAS/UAI from CSM 1.6

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -30,12 +30,6 @@ artifactory.algol60.net/csm-docker/stable:
     cray-sat:
       - 3.27.9
 
-    # XXX update-uas v1.4.0 should include these
-    cray-uai-sles15sp3:
-      - 1.4.0
-    cray-uai-broker:
-      - 1.4.0
-
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
       - 2.6.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -249,22 +249,6 @@ spec:
     version: 2.1.0
     namespace: services
 
-  # Cray UAS Manager service
-  - name: cray-uas-mgr
-    source: csm-algol60
-    version: 1.23.1
-    namespace: services
-    timeout: 10m
-    swagger:
-    - name: uas-mgr
-      version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/uas-mgr/v1.23.1/api/swagger.yaml
-
-  - name: update-uas
-    source: csm-algol60
-    version: 1.8.1
-    namespace: services
-
   # Spire service
   - name: spire
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR removes UAS and UAI from CSM for CSM 1.6. The UAI functionality has moved to USS.

## Issues and Related PRs

* Resolves [CASMUSER-3330](https://jira-pro.it.hpe.com:8443/browse/CASMUSER-3330)