### PR TITLE
cray-sysmgmt-health chart version upgrade

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.0
+    version: 1.0.1
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
This is related to CASMPET-6820 where iSCSI metrics are added to export them to Prometheus / Grafana. Since cray-sysmgmt-health chart is used to deploy the daemonset pod, the version of the chart needs to be upgraded.

## Summary and Scope
Manifest file (platform.yaml) file is modified to update the chart version of cray-sysmgmt-health.

## Issues and Related PRs
CASMPET-6820

### Tested on:
Mug

### Test description:

![image](https://github.com/user-attachments/assets/36e72f41-8cfb-4983-ba18-40d850ced6a7)

## Risks and Mitigations
None

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
