### PR TITLE
CASMCMS-9125: BOS: Update to correct TAPMS endpoint for CSM 1.6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.26.2
+    version: 2.26.3
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.26.2/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.26.3/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.20.0

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.26.2-1.noarch
+    - bos-reporter-2.26.3-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.2-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch


### PR DESCRIPTION
TAPMS updated to a new endpoint in CSM 1.6 and, sadly, it breaks backwards compatibility (including poor BOS). This updates BOS to use the new endpoint. Without this, multi-tenancy support in BOS is broken.

No backports needed.