### PR TITLE
CASMPET-7113: Update Spire charts for dvs-mqtt xname filtering issue

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -252,11 +252,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.15.1
+    version: 2.15.2
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.1
+    version: 1.6.2
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

Fixes a missed keyword in the workload definition in the new dvs mqtt workload. This lead to spire having two workloads on xname enabled systems one non xname and one with xnames. This lead to the token received first to be the non xname enabled token which failed in the validation on the mqtt broker.

## Issues and Related PRs


* Resolves [CASMPET-7113](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7113)

## Testing

### Tested on:

  *  lemondrop

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No risks only added needed keyword for xname validation.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

