### PR TITLE
Updates/ fixes to SBPS Marshall Agent

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -70,7 +70,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-spire-dracut-2.0.3-1.noarch
     - tpm-provisioner-client-1.0.1-3.x86_64
     - tpm-provisioner-client-1.0.1-3.aarch64
-    - sbps-marshal-0.0.5-1.noarch
+    - sbps-marshal-0.0.6-1.noarch
 
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/noos/:
   rpms:


### PR DESCRIPTION
## Summary and Scope
Updates/ fixes to SBPS Marshall Agent:
- CASMPET-7176: SBPS Marshall Agent Key:Value mismatch to IMS Image Records
- CASMPET-7196: Update SBPS Marshal Agent s3 access to new s3 user read only policy
- CASMPET-7154: sbps-marshal agent failure due to syntax error in agent

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7176
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7196
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7154

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

bare metal system: surtur

### Tested on:

bare metal system: surtur

### Test description:
1. Verified that "sbps-marshal.service" is running and "systemctl status sbps-marshal.service" do not show any syntax error.
2. Verified image filtering / projection of luns having tagged IMS images only and successfully booted compute nodes individually as well as all compute nodes boot at one go.
 3. Verified "boot-images" mapping / LUN projection with new s3 read only policy.

 
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

