### PR TITLE
CASMCMS-9101/CASMCMS-9113: Increase cfs-trust & cfs-state-reporter resiliency to network issues

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='5.14.21-150500.55.65-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.1.100
+KUBERNETES_IMAGE_ID=6.2.3
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.1.100
+PIT_IMAGE_ID=6.2.3
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.1.100
+STORAGE_CEPH_IMAGE_ID=6.2.3
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.1.100
+COMPUTE_IMAGE_ID=6.2.3
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='5.14.21-150500.55.65-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.2.3
+KUBERNETES_IMAGE_ID=6.1.100
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.2.3
+PIT_IMAGE_ID=6.1.100
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.2.3
+STORAGE_CEPH_IMAGE_ID=6.1.100
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.2.3
+COMPUTE_IMAGE_ID=6.1.100
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.7.1
+    version: 1.7.3
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -230,8 +230,9 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.6.1
+    version: 1.6.2
     namespace: services
+
   - name: gitea
     source: csm-algol60
     version: 2.7.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cani-0.4.0-1.x86_64
     - canu-1.9.2-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
-    - cfs-state-reporter-1.11.0-1.noarch
+    - cfs-state-reporter-1.12.0-1.noarch
     - cfs-trust-1.7.3-1.noarch
     - cray-cmstools-crayctldeploy-1.22.0-1.x86_64
     - cray-site-init-1.35.4-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,12 +25,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.25.0-1.noarch
+    - bos-reporter-2.26.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.2-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
-    - cfs-trust-1.7.1-1.noarch
+    - cfs-trust-1.7.3-1.noarch
     - cray-cmstools-crayctldeploy-1.22.0-1.x86_64
     - cray-site-init-1.35.4-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
@@ -41,8 +41,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.6-1.aarch64
     - csm-node-heartbeat-2.6-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
-    - csm-ssh-keys-1.6.1-1.noarch
-    - csm-ssh-keys-roles-1.6.1-1.noarch
+    - csm-ssh-keys-1.6.2-1.noarch
+    - csm-ssh-keys-roles-1.6.2-1.noarch
     - goss-servers-1.17.29-1.noarch
     - csm-testing-1.17.29-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
@@ -58,6 +58,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.6.10-1.noarch
+    - python3-liveness-1.4.3-1.noarch
+    - python3-requests-retry-session-0.1.5-1.noarch
+    - python310-requests-retry-session-0.1.5-1.noarch
+    - python311-requests-retry-session-0.1.5-1.noarch
+    - python312-requests-retry-session-0.1.5-1.noarch
+    - python39-requests-retry-session-0.1.5-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
This affects a number of different things, because cfs-trust is pulled in directly and indirectly by them.
This PR also bumps the `bos-reporter` RPM version to match the BOS service version.

Backports:
CSM 1.5.3: https://github.com/Cray-HPE/csm/pull/3593
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3594