### PR TITLE
CRAYSAT-1859: Update cray-sat version to 3.28.12

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.28.11
+      - 3.28.12
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION


## Summary and Scope

This includes the fix for CRAYSAT-1859, a minor bug in `sat bootsys` in how it handles failed BOS sessions.

## Issues and Related PRs

* Resolves CRAYSAT-1859

## Testing

### Tested on:

  * rocket

### Test description:

See Cray-HPE/sat#241

## Risks and Mitigations

Low risk change. See Cray-HPE/sat#241


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable