### PR TITLE
CASMNET-2223 - Pin unbound and prometheus uid/gid so Alpine Linux changes can't move them causing issues with the pod security context

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.27 # update platform.yaml cray-precache-images with this
+    version: 0.7.28 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.27
+        appVersion: 0.7.28
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.27
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.28
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

Alpine Linux added a klogd user recently which caused the unbound uid and gid to be shuffled up by one causing the pod to fail to start because the security context expects a certain uid and gid.

This PR pins the uid and gid for the `unbound` and `prometheus` users so upstream changes in Alpine Linux won't cause them to change.

## Issues and Related PRs

* Resolves [CASMNET-2223](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2223)

## Testing

### Tested on:

  * `mug`

### Test description:

Deployed new image and chart, deployed unbound and the prometheus-exporter started as expected.
```
mug-pit:~ # kubectl -n services logs cray-dns-unbound-5fbd455b5f-fmzrc -c cray-dns-unbound
+ sleep 5
+ true
+ /srv/unbound/initialize.py
2024-Jun-28 03:28

Unbound PID not detected.  Starting unbound
Starting check for updates to DNS records
ID for loaded data
ID for mounted data	..2024_06_28_03_28_05.223131801

Difference in IDs between mounted and loaded data detected

Copying data from mounted folder to Unbound config folder.
Processing data.
Reading A records JSON file at /etc/unbound/records.json.gz and translating to /etc/unbound/records.conf
Processing data completed.

Warm reload of Unbound started
Warm reload of unbound to update configurations
Unbound pid is: 12
Warm reload of Unbound completed.

Total time taken to run (0.016642s)

Completed check for updates to DNS records

[1719545296] unbound[12:0] warning: unable to initgroups unbound: Operation not permitted
+ sleep 90
[1719545296] unbound[12:0] info: start of service (unbound 1.20.0).
[1719545296] unbound[12:0] info: service stopped (unbound 1.20.0).
[1719545297] unbound[12:0] info: start of service (unbound 1.20.0).

mug-pit:~ # kubectl -n services logs cray-dns-unbound-5fbd455b5f-fmzrc -c unbound-exporter
level=info ts=2024-06-28T03:28:12.001Z caller=unbound_exporter.go:480 Startingunbound_exporter=(MISSING)
level=info ts=2024-06-28T03:28:12.001Z caller=unbound_exporter.go:498 Listeningonaddress:port>=:9167
```

Verified uid and gid were as expected
```
mug-pit:~ # kubectl -n services exec -it cray-dns-unbound-5fbd455b5f-fmzrc -c cray-dns-unbound -- id unbound
uid=1001(unbound) gid=1001(unbound) groups=1001(unbound),1001(unbound)

mug-pit:~ # kubectl -n services exec -it cray-dns-unbound-5fbd455b5f-fmzrc -c cray-dns-unbound -- ps
PID   USER     TIME  COMMAND
    1 unbound   0:00 {entrypoint.sh} /bin/bash /srv/unbound/entrypoint.sh
   12 unbound   0:00 unbound -c /etc/unbound/unbound.conf
  466 unbound   0:00 sleep 90
  852 unbound   0:00 ps

mug-pit:~ # kubectl -n services exec -it cray-dns-unbound-5fbd455b5f-fmzrc -c unbound-exporter -- id prometheus
uid=1002(prometheus) gid=1002(prometheus) groups=1002(prometheus),1002(prometheus)
mug-pit:~ # kubectl -n services exec -it cray-dns-unbound-5fbd455b5f-fmzrc -c unbound-exporter -- ps
PID   USER     TIME  COMMAND
    1 promethe  0:02 /usr/bin/unbound_exporter
   39 promethe  0:00 ps
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

