### PR TITLE
CASMCMS-9056 - update console-node base image.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -166,7 +166,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.2.1
+    version: 2.3.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

The cray-console-node image was based on sles15sp4 - that has reached end of life so we needed to update to sp5. That also resolved some CVE's that were reported against it.

## Issues and Related PRs
* Resolves [CASMCMS-9056](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9056)
* Resolves [CASMPET-7114](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7114)

## Testing
### Tested on:
  * `Mug`
  * Local development environment

### Test description:

I loaded the image on Mug and tested it to make sure all functionality works as expected. I also ran snyk scans locally and reviewed the snyk scans run in the build pipeline and they are clean.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as we do not depend on any service pack specific features of the base image.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

