### PR TITLE
CASMCMS-9100: Make cfs-operator more resilient to network issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.26.1
+    version: 1.26.2
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
Use requests_retry_session Python module to avoid operator hangs due to network issues.

Backports:

1.5.3: https://github.com/Cray-HPE/csm/pull/3579
1.4.5: https://github.com/Cray-HPE/csm/pull/3580