### PR TITLE
CRAYSAT-1706: Update cray-sat to version 3.30.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.30.0
+      - 3.30.2
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_This will Backport cray-sat 3.30.0 through 3.30.2_

## Issues and Related PRs

_Includes the following:_

- [CRAYSAT-1392](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1392): https://github.com/Cray-HPE/sat/pull/256
- [CRAYSAT-1706](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1706): https://github.com/Cray-HPE/sat/pull/257

## Testing

_See linked PRs_

## Risks and Mitigations

_See linked PRs_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

