### PR TITLE
CASMCMS-9114: Update csm-config to SLES SP6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -198,7 +198,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.33
+    version: 1.16.34
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
No functional changes -- just allowing the rebuilds to work.

CSM 1.4.5 backport:

No CSM 1.6 PR needed.