### PR TITLE
CASMCMS-9066: Fix build break in image-recipes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -173,13 +173,13 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.2.2
+    version: 2.2.3
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
-            tag: 2.2.2
+            tag: 2.2.3
   - name: cray-ims
     source: csm-algol60
     version: 3.15.0


### PR DESCRIPTION
[CASMCMS-9066](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9066) Fix build break in image-recipes