### PR TITLE
CASMPET-6797/CASMPET-6980: Ansible play to provision LIO services on worker nodes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.20.0
+    version: 1.21.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
This new "csm-config" version consists of the changes (CFS plays) part of new iSCSI based boot content projection solution (replacing existing DVS solution) in order to boot compute nodes. These CFS plays are deployed as part of worker node personalization by user/ admin post NCN install/ config.

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6797
* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6980
* https://github.com/Cray-HPE/csm-config/pull/232

## Testing
Worker nodes personalization verification w.r.t this iSCSI based boot content projection solution is done on **Odin** cluster with 3 master and 6 worker nodes.

### Tested on:

  Odin

### Test description:
Verified these CFS plays of iSCSI based boot content projection solution 1) via standard ansible way using "ansible-playbook" with source being local on the cluster including the host inventory file 2) via CFS way with CFS session/ CFS config with branch being posted to VCS (Gitea). 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? **Not applicable at this point of time.**
- Was downgrade tested? If not, why? **Not applicable at this point of time.**
- Were new tests (or test issues/Jiras) created for this change? **UT done and there are integration tests that are planned for execution next which need the dependency images to be part of CSM 1.6 NCN image**

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable