### PR TITLE
CRAYSAT-1881: Update cray-sat container image to 3.28.11

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.28.10
+      - 3.28.11
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_This will Backport cray-sat 3.28.11_

## Issues and Related PRs

[CRAYSAT-1881](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1881)[: Bump certifi from 2023.7.22 to 2024.7.4](https://github.com/Cray-HPE/sat/commit/bde61a3a72c69368e2f31bdd75e393a1c970c780)

## Testing

See the above PR

## Risks and Mitigations

_See the above PR_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

