### PR TITLE
CASMPET-7131 NCN images with k8s 1.24

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -31,17 +31,17 @@ NCN_ARCH='x86_64'
 CN_ARCH=("x86_64")
 
 # All images must use the same, exact kernel version.
-KERNEL_VERSION='5.14.21-150500.55.65-default'
+KERNEL_VERSION='6.4.0-150600.23.7.4.28314.3.PTF.1215587-default'
 # NOTE: The kernel-default-debuginfo package version needs to be aligned
 # to the KERNEL_VERSION. Always verify and update the correct version of
 # the kernel-default-debuginfo package when changing the KERNEL_VERSION
 # by doing a zypper search for the corresponding kernel-default-debuginfo package
 # in the SLE-Module-Basesystem update_debug repo
 # zypper --plus-repo=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update_debug se -s kernel-default-debuginfo
-KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
+KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.100
+KUBERNETES_IMAGE_ID=6.2.1
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.100
+PIT_IMAGE_ID=6.2.1
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.100
+STORAGE_CEPH_IMAGE_ID=6.2.1
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.100
+COMPUTE_IMAGE_ID=6.2.1
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \
@@ -77,20 +77,22 @@ done
 # hpe-signing-key.asc - for all packages signed by HPE Code Signing DST/CSM old key (expires 2025-12-07)
 # hpe-signing-key-fips.asc - for all packages signed by HPE Code Signing, DST new key (expires 2026-09-01), for example kernel-mft-mlnx-kmp-default
 # hpe-sdr-signing-key.asc - older HPE key used by SDR repos (Qlogic driver - qlgc-fastlinq-kmp-default)
-# google-package-key.asc - for kubelet/kubeadm/kubectl from https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 # suse-package-key.asc - for most SUSE packages in embedded repo
 # opensuse-obs-filesystems.asc - for packages copied into /csm-rpms/stable from OpenSUSE filesystems (such as csm-rpms/hpe/stable/sle-15sp5/ceph-common-17.2.6.865+g60870edfe2e-lp155.1.1.x86_64.rpm): https://download.opensuse.org/repositories/filesystems:/ceph:/quincy:/upstream/openSUSE_Leap_15.5/repodata/repomd.xml.key
 # opensuse-obs-backports.asc - for packages in /sles-mirror/Backports/SLE-15-SP5_x86_64 (dkms, perl-File-BaseDir)
 # suse_ptf_key.asc - for SUSE PTF kernel packages, see https://www.suse.com/support/kb/doc/?id=000018545
+# opensuse-tumbleweed.asc - k8s packages taken from https://download.opensuse.org/tumbleweed/repo/oss/repodata/
 HPE_RPM_SIGNING_KEYS=(
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key-fips.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-sdr-signing-key.asc
-    https://artifactory.algol60.net/artifactory/gpg-keys/google-package-key.asc
+    # https://artifactory.algol60.net/artifactory/gpg-keys/google-package-key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/suse-package-key.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/suse-package-2027-01-18.key
     https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-filesystems-15-sp5.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-backports-15-sp5.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/suse_ptf_key.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-tumbleweed.asc
 )
 
 # Public keys for container image signature validation.

--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='6.4.0-150600.23.7.4.28314.3.PTF.1215587-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.2.1
+KUBERNETES_IMAGE_ID=6.2.3
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.2.1
+PIT_IMAGE_ID=6.2.3
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.2.1
+STORAGE_CEPH_IMAGE_ID=6.2.3
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.2.1
+COMPUTE_IMAGE_ID=6.2.3
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -121,33 +121,34 @@ artifactory.algol60.net/csm-docker/stable:
       - v3.9.1
       - v3.9.3
 
-    # CoreDNS required by platform
-    # XXX Note this is different from any docker.io/coredns/coredns images
-    k8s.gcr.io/coredns:
-      - v1.8.0
-
     # Note this is the new layout for k8s 1.22 for coredns upstream the above
     # will go away for k8s 1.23+
     k8s.gcr.io/coredns/coredns:
-      - v1.8.0
       - v1.8.4
+    registry.k8s.io/coredns/coredns:
+      - v1.8.6
 
     # Kube images required by platform
     k8s.gcr.io/kube-apiserver:
-      - v1.21.12
       - v1.22.13
+    registry.k8s.io/kube-apiserver:
+      - v1.24.17
     k8s.gcr.io/kube-controller-manager:
-      - v1.21.12
       - v1.22.13
+    registry.k8s.io/kube-controller-manager:
+      - v1.24.17
     k8s.gcr.io/kube-proxy:
-      - v1.21.12
       - v1.22.13
