### PR TITLE
CASMTRIAGE-7198: Updating cray-product-catalog chart version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -206,7 +206,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.1.1
+            tag: 2.3.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -243,7 +243,7 @@ spec:
     # Unless there is a specific reason not to, this version should be
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
-    version: 2.1.1
+    version: 2.3.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

updating cray-product-catalog chart version to 2.3.0. 

## Issues and Related PRs

* Resolves [CASMTRIAGE-7198](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7198) , [CASMTRIAGE-6934](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6934)
* https://github.com/Cray-HPE/cray-product-catalog/pull/325

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

