### PR TITLE
CASMCMS-9052/CASMTRIAGE-7147: BOS fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.20
+    version: 2.10.22
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.20/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.22/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.6

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.10.20-1.noarch
+    - bos-reporter-2.10.22-1.noarch
     - cani-0.3.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch
@@ -36,8 +36,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
     - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
-    - craycli-0.82.15-1.aarch64
-    - craycli-0.82.15-1.x86_64
+    - craycli-0.82.16-1.aarch64
+    - craycli-0.82.16-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.6-1.aarch64
     - csm-node-heartbeat-2.6-1.x86_64


### PR DESCRIPTION
Fixes for the following BOS issues:
[CASMCMS-9052](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9052) - Prevent BOS state reporter hangs
[CASMTRIAGE-7147](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7147) - Workaround PCS scale errors by breaking up outgoing API requests from BOS