### PR TITLE
CASMCMS-9123: cfs-hwsync-agent: Use requests-retry-session Python module

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,7 +147,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.9.3
+    version: 1.9.4
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
CSM 1.4.5 backport of https://github.com/Cray-HPE/csm/pull/3611