### PR TITLE
CASMPET-7912 update cray-precache-images chart to v0.6.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -41,7 +41,7 @@ spec:
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60
-    version: 0.5.2
+    version: 0.6.0
     namespace: nexus
     timeout: 20m0s
     values:


### PR DESCRIPTION
## Summary and Scope

Update cray-precache-images chart to v0.6.0.

This update cray-precache-images so that it uses github.com/kubernetes-sigs/cri-tools:v1.24.2 container image. This is a container image with 'crictl'.

This container image is necessary in CSM 1.6 because in the K8s 1.24/SLES 15 SP6 build, cray-precache-images no longer works. The cray-precached-images container is not able to access the crictl binary on the host. This container image means that the cray-precached-images container won't need to access the crictl on the host.

## Issues and Related PRs

Resolves [CASMPET-7912](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7912)
Resolves [CASMTRIAGE-7227](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7227)

## Testing

Tested a cray-precache-images chart upgrade on Fanta (CSM 1.6, k8s 1.24 system)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

