### PR TITLE
CASMCMS-9029: TESTS: cmsdev: Improve handling of credentials

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.7.0-1.noarch
-    - cray-cmstools-crayctldeploy-1.21.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.22.0-1.x86_64
     - cray-site-init-1.33.1-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch


### PR DESCRIPTION
The `cmsdev` test tool had some poor handling of credentials, which this corrects.

Backports:
CSM 1.5.3: https://github.com/Cray-HPE/csm/pull/3483
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3484