### PR TITLE
MTL-2450 - Remove unused hsn-dynamic-pool and hsn-static-pool parameters

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-state-reporter-1.11.0-1.noarch
     - cfs-trust-1.7.1-1.noarch
     - cray-cmstools-crayctldeploy-1.22.0-1.x86_64
-    - cray-site-init-1.35.3-1.x86_64
+    - cray-site-init-1.35.4-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
     - craycli-0.83.6-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The following two CSI flags were marked deprecated

```
      --hsn-dynamic-pool string               Overall IPv4 CIDR for dynamic High Speed load balancer addresses
      --hsn-static-pool string                Overall IPv4 CIDR for static High Speed load balancer addresses
```

The parameters re-added by a recent refactor. [MTL-2396](https://jira-pro.it.hpe.com:8443/browse/MTL-2396) https://github.com/Cray-HPE/cray-site-init/pull/391

This PR removes them again.

## Issues and Related PRs

* Resolves [MTL-2450](https://jira-pro.it.hpe.com:8443/browse/MTL-2450)

## Testing


### Tested on:

  * `fanta`
  * Local development environment

### Test description:

The `hsn-dynamic-pool` and `hsn-static-pool` flags are no longer visible

```bash
# csi config init --help | grep hsn
      --hsn-cidr string                       Overall IPv4 CIDR for all HSN subnets (default "10.253.0.0/16")
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

