### PR TITLE
CASMTRIAGE-7079: Paradise: Fixed functional hardware test to pass processor types of "FPGA"

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.13
+    version: 7.1.14
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Hardare tavern test was failing when run against Paradise.  Paradise includes a new processor type "FPGA" that was not expected by the test.  The change here is to add "FPGA" as a valid processor type.  This was not hit previously because the tavern tests do not test against each node type on a system.  Node selection is random, and we got unlucky that no Paradise node had been previously chosen.

Adopted app version 2.11.15 for CSM 1.5.2 (helm chart 7.0.19)
Adopted app version 2.26.0 for CSM 1.6 (helm chart 7.1.14)

## Issues and Related PRs

* Resolves [CASMTRIAGE-7079](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7079)
* Change will also be needed in `master` (ie. 1.6)

## Testing

Tested on:

  * `tyr`

Test description:

Made a temporary change to the test_hardware.tavern.yaml file:

` -      url: "{hsm_base_url}/hsm/v2/State/Components?type=Node"`
` +      url: "{hsm_base_url}/hsm/v2/State/Components?type=Node&id=x3000c0s33b2n0"`

This ensured the test was run against a Paradise node.  The test then passed.  I removed this code change before making the final PR.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable