### PR TITLE
CASMCMS-9115: Update cray-aee to SLES15SP6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -153,7 +153,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.26.2
+    version: 1.26.3
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
No functional changes. No backports.