### PR TITLE
CASM-4820: KYVERNO chart upgrade needed for CSM version 1.6.x

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,9 +62,12 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.11.8-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.11.8-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
@@ -85,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.1
+    version: 1.6.2
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Kyverno Upgrade Needed for CSM version 1.6.x, to ensure the Kubernetes Version 1.24 Compatibility and N-2 support policy offered by the Kyverno community.

## Testing

Install, upgrade, rollback, policy and cluster policy listing, policy report.

### Tested on:

Surtur

### Test description:

[KyvernoLogs1.6.2artiChart.txt](https://github.com/user-attachments/files/16687321/KyvernoLogs1.6.2artiChart.txt)
