### PR TITLE
CASMCMS-9011: Update gitea to use newer cray-keycloak-setup image

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -234,11 +234,8 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.6.3
+    version: 2.7.0
     namespace: services
-    values:
-      keycloakImage:
-        tag: 3.6.1
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
The gitea chart has been updated to use the newer keycloak version.

CSM 1.5.3 backport: https://github.com/Cray-HPE/csm/pull/3496