### PR TITLE
Updated etcd-base chart and cray-service chart in hms services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cloud-init.json
 *.log
 *.pyc
 *.code-workspace
+*.swp

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,12 +12,12 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 5.1.5
+    version: 5.1.6
     namespace: services
     swagger:
     - name: sls
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.4.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.2.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
     version: 7.1.14

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.2.0
+    version: 3.2.1
     namespace: services
     timeout: 10m
     swagger:
@@ -45,15 +45,15 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.26.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 4.0.3
+    version: 4.1.0
     namespace: services
     swagger:
     - name: capmc
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.4.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.4
+    version: 3.1.5
     namespace: services
     swagger:
     - name: firmware-action
@@ -61,7 +61,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.33.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: services
     timeout: 10m
     swagger:
@@ -70,7 +70,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.20.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 4.0.2
+    version: 4.0.3
     namespace: services
     timeout: 10m
     swagger:
@@ -105,13 +105,13 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.1.6
+    version: 2.1.7
     namespace: services
     timeout: 10m
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.3.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.4.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
## Summary and Scope

Updated to version 1.2.0 of the cray-etcd-base chart and version 10.0.6 of the cray-service chart.

## Issues and Related PRs

* Resolves [CASMHMS-6232](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6232)
* Resolves [CASMHMS-6234](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6234)

## Testing

### Tested on:

  * starlord

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

