### PR TITLE
CASMPET-7072: Add Vault access through istio

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -136,7 +136,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.6.1
+    version: 1.6.2
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This adds in a new virtual service to allow vault access through the istio ingress gateways. This also adds in a new transit engine for use in the SOPs tooling to allow encrypting and decrypting secrets for use in ansible plays.

## Issues and Related PRs

* Resolves [CASMPET-7072](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7072)

## Testing

### Tested on:

  * beau

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No risk or changes only adds new functionality


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

