### PR TITLE
CASMTRIAGE-6934: CSM IUF fails to restart management-nodes-rollout stage with key error after pre-hook failed

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -50,7 +50,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.13-1.x86_64
+    - iuf-cli-1.6.14-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.6-1.x86_64
     - metal-init-1.4.10-1.noarch


### PR DESCRIPTION
## Summary and Scope

updating iuf-cli version to 1.6.14

## Issues and Related PRs

* Resolves [CASMTRIAGE-6934](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6934) , [CASM-4729](https://jira-pro.it.hpe.com:8443/browse/CASM-4729)
* https://github.com/Cray-HPE/iuf-cli/pull/184

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

