### PR TITLE
CASMMON-415 Conversion to victoria-metrics broke spire chart

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,7 +51,7 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.8.0 # update platform.yaml cray-precache-images with this
+    version: 0.8.1 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
@@ -60,7 +60,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.4.0 # update platform.yaml cray-precache-images with this
+    version: 0.4.1 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,8 +69,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 0.30.2
+    version: 1.0.0
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:
@@ -233,7 +233,7 @@ spec:
     namespace: services
   - name: cray-metallb
     source: csm-algol60
-    version: 1.2.1
+    version: 1.2.2
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -249,11 +249,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.15.4
+    version: 2.15.5
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.4
+    version: 1.6.5
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope
Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?

Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?

Prometheus migration to victoria-metrics in CSM 1.6
Changes in the following CRDs dependent charts:

cray-dns-unbound
cray-dns-powerdns
cray-spire
spire
cray-metallb
## Issues and Related PRs
[
_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

](https://jira-pro.it.hpe.com:8443/browse/CASMMON-415)