+    registry.k8s.io/kube-proxy:
+      - v1.24.17
     k8s.gcr.io/kube-scheduler:
-      - v1.21.12
       - v1.22.13
+    registry.k8s.io/kube-scheduler:
+      - v1.24.17
     k8s.gcr.io/pause:
-      - 3.4.1
       - 3.5
+    registry.k8s.io/pause:
+      - 3.7
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
 

--- a/hack/rpms.sh
+++ b/hack/rpms.sh
@@ -104,6 +104,7 @@ rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp2"
 rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp3"
 rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp4"
 rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp5"
+rpm-sync-with-csm-base "rpm/cray/csm/sle-15sp6"
 rpm-sync-with-csm-base "rpm/cray/csm/noos"
 
 if [ "${VALIDATE}" == "1" ]; then
@@ -127,5 +128,6 @@ else
     mkdir -p "${BUILDDIR}/rpm/cray/csm/sle-15sp3" && createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp3"
     mkdir -p "${BUILDDIR}/rpm/cray/csm/sle-15sp4" && createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp4"
     mkdir -p "${BUILDDIR}/rpm/cray/csm/sle-15sp5" && createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp5"
+    mkdir -p "${BUILDDIR}/rpm/cray/csm/sle-15sp6" && createrepo "${BUILDDIR}/rpm/cray/csm/sle-15sp6"
     mkdir -p "${BUILDDIR}/rpm/cray/csm/noos" && createrepo "${BUILDDIR}/rpm/cray/csm/noos"
 fi

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 
@@ -77,6 +77,7 @@ nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp2"         "csm-${RELEASE_VERS
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp3"         "csm-${RELEASE_VERSION}-sle-15sp3"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp4"         "csm-${RELEASE_VERSION}-sle-15sp4"
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp5"         "csm-${RELEASE_VERSION}-sle-15sp5"
+nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp6"         "csm-${RELEASE_VERSION}-sle-15sp6"
 nexus-upload raw "${ROOTDIR}/rpm/embedded"                   "csm-${RELEASE_VERSION}-embedded"
 
 clean-install-deps

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,9 +62,12 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
@@ -85,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.2
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.13.1
+    version: 1.14.1
     namespace: services
   - name: cray-bos
     source: csm-algol60

--- a/nexus-repositories.yaml
+++ b/nexus-repositories.yaml
@@ -77,6 +77,21 @@ group:
   - csm-0.0.0-sle-15sp5
 
 ---
+name: csm-0.0.0-sle-15sp6
+format: raw
+storage:
+  blobStoreName: csm
+---
+name: csm-sle-15sp6
+format: raw
+storage:
+  blobStoreName: csm
+type: group
+group:
+  memberNames:
+  - csm-0.0.0-sle-15sp6
+
+---
 name: csm-0.0.0-noos
 format: raw
 storage:

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -43,8 +43,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch
-    - goss-servers-1.17.29-1.noarch
-    - csm-testing-1.17.29-1.noarch
+    - goss-servers-1.17.30-1.noarch
+    - csm-testing-1.17.30-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.0-1.noarch
     - hpe-yq-4.33.3-1.aarch64
@@ -52,10 +52,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - ilorest-4.2.0.0-20.x86_64
     - iuf-cli-1.6.15-1.x86_64
     - manifestgen-1.3.10-1.noarch
-    - metal-basecamp-1.2.6-1.x86_64
+    - metal-basecamp-1.2.7-1.x86_64
     - metal-init-1.4.10-1.noarch
-    - metal-ipxe-2.4.100-1.noarch
-    - metal-nexus-1.3.0-3.38.0_1.x86_64
+    - metal-ipxe-2.6.1-1.noarch
+    - metal-nexus-1.6.0-3.68.1_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.6.10-1.noarch
     - smart-mon-1.0.3-1.noarch

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - cfs-debugger-1.7.0-1.x86_64
+    - cfs-debugger-1.8.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
-    - cfs-debugger-1.7.0-1.x86_64
+    - cfs-debugger-1.8.0-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp6/index.yaml
+++ b/rpm/cray/csm/sle-15sp6/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp6/:
   rpms:
     - cfs-debugger-1.8.0-1.x86_64
     - libcsm-0.0.5-1.noarch


### PR DESCRIPTION
## Summary and Scope

Upgrade Kubernetes included with CSM to version 1.24.

## Issues and Related PRs


* Resolves CASMPET-7131

## Testing
### Tested on:

  * `fanta`
  * Virtual Shasta

### Test description:

Multiple fresh installs and upgrades on vShasta, fresh install on `fanta`.

## Risks and Mitigations
TFTP test is known to fail - test issue only.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

