### PR TITLE
CASMHMS-6233: Paradise: Adapted SMD to BMC fw changing the behavior of the /Power endpoint read over redfish

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.19
+    version: 7.0.20
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

In BMC fw 1.17, Foxconn changed the behavior associated with reading the /Power endpoint in the ProcessorModule_0 chassis over redfish.  In previous versions, the read just failed and returned no data when the data was not yet available (ie. when node power was off, or shortly after when node power was turned on).  SMD was coded to retry until the read succeeded, up to four times.  When it did finally succeed, the data returned was always correct as BMC fw did not allow it to be read until the data was available.  With BMC fw v1.17, the /Power endpoint no longer returns an error when the data is not available (again, when node power is off or shortly after it is turned on).  If the data is not yet available on the BMC,  the BMC fw simply returns zero or nil for it.  This means that the mini-discover that is run after receiving a node power on event will not read the data needed for power capping.

The change in this PR looks at the data returned by the read and retries the read up to 4 times if it is zero or nil.  It sleeps for 10, 20, 40, and 80 seconds before the next retry.  These values were determined empirically, balancing sleep time while ensuring we eventually do read the data.  Another goto statement was used to avoid significant refactoring of the code.

There were also a lot of updates to code comments to reflect the new behavior associated with this redfish endpoint.

Adopted app version 2.11.16 for CSM 1.5.3 (helm chart 7.0.20)

## Issues and Related PRs

* Resolves [CASMHMS-6233](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6233)

## Testing

Tested on:

  * tyr

Test description:

Test cases:

- Manual discover against Paradise BMC with node power on
- Manual discover against Paradise BMC with node power off
- Manual discover against non-Paradice BMC with node power on
- Many auto mini-discovers of Paradise BMC after receiving node power on event
- Verified that all smoke and functional smd tests still pass by executing `run_hms_ct_tests.sh`

Test checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

