### PR TITLE
CASMMON-397: CSM-1.6: Retrieve SMART metrics from E1000 via redfish exporter.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -161,7 +161,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.6
+    version: 1.0.7
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMMON-397