### PR TITLE
CASMCMS-9055: Update URL for CFS API doc generation

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -146,7 +146,9 @@ spec:
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.6/api/openapi.yaml
+      # Following URL is one patch version ahead of the service version because it only contains informational
+      # changes to the API spec
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.7/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.2


### PR DESCRIPTION
This makes no changes to the build itself -- it only updates the URL for the CFS API doc generation.