### PR TITLE
CASMPET-7180 CASMPET-7195: iSCSI SBPS CFS plays additions/ fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.24.1
+    version: 1.24.2
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
iSCSI SBPS: 
    - CASMPET-7180: New CFS play for enabling spire for SBPS Marshal Agent
    - CASMPET-7195: New CFS play for install (+ previous enable) SBPS Marshal Agent
    - typo fix in DNS SRV A records creation

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7195
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7180

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Bare metal system: surtur

### Tested on:
Bare metal system: surtur

### Test description:

- Verified CFS plays for worker node personalization for iSCSI SBPS and it has suceeded.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

