### PR TITLE
CASMTRIAGE-7163/CASMCMS-9055/CASMCMS-9058/CASMCMS-9060: CFS fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,19 +141,19 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.20.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.19.7
+    version: 1.20.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.19.7/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.20.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.10.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.25.0
+    version: 1.26.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.26.0
+    version: 1.26.1
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
Fixes for:
* [CASMTRIAGE-7163](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7163): Configured CFS session TTL isn't honored by CFS Kubernetes job
* [CASMCMS-9055](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9055): Validate age/TTL parameters in CFS API
* [CASMCMS-9058](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9058): Resolve CVEs in cfs-operator
* [CASMCMS-9060](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9060): Resolve CVEs in cray-aee