### PR TITLE
CASMPET-7142 tpm-provisioner-client RPM is not istallable on SLES15-SP5

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -62,8 +62,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
-    - tpm-provisioner-client-1.0.1-2.x86_64
-    - tpm-provisioner-client-1.0.1-2.aarch64
+    - tpm-provisioner-client-1.0.1-3.x86_64
+    - tpm-provisioner-client-1.0.1-3.aarch64
     - sbps-marshal-0.0.5-1.noarch
 
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/noos/:


### PR DESCRIPTION
## Summary and Scope

tpm-provisioner-client RPM is produced using rolling tag of artifactory.algol60.net/csm-docker/stable/csm-docker-sle:latest container image. This image is currently based on SLES15-SP6. As a result, produced RPM requires glibc 2.34 and is not installable on SLES15-SP5 which comes with glibc 2.31.


## Issues and Related PRs

* Resolves CASMPET-7142

