### PR TITLE
CASMINST-6895 Support new DST key for build time signature validation

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -74,3 +74,4 @@ for arch in "${CN_ARCH[@]}"; do
 done
 
 HPE_SIGNING_KEY=https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key.asc
+HPE_SIGNING_KEY_FIPS=https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key-fips.asc

--- a/hack/rpms.sh
+++ b/hack/rpms.sh
@@ -27,7 +27,7 @@ function rpm-sync() {
             -v "$(realpath "${destdir}"):/data" \
             -v "$(realpath "${BUILDDIR}/security/"):/keys" \
             "${PACKAGING_TOOLS_IMAGE}" \
-            rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -n 1 -s -v -k /keys/hpe-signing-key.asc -d /data /index.yaml
+            rpm-sync ${REPO_CREDS_RPMSYNC_OPTIONS} -n 1 -s -v -k /keys/hpe-signing-key.asc -k /keys/hpe-signing-key-fips.asc -d /data /index.yaml
     fi
 }
 
@@ -75,10 +75,17 @@ function createrepo() {
         createrepo --verbose /data
 }
 
-if [ "${VALIDATE}" != "1" ] && ! [ -f "${BUILDDIR}/security/hpe-signing-key.asc" ]; then
-    echo "Downloading HPE signing key"
-    mkdir -p "${BUILDDIR}/security"
-    acurl -Ss -o "${BUILDDIR}/security/hpe-signing-key.asc" "${HPE_SIGNING_KEY}"
+if [ "${VALIDATE}" != "1" ]; then
+    if ! [ -f "${BUILDDIR}/security/hpe-signing-key.asc" ]; then
+        echo "Downloading HPE signing key"
+        mkdir -p "${BUILDDIR}/security"
+        acurl -Ss -o "${BUILDDIR}/security/hpe-signing-key.asc" "${HPE_SIGNING_KEY}"
+    fi
+    if ! [ -f "${BUILDDIR}/security/hpe-signing-key-fips.asc" ]; then
+        echo "Downloading new HPE signing key"
+        mkdir -p "${BUILDDIR}/security"
+        acurl -Ss -o "${BUILDDIR}/security/hpe-signing-key-fips.asc" "${HPE_SIGNING_KEY_FIPS}"
+    fi
 fi
 
 rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp2"


### PR DESCRIPTION
## Summary and Scope

A new `sma-cli-utils` RPM signed with new DST key was proposed with https://github.com/Cray-HPE/csm/pull/3473. For this RPM to pass signature verification stage, we need to add new GPG key to RPM download/verification procedure.

## Issues and Related PRs

* Resolves CASMINST-6895

## Testing
### Tested on:

  * Local development environment

### Test description:

Ran `hack/rpms.sh --download` locally, ensured that new key is added and signature verification for new RPM is passing.

## Risks and Mitigations
Low - new file and build time change only.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

