### PR TITLE
CASMCMS-9011: Update gitea to use newer cray-keycloak-setup image

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -213,11 +213,8 @@ spec:
     namespace: services
   - name: gitea
     source: csm-algol60
-    version: 2.6.3
+    version: 2.6.4
     namespace: services
-    values:
-      keycloakImage:
-        tag: 3.6.1
 
   # Cray Product Catalog
   - name: cray-product-catalog


### PR DESCRIPTION
CSM 1.5.3 backport of https://github.com/Cray-HPE/csm/pull/3495