### PR TITLE
CASMCMS-9005/CASMCMS-9006/CASMCMS-9030: Update cray-services base chart version for cfs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,11 +120,11 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.12.0
+    version: 1.12.1
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.20.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.19.6
+    version: 1.19.7
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.6/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.7/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.10.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
-    - cfs-trust-1.7.0-1.noarch
+    - cfs-trust-1.7.1-1.noarch
     - cray-cmstools-crayctldeploy-1.22.0-1.x86_64
     - cray-site-init-1.33.1-1.x86_64
     - cray-uai-util-2.2.1-1.noarch


### PR DESCRIPTION
This updates the version of the cray-services base chart used by CFS, cfs-trust, and cfs-hwsync-agent.

There are no backports -- this is CSM 1.6 only.