### PR TITLE
CASMPET-6936 Updating the kafka chart versions holding kafka upgrade …

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -181,7 +181,7 @@ spec:
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 1.1.0
+    version: 1.2.0
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
@@ -209,7 +209,7 @@ spec:
     namespace: services
   - name: cray-shared-kafka
     source: csm-algol60
-    version: 1.0.0
+    version: 1.1.0
     namespace: services
   - name: cray-sts
     source: csm-algol60


### PR DESCRIPTION
…to 0.41.0

## Summary and Scope

Upgrading strimzi kafka to 0.41.0. 

## Issues and Related PRs

* Resolves [CASMPET-6936](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6936)

### Tested on:

  *craystack VM
  *Virtual Shasta - Beau
  *Starlord

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

