### PR TITLE
CASMMON-413 and CASMMON-424 node_exporter to authenticate itself with its TLS certificate

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.2
+    version: 1.0.3
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
node_exporter to authenticate itself with its TLS certificate
Fix CVE's in artifactory.algol60.net/csm-docker/stable/gcr.io/google_containers/hyperkube:v1.18.0

system monitoring and metrics collection, ensuring the security of data transmission is paramount. This article delves into the configuration of Transport Layer Security (TLS) and HTTPS for the Prometheus Node Exporter, alongside implementing basic authentication. These measures are critical for safeguarding the integrity and confidentiality of the data as it moves between the Node Exporter and Prometheus server, offering an essential layer of security against potential eavesdropping or unauthorized access.

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMMON-424
https://jira-pro.it.hpe.com:8443/browse/CASMMON-413

## Testing

_List the environments in which these changes were tested._

### Tested on: mug

from the Master

curl 10.20.214.210:9100/metrics
Client sent an HTTP request to an HTTPS server.

From the worker

![image](https://github.com/user-attachments/assets/8f1a46bf-28ac-4190-a0b8-30f82286e0b8)


