### PR TITLE
 CASMPET-6721: upgrade istio to 1.19.10 

### DIFF
--- a/lib/wait-for-unbound.sh
+++ b/lib/wait-for-unbound.sh
@@ -27,8 +27,8 @@ set -exo pipefail
 
 function clean_up_unbound_manager_jobs() {
 
-    # Get the list of all unfinished jobs in the services namespace
-    unfinished_jobs=$(kubectl -n services get jobs -o=jsonpath='{.items[?(@.status.active==1)].metadata.name}' || true)
+    # Get the list of all unfinished or failed jobs in the services namespace
+    unfinished_jobs=$(kubectl -n services get jobs -o go-template --template '{{ range .items }}{{ if or .status.active .status.failed }}{{ .metadata.name }}{{ "\n" }}{{ end }}{{ end }}' || true)
 
     for job in ${unfinished_jobs};do
         # Only delete the job if it is a cray-dns-unbound-manager job

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -58,9 +58,9 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.5
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.11.8-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
       # Kyverno
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
@@ -73,7 +73,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
-      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
@@ -113,11 +113,11 @@ spec:
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
-    version: 1.26.0
+    version: 2.0.0
     namespace: istio-system
   - name: cray-istio-deploy
     source: csm-algol60
-    version: 1.29.0   # Update cray-precache-images above on proxyv2 tag change.
+    version: 2.0.0   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager
     source: csm-algol60
@@ -149,11 +149,11 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 2.10.0
+    version: 3.0.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.5.3
+    version: 0.6.1
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

We need to upgrade to istio 1.19.10 (our current version is 1.11.8) in order to support Kubernetes 1.24. Istio 1.11.8 or 1.12 does not support k8s 1.24. Istio 1.19 supports k8s 1.24 as well, so it will be beneficial to upgrade istio to 1.19 in CSM 1.6 regardless if we're going to upgrade kubernetes to 1.24 for CSM 1.6. 

## Issues and Related PRs

* Resolves  CASMPET-6721

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Performed  full install and upgrade cycle in vShasta.

## Risks and Mitigations

No specific risks, part of global upgrade.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

