### PR TITLE
CASMCMS-9082: Build csm-config Docker image on SLE15 SP6 (up from SP4)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.22.0
+    version: 1.23.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Just moves the base image of the `csm-config` Docker image. No functional changes. No backports.