### PR TITLE
CASMMON-411: Conversion to victoria-metrics broke metallb deployment

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,7 +51,7 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.28 # update platform.yaml cray-precache-images with this
+    version: 0.8.0 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
@@ -60,7 +60,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.3.1 # update platform.yaml cray-precache-images with this
+    version: 0.4.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,8 +69,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.28
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
@@ -233,7 +233,7 @@ spec:
     namespace: services
   - name: cray-metallb
     source: csm-algol60
-    version: 1.2.0
+    version: 1.2.1
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -249,11 +249,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.15.3
+    version: 2.15.4
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.3
+    version: 1.6.4
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Prometheus migration to victoria-metrics in CSM 1.6
Changes in the following CRDs dependent charts:

cray-dns-unbound 
cray-dns-powerdns
cray-spire
spire
cray-metallb 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMMON-411
