### PR TITLE
CASMCMS-9118: Improve BOS resiliency by using requests_retry_session module

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,13 +159,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.44
+    version: 2.0.45
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.44/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.45/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.9

--- a/rpm/cray/csm/sle-15sp2-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp2-compute/index.yaml
@@ -26,5 +26,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
     - cray-switchboard-2.1.0-1.x86_64
     - cray-uai-util-2.1.0-1.x86_64
     - craycli-0.74.3-1.x86_64
-    - bos-reporter-2.0.44-1.x86_64
+    - bos-reporter-2.0.45-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp3-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp3-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - bos-reporter-2.0.44-1.x86_64
+    - bos-reporter-2.0.45-1.x86_64

--- a/rpm/cray/csm/sle-15sp4-compute/index.yaml
+++ b/rpm/cray/csm/sle-15sp4-compute/index.yaml
@@ -25,5 +25,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
-    - bos-reporter-2.0.44-1.x86_64
+    - bos-reporter-2.0.45-1.x86_64
 

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,7 +23,7 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - bos-reporter-2.0.44-1.x86_64
+    - bos-reporter-2.0.45-1.x86_64
     - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
     - cfs-debugger-1.3.1-1.x86_64


### PR DESCRIPTION
CSM 1.4.5 backport of the CASMCMS-9118 content in https://github.com/Cray-HPE/csm/pull/3595