### PR TITLE
Fix CVEs for vmalert:v1.93.1 and CASMMON-421 vminsert:v1.93.1-cluster

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.4
+    version: 1.0.6
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
#
CASMMON-418 Fix CVEs for vmalert:v1.93.1 and CASMMON-421 vminsert:v1.93.1-cluster
## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMMON-417
https://jira-pro.it.hpe.com:8443/browse/CASMMON-421
## Testing

_List the environments in which these changes were tested._

### Tested on:
Mug
### Test description:
![Uploading image.png…]()
