### PR TITLE
CASMCMS-9023: Remove superfluous cray-product-catalog Docker images

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -184,11 +184,8 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Images needed by IUF and possibly non-CSM products
     cray-product-catalog-update:
-      - 1.3.1
-      - 1.3.2
-      - 1.8.8
-      - 1.8.12
       - 1.9.0
+
     cray-nexus-setup:
       - 0.10.1
 


### PR DESCRIPTION
Not exactly a backport, but there is a PR to fix the same issue in CSM 1.6:
https://github.com/Cray-HPE/csm/pull/3500