### PR TITLE
CASMHMS-6180: Reduce OS noise from csm-node-heartbeat.service

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -38,8 +38,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.83.6-1.aarch64
     - craycli-0.83.6-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.6-1.aarch64
-    - csm-node-heartbeat-2.6-1.x86_64
+    - csm-node-heartbeat-2.7-1.aarch64
+    - csm-node-heartbeat-2.7-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.1-1.noarch
     - csm-ssh-keys-roles-1.6.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

There are two primary sets of optimizations made to reduce OS noise/jitter caused by the heartbeat client on compute nodes:

1. Various optimizations to the C source code including reusing buffers rather than allocating/freeing each heartbeat, caching static data rather than refreshing every heartbeat, removing unnecessary library/system calls, etc
2. Caching the Spire token when acquired, and only re-acquiring if it expires within the next heartbeat interval.  Previously a new Spire token was acquired for every heartbeat regardless of expiration. 

A more detailed listing of optimizations to hb_ref include:

- Defined a new function to extract the expiration timestamp from token
- A new token is not acquired unless the cached token expires within the next hb window
- Cached the HTTP header so that we don't have to recreate it every hb, only when a new token is acquired
- When a new HTTP header is necessary, reuse the prior buffer, increasing the size if necessary
- Cached gethostname() value at start time rather than re-read every hb
- send_message(): Initialize rsp_data on the stack rather than explicitly in the middle of the function
- send_message(): When getting a new token, the original code allocated memory for the token 3 times and copied the entire contents around 4 times.  Token size was about ~1k so this wasn't insignificant.  The optimized code only allocates memory once (unless the size needs to be increased) and does only two copies (into and out of the local buffer)
- iso_8601_timestamp(): Replaced gettimeofday() with clock_gettime() as it avoids system call if VDSO enabled (it is on our compute nodes)
- iso_8601_timestamp(): Removed unnecessary calls to gmtime_t() and mktime() when calculating timezone offset
- Completely removed the make_hb() routine.  All contents but the timestamp are static in the hb message so the static data was changed to be statically set at start time rather than repopulated for each hb.
- The main() routine now directly calls the iso_8601_timestamp() at each hb to update the hb message buffer

Additional changes made to hb_rf:

- Made hb_interval a global
- Switched verbose logging from stdout to stderr because journalctl buffers stdout and dumps it en-masse infrequently which makes it pretty useless as messages aren't timely and not in order with stderr
- Only set CURLOPT_VERBOSE if verbosity level > 2
- The iso_8601_timestamp() changes also resolved a long-time bug where our timestamps were off by 1 when calculating tz_mins
- To improve debuggability in the field, hb_ref now logs its entire configuration at start time

The csm-node-heartbeat.sh.in script was modified to start hb_ref with the -s option.  This tells hb_ref to fire the heartbeat message and continue without waiting for a response.  There appears to be no benefit for waiting on a response, and the response data that does come back is always zero-length.  To ensure I'm not missing anything, I reached out to one of the original heartbeat architects.  He did not recall why the initial implementation included waiting for a response.  The other original heartbeat architect has since retired.

Also added osnoise_trace.sh script I used to gather data to the repo so that we can more easily measure noise if necessary, in the future.  The performance data that was gathered has already been attached to and summarized in CASMHMS-6180.

### Notes of Interest

Recording an observation...  Neither the original code nor the changes in this PR log anything when hb_ref does not receive a 200 (OK) HTTP response code from the server.  I debated adding this, but opted not to as there may be many potential transient conditions that might force a lot of local compute node log traffic when unnecessary.  Customer applications should generally not be interfered with if there are issues on the management plane or network.  The management plane will already know if heartbeats are not making it through, without this extra logging.  Once any management plane or network issues are resolved, heartbeats will continue.  If it is necessary to do debugging on the compute node side, hb_ref can be run with the --verbose option, which will log the HTTP response codes.  Removing the --sendonly option may provide additional detail in the response body from the server.

Receiving an HTTP response code implies connectivity with the server on the management plane.  The above comment applies only to that situation.  If for any reason the HTTP message is unable to be successfully delivered to the server, that will be logged, along with the reason why.

Updated csm-node-heartbeat RPM version from 2.6-1 to 2.7-1.

## Issues and Related PRs

* Resolves [CASMHMS-6180](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6180)

## Testing

### Tested on:

  * `surtur`

### Test description:

Test notes:

- Tested on Gigabyte compute node x3000c0s17b2n0 on surtur.
- Testing was done while node was idle.  This allowed me to gather data for only the noise generated by periodic system processes.
- Tested with and without the --verbose, --interval, --no-token, and --sendonly options.
- Verified on surtur-ncn-m001 that heartbeats were arriving by looking at the cray-hbtd-bitname-etc logs.
- Monitored journalctl log for heartbeat service throughout all testing.
- Gathered several hours of data with modified hb_ref running.
- Ran under valgrind to find potential memory issues since I made a lot of buffer related changes.  One problem was found and fixed.
- Also ran the modified hb_ref client on surtur NCN worker node x3000c0s31b0n0 to verify functionality outside of a compute node

Test checklist: 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N - This service is packaged in an rpm and not a helm chart
- Were continuous integration tests run? If not, why? N - No CI tests for this code
- Was upgrade tested? If not, why? N - This service is packaged in an rpm and not a helm chart
- Was downgrade tested? If not, why? N - This service is packaged in an rpm and not a helm chart
- Were new tests (or test issues/Jiras) created for this change? N
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

