### PR TITLE
CASMCMS-9100: Make cfs-operator more resilient to network issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.22.4
+    version: 1.22.5
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
CSM 1.5.3 backport of https://github.com/Cray-HPE/csm/pull/3578