### PR TITLE
CRAYSAT-1866, CRAYSAT-1871: Update cray-sat version in CSM 1.4

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -25,7 +25,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.21.11
+      - 3.21.12
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.21.11"
+sat_version="3.21.12"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

Backport the following changes to CSM 1.4:

* https://github.com/Cray-HPE/sat/pull/221
* https://github.com/Cray-HPE/sat/pull/228

## Issues and Related PRs

* Resolves CRAYSAT-1866
* Resolves CRAYSAT-1871

## Testing

See linked PRs above.

## Risks and Mitigations

See linked PRs above.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
