### PR TITLE
CASMCMS-9101: Add CSM Python package RPMs

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -26,4 +26,10 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - csm-testing-1.15.62-1.noarch
     - goss-servers-1.15.62-1.noarch
+    - python3-liveness-1.4.3-1.noarch
+    - python3-requests-retry-session-0.1.5-1.noarch
+    - python310-requests-retry-session-0.1.5-1.noarch
+    - python311-requests-retry-session-0.1.5-1.noarch
+    - python312-requests-retry-session-0.1.5-1.noarch
+    - python39-requests-retry-session-0.1.5-1.noarch
     - smart-mon-1.0.3-1.noarch


### PR DESCRIPTION
Partial backport of https://github.com/Cray-HPE/csm/pull/3588 for CSM 1.4.5