### PR TITLE
CASMCMS-9123: cfs-hwsync-agent: Use requests-retry-session Python module

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.11.0
+    version: 1.11.1
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
CSM 1.5.3 backport of https://github.com/Cray-HPE/csm/pull/3611