### PR TITLE
CASMTRIAGE-7184: SURTUR: Kiali does not work in csm-1.6-alpha.58

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.5.2
+    version: 0.5.3
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7184
