### PR TITLE
CASMNET-1943 - Support for adding custom DNS records

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.8.1 # update platform.yaml cray-precache-images with this
+    version: 0.8.2 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.28
+        appVersion: 0.8.2
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

There is currently no easy way of creating custom records in the `cray-dns-unbound` service.

The Helm chart provides a basic facility to allow the injection of `A` records via `customizations.yaml` but no other record types are supported. Introducing new records via this mechanism also requires the `cray-dns-unbound` Helm chart to be re-deployed which is not a good user experience.

This PR introduces a `custom_records.conf` data element to the `cray-dns-unbound` Kubernetes ConfigMap which is included by the main `unbound.conf` configuration.

This PR also resolves CASMNET-2232 by updating the manager.py code so that any regular expressions are now raw strings. Python 3.12 throws a syntax warning if regular expressions that use `\` notation are not raw strings. Future Python versions will throw a syntax error.

## Issues and Related PRs

* Resolves [CASMNET-1943](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1943)
* Resolves [CASMNET-2232](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2232)
* Documentation changes required in https://github.com/Cray-HPE/docs-csm/pull/5272

## Testing

### Tested on:

  * `surtur`

### Test description:

Deployed code on surtur with the following configuration.

```
ncn-m001:~ # kubectl -n services get cm cray-dns-unbound -o yaml | yq4 '.data."custom_records.conf"'
# Add any additional local-data or local-data-ptr records here, one per line.
# See https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#unbound-conf-local-data for syntax.
# WARNING: Syntax errors here will cause Unbound to fail to start and the cluster DNS service will fail.
#
# Examples:
# local-data: "axfr-service.example.com A 10.252.4.254"
# local-data-ptr: "10.252.4.254 axfr-service.example.com"
# local-data: "_axfr-service._tcp.example.com 3600 IN SRV 0 100 8080 axfr-service.example.com."
local-data: "axfr-service.example.com A 10.252.4.254"
local-data: "_axfr-service._tcp.example.com 3600 IN SRV 0 100 8080 axfr-service.example.com."
```
Checked the DNS resolution of the SRV record works.
```
ncn-m001:~ # host -t SRV _axfr-service._tcp.example.com
_axfr-service._tcp.example.com has SRV record 0 100 8080 axfr-service.example.com.
```
Verified that upgrading the Helm chart does not overwrite user-supplied values.

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

