### PR TITLE
Add IMS tagging Support

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,7 +180,7 @@ spec:
             tag: 2.5.1
   - name: cray-ims
     source: csm-algol60
-    version: 3.15.0
+    version: 3.16.0
     namespace: services
     swagger:
     - name: ims

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,7 +180,7 @@ spec:
             tag: 2.5.1
   - name: cray-ims
     source: csm-algol60
-    version: 3.16.0
+    version: 3.16.1
     namespace: services
     swagger:
     - name: ims

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -35,8 +35,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.33.1-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
-    - craycli-0.83.3-1.aarch64
-    - craycli-0.83.3-1.x86_64
+    - craycli-0.83.4-1.aarch64
+    - craycli-0.83.4-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.6-1.aarch64
     - csm-node-heartbeat-2.6-1.x86_64


### PR DESCRIPTION
## Summary and Scope

This is a set of changes for the IMS image tagging feature, which is going to be used by iSCSI rootfs projection, and perhaps other features that need to create user specified dynamic information associated with an image.

## Issues and Related PRs
* Resolves [CASMCMS-8915](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8915)
* Resolves [CASMCMS-8833](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8833)


## Testing

### Test description:

New unit tests were added to the IMS API in order to set and remove user supplied information as it pertains to images. The assocaited IMS docker image was built out and installed on dev systems, and the CLI changes were installed alongside them. For an integration test, I was able to create a new image, decorate it with random new metadata tags, display those tags individually on the image and on the list of images, and also remove the image information.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

