### PR TITLE
CASMTRIAGE-7163/CASMCMS-9055: CFS fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -146,14 +146,16 @@ spec:
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.6/api/openapi.yaml
+      # Following URL is one patch version ahead of the service version because it only contains informational
+      # changes to the API spec
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.7/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.2
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.22.3
+    version: 1.22.4
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
* [CASMTRIAGE-7163](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7163): Configured CFS session TTL isn't honored by CFS Kubernetes job
* [CASMCMS-9055](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9055): Update URL for API spec
