### PR TITLE
CASMCMS-9023: Update Cray Product Catalog version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -206,7 +206,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.1.0
+            tag: 2.1.1
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -246,7 +246,7 @@ spec:
     # Unless there is a specific reason not to, this version should be
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
-    version: 2.1.0
+    version: 2.1.1
     namespace: services
 
   # Spire service


### PR DESCRIPTION
Not exactly a backport of https://github.com/Cray-HPE/csm/pull/3499, but fixing the same issue in CSM 1.6