### PR TITLE
CASM-4818: Creation of post install hook for Kyverno deployment to enable trust between Kyverno and Nexus

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.2
+    version: 1.6.3
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The changes with this PR will enable trust between Kyverno and Nexus for container image verification.

In order to support trust between nexus and kyverno, we have introduced post install hooks. The changes are made available in 1.6.3 version of cray-kyverno and the same we are submitting through this change. This change is needed to support container image signing and verification feature through Kyverno policies.

## Testing

Kyverno trust build and postinstall hook verification.

Below mentioned 4 scenarios are verified successfully:
1] cray-kyverno 1.6.3 version Fresh install
2] cray-kyverno 1.6.0 to 1.6.3 version upgrade and rollback
3] cray-kyverno 1.6.3 to 1.6.4 version upgrade and rollback
4] cray-kyverno 1.5.5 to 1.6.3 version upgrade and rollback

### Tested on:

MUG

### Test description:

[kyverno_1_6_3_fresh_install_logs.txt](https://github.com/user-attachments/files/16760167/kyverno_1_6_3_fresh_install_logs.txt)
[kyverno_1_6_0_to_1_6_3_logs.txt](https://github.com/user-attachments/files/16760168/kyverno_1_6_0_to_1_6_3_logs.txt)
[kyverno_1_6_3_to_1_6_4_logs.txt](https://github.com/user-attachments/files/16760169/kyverno_1_6_3_to_1_6_4_logs.txt)
[kyverno_1_5_5_to_1_6_3_logs.txt](https://github.com/user-attachments/files/16760171/kyverno_1_5_5_to_1_6_3_logs.txt)
