### PR TITLE
CRAYSAT-1868: Backport firmware improvements

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.10
+      - 3.21.11
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.10"
+sat_version="3.21.11"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

_This will Backport cray-sat: 3.28.4_

- Polling the snapshot in `sat firmware` resulted in HTTP errors in large clusters.
  Hence, adding the retry option when it consecutively fails for up to 5 times.
- Remove expiration time and add `--delete-snapshot` option to prompt the user to delete the snapshot
  if it is no longer needed. By default, log a message referring the user how to delete the snapshot.

## Issues and Related PRs

_Resolves [CRAYSAT-1193](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1193)._

## Testing

_List the environments in which these changes were tested._

### Tested on:

 Odin

### Test description:

_Test by creating a new snapshot using `sat firmware` command_
_Test by deleting the snapshot using `sat firmware --delete-snapshot <snapshote-name>`_

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

