### PR TITLE
CASMTRIAGE-7063: cray-sysmgmt-health chart install failure

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -168,7 +168,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.26.29
+    version: 0.26.30
     namespace: sysmgmt-health
     values:
       prometheus-operator:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7063