### PR TITLE
CASMTRIAGE-7233/CASMCMS-8814: CFS batcher bug fix and resiliency improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -149,7 +149,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.20.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.10.0
+    version: 1.11.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60


### PR DESCRIPTION
* https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8814
* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7233

CSM 1.5.3 backport: https://github.com/Cray-HPE/csm/pull/3576

CSM 1.4.5 backport (does not contain CASMCMS-8814, as that bug did not exist in CSM 1.4): https://github.com/Cray-HPE/csm/pull/3577
