### PR TITLE
CASMCMS-9123: cfs-hwsync-agent: Use requests-retry-session Python module

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.12.1
+    version: 1.12.2
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
Updates the cfs-hwsync-agent to use the requests-retry-session Python module, rather than duplicating its code.

Backports:

CSM 1.5.3: https://github.com/Cray-HPE/csm/pull/3612
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3613