### PR TITLE
CASMHMS-6140: Parse Managers .Actions correctly for Gigabyte and Paradise platforms during discovery

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.0.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.0.20
+    version: 7.0.21
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

River platforms Gigabyte and Paradise use the redfish endpoint /redfish/v1/Managers/<MANAGER>/ResetActionInfo to provide the allowable reset actions for the BMC rather than .Actions in the /redfish/v1/Managers/<MANAGER> redfish endpoint that HP platforms use.   Systems discovery in SMD actually supports either .Actions or /ResetActionInfo so the change here for Managers discovery is to mimic what we do for Systems discovery for processing these redfish endpoints.

Also updated the Gigabyte unit tests to include testing the new /ResetActionInfo processing during discovery.  The Paradise unit testing will be added as part of CASMHMS-6178.

Adopted app version 2.11.17 for CSM 1.5.3 (helm chart 7.0.21)

## Issues and Related PRs

* Resolves [CASMHMS-6140](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6140)

## Testing

Tested on:

  * drax (for Gigabyte testing)
  * tyr (for Paradise testing)

Test description:

Ran discover against target BMCs and verified that afterwards the correct "ResetType@Redfish.AllowableValues" values now appeared in 'cray hsm inventory componentEndpoints list' output when run against the target BMCs.

In order for PCS to read the new "supportedPowerTransitions" in 'cray power status describe' output, the PCS deployment must be restarted or the slot the blades are in must be power cycled.  I restarted to PCS deployment and verified afterwards that the correct supported transitions then appeared.

Using PCS I targeted both Gigabyte and Paradise BMCs with a soft-restart while logged into the BMC.  The ssh session terminated (as expected), and after the BMC rebooted I logged in and checked 'uptime' to verify that the BMC had indeed rebooted.

Ran discover against an HPE River BMC to verify .Actions still processed correctly for non-Paradise and non-Gigabyte BMCs.

Verified that HMS smoke and functional tests still past with changes in place.

Did not test CAPMC as CAPMC can only target nodes and not BMCs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

