### PR TITLE
CASMPET-7078 update CSM with chart changes for k8s 1.24

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -213,7 +213,7 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.8.1
+    version: 0.8.2
     namespace: services
     swagger:
     - name: sts

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -109,7 +109,7 @@ spec:
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60
-    version: 1.9.0
+    version: 1.10.0
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.29.4
+    version: 0.30.0
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:
@@ -233,7 +233,7 @@ spec:
     namespace: services
   - name: cray-metallb
     source: csm-algol60
-    version: 1.1.1
+    version: 1.2.0
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
@@ -249,11 +249,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.12
+    version: 4.0.13
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.12
+    version: 4.0.13
     namespace: argo
     swagger:
     - name: nls
@@ -267,5 +267,5 @@ spec:
     timeout: 10m0s
   - name: cray-k8s-encryption
     source: csm-algol60
-    version: 0.0.4
+    version: 0.1.0
     namespace: kube-system

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -249,11 +249,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.15.2
+    version: 2.15.3
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.2
+    version: 1.6.3
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This PR updates CSM with many changes needed for K8s 1.24.
Most chart changes involve adding a k8s toleration for k8s control-plane nodes. Charts with these changes are listed below:

- cray-nls: 4.0.13
- cray-iuf: 4.0.13
- cray-k8s-encryption: 0.1.0
- cray-node-problem-detector: 1.10.0
- cray-sysmgmt-health: 0.30.0
- cray-metallb: 1.2.0
- spire: 2.15.3
- cray-spire: 1.6.3

One chart change involved picking up the latest cray-service chart which has the docker-kubectl container version 1.24.17. This chart change was
- cray-sts: 0.8.2

## Issues and Related PRs

* Resolves [CASMPET-7078](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7078)
* Resolves [CASMPET-7080](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7080)
* Resolves [CASMPET-7084](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7084)
* Resolves [CASMPET-7085](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7085)
* Resolves [CASMPET-7086](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7086)
* Resolves [CASMPET-7081](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7081)
* Resolves [CASMPET-7082](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7082)
* Resolves [CASMPET-7063](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7063)



## Testing

All charts except cray-sts were deployed on a vshasta system.
Cray-sts was deployed manually on Beau.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

