### PR TITLE
CASMCMS-9114: Update csm-config to SLES SP6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -233,7 +233,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.15.32
+    version: 1.15.33
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3591 for CSM 1.4.5