### PR TITLE
CASMCMS-9062/CASMCMS-9063/CASMCMS-9064/CASMCMS-9065/CASMCMS-9066: Resolve CVEs in IMS, fix image-recipes build break

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -32,7 +32,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.6.1
+      - 2.7.2
     cray-grafterm:
       - 1.0.3
     # XXX Are these HMS images missing from a chart or are they used to

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,12 +180,12 @@ spec:
             tag: 2.5.1
   - name: cray-ims
     source: csm-algol60
-    version: 3.16.1
+    version: 3.16.2
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.15.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.16.2/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.9.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -171,13 +171,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.5.1
+    version: 2.5.2
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.5.1
+            tag: 2.5.2
   - name: cray-ims
     source: csm-algol60
     version: 3.16.2


### PR DESCRIPTION
* [CASMCMS-9062](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9062) Resolve CVEs in ims-utils
* [CASMCMS-9063](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9063) Resolve CVEs in ims-load-artifacts
* [CASMCMS-9064](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9064) Resolve CVEs in ims-kiwi-ng-opensuse-x86_64-builder
* [CASMCMS-9065](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9065) Resolve CVEs in ims
* [CASMCMS-9066](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9066) Fix build break in `image-recipes`