### PR TITLE
CASM-4819 Inject OCI signing keys onto Kubernetes secret

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -82,9 +82,16 @@ deploy "${BUILDDIR}/manifests/keycloak-gatekeeper.yaml"
 # For backward compatibility, also import hpe-signing-key.asc under the name "gpg-pubkey"
 RPM_SIGNING_KEYS_OPT="--from-file gpg-pubkey=${ROOTDIR}/security/keys/rpm/hpe-signing-key.asc"
 for key in ${ROOTDIR}/security/keys/rpm/*.asc; do
-        RPM_SIGNING_KEYS_OPT="${RPM_SIGNING_KEYS_OPT} --from-file ${key}"
+    RPM_SIGNING_KEYS_OPT="${RPM_SIGNING_KEYS_OPT} --from-file ${key}"
 done
 kubectl create secret generic hpe-signing-key -n services ${RPM_SIGNING_KEYS_OPT} --dry-run=client --save-config -o yaml | kubectl apply -f -
+
+# Create secret with OCI (images) signing keys
+OCI_SIGNING_KEYS_OPT=""
+for key in ${ROOTDIR}/security/keys/oci/*.pub; do
+    OCI_SIGNING_KEYS_OPT="${OCI_SIGNING_KEYS_OPT} --from-file ${key}"
+done
+kubectl create secret generic hpe-oci-signing-key -n kyverno ${OCI_SIGNING_KEYS_OPT} --dry-run=client --save-config -o yaml | kubectl apply -f -
 
 # Save previous Unbound IP
 pre_upgrade_unbound_ip="$(kubectl get -n services service cray-dns-unbound-udp-nmn -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"


### PR DESCRIPTION
## Summary and Scope

We want OCI public signing keys to be handled similar to RPM signing keys - i.e. inject them from file into Kubernetes secret, instead of strings in `customization.yaml` consumable by Helm chart. This change adds injection into a secret named `hpe-oci-signing-key` in `kyverno` namespace.

## Issues and Related PRs

* Resolves CASM-4819

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Performed fresh install and ensured secret is created:

    ncn-m001:~ # kubectl -n kyverno get secret hpe-oci-signing-key -o yaml
    apiVersion: v1
    data:
      csm-sigstore-images.pub: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFwbVNzOVFhNm8zRThzWUFsTTY0bgoxY0wwUkc2SmRjNnBHNzhCMVAzczY3eFpUTzc2dnhZdUEwd2ZTOGN2elBzVUZIaTVZY0pFRUJrRmNEQVVBRXVrCjNJVzd2cDA1NEg5bWNNS1VVY0R0ZGNCQ3Z1d3VRSGtPSlFOTmF5K0ZHdU5MSFVhWkR5dUVkVnhIZUtucFQwNEMKVURtSnJwNzB4T0p3TUFoaGlZS0hJdG0rY0szRmxIRjc3b2tMdXM0Zi9oK1BXNGQ5cmYwdTkvdE5BZE1ZSU5mZQpEOG01cWRQeUU0UDBoam5hRU9WOXN4dlczTm1DMG5ZMkRhWTA5MkJGcVlOMG1ROGhuSE5hRmo2ZFVKcExQT3hjCm5HbVRpejBlSlU4Wk1Ob1libFJHVXJnUW9TL1BrSktDQmEvTVpiL1JZcW1sZllPaExXUEdnbnRVVEJEMzh5ZGsKTmF2clBjR1pzY3YzTGZKWnEvcWFnL29zTk1HZ1Nya29Mc0ZhWVljOHJ1SFZnczB6bVNwTlNlemloNm15UGZKUwp4RE9CYlRhaFdKdDFnaUlndEZ6UDR6eHlzMDVzckJFOXAvT2hsbUM2M1BoRVVkb3VlVnpHZjRMcEVjL2s4eU1rCi9WSGhKTVo3VlJ6RHJlWkY1R2ZpUUpTYko4Q3RhOUpRRU9BQzlqdndPY1Y0cDM0L3h5dUdGMDhkeXNYZHgzZFUKN0tuM1ZHS0FwTWVNU0IzTkNoaWxsRnovbEc4ZjAyZkdlQjNsQnhIdGJ2K2syTDU5SEFsRVJOTUFEZlJFb2xtdQpjblI2dUVlRy9uV05sc21WMi84U1RPRlVJWW9Od1RaeVo5QmJLTFpneksyN1R1b2dYaFhkSTRFeU9rMGpmTGJnClpBSUd6R2xTQ05CbXJSbDNtdUQ2blc4Q0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQoK
      gcp-csm-builds-github-cray-hpe.pub: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFUnhMWU9WcS9rQmVFMDVtVVpxVGs4NUNhT3BTQwpDZFllTGxDdCtLOTQxZVFnTldRTEJkTWlEUG5pY3c1aTlvMjc4YXBvL09MRDVBWlZTWDhaWFBZa0tRPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCgo=
      gcp-csm-builds-jenkins-csm.pub: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFaEVROVgxajJkN3FESEVYSlJiWW5BY1lNaEdvcApPQmhrbkl2U1dRWWhPcGlINzRDdEpYNC9LS1BPUUp4bWIrWkhkWmpDOUdRWnp4eWF5cDJFdkxGMk9nPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCgo=
    kind: Secret
    metadata:
      annotations:
        kubectl.kubernetes.io/last-applied-configuration: |
          {"apiVersion":"v1","data":{"csm-sigstore-images.pub":"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFwbVNzOVFhNm8zRThzWUFsTTY0bgoxY0wwUkc2SmRjNnBHNzhCMVAzczY3eFpUTzc2dnhZdUEwd2ZTOGN2elBzVUZIaTVZY0pFRUJrRmNEQVVBRXVrCjNJVzd2cDA1NEg5bWNNS1VVY0R0ZGNCQ3Z1d3VRSGtPSlFOTmF5K0ZHdU5MSFVhWkR5dUVkVnhIZUtucFQwNEMKVURtSnJwNzB4T0p3TUFoaGlZS0hJdG0rY0szRmxIRjc3b2tMdXM0Zi9oK1BXNGQ5cmYwdTkvdE5BZE1ZSU5mZQpEOG01cWRQeUU0UDBoam5hRU9WOXN4dlczTm1DMG5ZMkRhWTA5MkJGcVlOMG1ROGhuSE5hRmo2ZFVKcExQT3hjCm5HbVRpejBlSlU4Wk1Ob1libFJHVXJnUW9TL1BrSktDQmEvTVpiL1JZcW1sZllPaExXUEdnbnRVVEJEMzh5ZGsKTmF2clBjR1pzY3YzTGZKWnEvcWFnL29zTk1HZ1Nya29Mc0ZhWVljOHJ1SFZnczB6bVNwTlNlemloNm15UGZKUwp4RE9CYlRhaFdKdDFnaUlndEZ6UDR6eHlzMDVzckJFOXAvT2hsbUM2M1BoRVVkb3VlVnpHZjRMcEVjL2s4eU1rCi9WSGhKTVo3VlJ6RHJlWkY1R2ZpUUpTYko4Q3RhOUpRRU9BQzlqdndPY1Y0cDM0L3h5dUdGMDhkeXNYZHgzZFUKN0tuM1ZHS0FwTWVNU0IzTkNoaWxsRnovbEc4ZjAyZkdlQjNsQnhIdGJ2K2syTDU5SEFsRVJOTUFEZlJFb2xtdQpjblI2dUVlRy9uV05sc21WMi84U1RPRlVJWW9Od1RaeVo5QmJLTFpneksyN1R1b2dYaFhkSTRFeU9rMGpmTGJnClpBSUd6R2xTQ05CbXJSbDNtdUQ2blc4Q0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQoK","gcp-csm-builds-github-cray-hpe.pub":"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFUnhMWU9WcS9rQmVFMDVtVVpxVGs4NUNhT3BTQwpDZFllTGxDdCtLOTQxZVFnTldRTEJkTWlEUG5pY3c1aTlvMjc4YXBvL09MRDVBWlZTWDhaWFBZa0tRPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCgo=","gcp-csm-builds-jenkins-csm.pub":"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFaEVROVgxajJkN3FESEVYSlJiWW5BY1lNaEdvcApPQmhrbkl2U1dRWWhPcGlINzRDdEpYNC9LS1BPUUp4bWIrWkhkWmpDOUdRWnp4eWF5cDJFdkxGMk9nPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCgo="},"kind":"Secret","metadata":{"annotations":{},"creationTimestamp":"2024-08-23T18:04:19Z","name":"hpe-oci-signing-key","namespace":"kyverno","resourceVersion":"17904","uid":"1faaddfc-a3ea-43af-bf13-25cd8b183d2c"},"type":"Opaque"}
      creationTimestamp: "2024-08-23T18:04:19Z"
      name: hpe-oci-signing-key
      namespace: kyverno
      resourceVersion: "18130"
      uid: 1faaddfc-a3ea-43af-bf13-25cd8b183d2c
    type: Opaque


## Risks and Mitigations

None known.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

