### PR TITLE
CASMCMS-9101: Make cfs-trust more resilient to network issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.8
+    version: 1.6.9
     namespace: services
   - name: cms-ipxe
     source: csm-algol60

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.5.0-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
     - cfs-state-reporter-1.11.0-1.noarch
-    - cfs-trust-1.6.8-1.noarch
+    - cfs-trust-1.6.9-1.noarch
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
     - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
@@ -60,6 +60,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.6.10-1.noarch
+    - python3-liveness-1.4.3-1.noarch
+    - python3-requests-retry-session-0.1.5-1.noarch
+    - python310-requests-retry-session-0.1.5-1.noarch
+    - python311-requests-retry-session-0.1.5-1.noarch
+    - python312-requests-retry-session-0.1.5-1.noarch
+    - python39-requests-retry-session-0.1.5-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.6.1-1.noarch
     - cfs-debugger-1.5.0-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cfs-state-reporter-1.11.0-1.noarch
+    - cfs-state-reporter-1.11.1-1.noarch
     - cfs-trust-1.6.9-1.noarch
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
     - cray-site-init-1.32.6-1.x86_64


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/3588 for CSM 1.5.3