### PR TITLE
CASMPET-6904 upgrade certmanager and certmanager-issuers

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -121,7 +121,7 @@ spec:
     namespace: istio-system
   - name: cray-certmanager
     source: csm-algol60
-    version: 0.7.3
+    version: 0.8.1
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
@@ -145,7 +145,7 @@ spec:
     namespace: ceph-rgw
   - name: cray-certmanager-issuers
     source: csm-algol60
-    version: 0.6.3
+    version: 0.7.1
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Cert-manager is upgraded to 1.12.9 in CSM 1.6. This PR updates the cray-certmanager and cray-certmanager-issuers charts for this upgrade. 

## Issues and Related PRs

* Resolves [CASMPET-6904](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6904)

## Testing

This has been tested on Vshasta upgrades and fresh installs.
This has also been tested on Mercury running k8s 1.24 which will also be going into CSM 1.6.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

