### PR TITLE
CASMNET-2223 - cray-dns-unbound: UID insonsistency between chart and image

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.26 # update platform.yaml cray-precache-images with this
+    version: 0.7.27 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.26
+        appVersion: 0.7.27
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.26
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.27
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

The Alpine rolling release added a klogd user which caused the uid and gid used by their unbound package to get bumped up by one.

Updated Helm chart to address this and pulled in CSM 1.6 version of the cray-service chart.

## Issues and Related PRs

* Resolves [CASMNET-2223](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2223)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * `surtur`
  * Local development environment
  * Virtual Shasta

### Test description:

Verified service installs and DNS now functions correctly.
```
ncn-m001:~ # host registry.local 10.92.100.225
Using domain server:
Name: 10.92.100.225
Address: 10.92.100.225#53
Aliases:

registry.local has address 10.92.100.71
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

