### PR TITLE
CASMTRIAGE-7163/CASMCMS-9055: CFS fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -173,14 +173,16 @@ spec:
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.9/api/openapi.yaml
+      # Following URL is one patch version ahead of the service version because it only contains informational
+      # changes to the API spec
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.10/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.8.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.17.3
+    version: 1.17.4
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
* [CASMTRIAGE-7163](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7163): Configured CFS session TTL isn't honored by CFS Kubernetes job
* [CASMCMS-9055](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9055): Update URL for API spec
