### PR TITLE
CASMCMS-9118: Improve BOS resiliency by using requests_retry_session module

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='6.4.0-150600.23.7.4.28314.3.PTF.1215587-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.2.3
+KUBERNETES_IMAGE_ID=6.2.4
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.2.3
+PIT_IMAGE_ID=6.2.4
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.2.3
+STORAGE_CEPH_IMAGE_ID=6.2.4
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.2.3
+COMPUTE_IMAGE_ID=6.2.4
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.26.1
+    version: 2.26.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.26.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.26.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.20.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.26.1-1.noarch
+    - bos-reporter-2.26.2-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.2-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch


### PR DESCRIPTION
This updates BOS to use the new `requests_retry_session` Python module, rather than duplicating the code.

Backports:
1.5.3: https://github.com/Cray-HPE/csm/pull/3603
1.4.5: https://github.com/Cray-HPE/csm/pull/3604

`node-images` PR:
https://github.com/Cray-HPE/node-images/pull/1140