### PR TITLE
CASMNET-2239 - Update cray-services version in networking services charts

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -45,25 +45,25 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.3 # update platform.yaml cray-precache-images with this
+    version: 0.11.4 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.8.2 # update platform.yaml cray-precache-images with this
+    version: 0.8.3 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.8.2
+        appVersion: 0.8.3
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.4.1 # update platform.yaml cray-precache-images with this
+    version: 0.4.2 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.8.3 # update platform.yaml cray-precache-images with this
+    version: 0.8.4 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -71,10 +71,10 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.2
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.1
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.4
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.3
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0


### PR DESCRIPTION
## Summary and Scope

Update cray-service chart version to ~11.0.0 in order to pick up the new cert-manager.io/v1 API changes.

## Issues and Related PRs

* Resolves 
  * [CASMNET-2239](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2239) - cray-dhcp-kea
  * [CASMNET-2243](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2243) - cray-dns-unbound
  * [CASMNET-2244](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2244) - cray-dns-powerdns
  * [CASMNET-2245](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2245) - cray-powerdns-manager

## Testing

### Tested on:

  * `fanta`

### Test description:

All charts were deployed on fanta

#### cray-dhcp-kea

Verified Kea has leases
```
ncn-m001:~ # curl -sH "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq .[].text
"63 IPv4 lease(s) found."
```

#### cray-dns-unbound

Verified unbound is working as expected and has been populated by unbound-manager

```
ncn-m001:~ # host registry.local 10.92.100.225
Using domain server:
Name: 10.92.100.225
Address: 10.92.100.225#53
Aliases:

registry.local has address 10.92.100.71
```

#### cray-dns-powerdns

Verified PowerDNS is serving records

```
ncn-m001:~ # host api.cmn.fanta.hpc.amslabs.hpecorp.net 10.92.100.85
Using domain server:
Name: 10.92.100.85
Address: 10.92.100.85#53
Aliases:

api.cmn.fanta.hpc.amslabs.hpecorp.net has address 10.102.4.65
```

#### cray-powerdns-manager

Verified powerdns-manager is operating as expected

Deleted the CAN zone from PowerDNS
```
ncn-m001:~ # kubectl -n services exec -it deployment/cray-dns-powerdns -- sh
/ $ pdnsutil delete-zone can.fanta.hpc.amslabs.hpecorp.net
/ $
```
Verified it was recreated an populated
```
ncn-m001:~ # kubectl -n services exec -it deployment/cray-dns-powerdns -- sh
/ $ pdnsutil list-zone can.fanta.hpc.amslabs.hpecorp.net
$ORIGIN .
a-api.can.fanta.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-can"
a-auth.can.fanta.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-can"
a-capsules.can.fanta.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/services/cray-oauth2-proxies-customer-access-ingress"
api.can.fanta.hpc.amslabs.hpecorp.net	300	IN	A	10.102.4.161
api.can.fanta.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-can"
auth.can.fanta.hpc.amslabs.hpecorp.net	300	IN	A	10.102.4.161
auth.can.fanta.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-can"
can.fanta.hpc.amslabs.hpecorp.net	3600	IN	NS	primary.fanta.hpc.amslabs.hpecorp.net.
can.fanta.hpc.amslabs.hpecorp.net	3600	IN	SOA	primary.fanta.hpc.amslabs.hpecorp.net hostmaster.can.fanta.hpc.amslabs.hpecorp.net 2024090203 10800 3600 604800 3600
can-switch-1.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.130
can-switch-2.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.131
capsules.can.fanta.hpc.amslabs.hpecorp.net	300	IN	A	10.102.4.160
capsules.can.fanta.hpc.amslabs.hpecorp.net	300	IN	TXT	"heritage=external-dns,external-dns/owner=default,external-dns/resource=service/services/cray-oauth2-proxies-customer-access-ingress"
kubeapi-vip.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.132
ncn-m001-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s1b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-m001.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s1b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-m002-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s3b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-m002.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s3b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-m003-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s5b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-m003.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s5b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s001-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s13b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s001.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s13b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s002-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s15b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s002.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s15b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s003-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s17b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s003.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s17b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s004-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s36b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-s004.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s36b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w001-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s7b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w001.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s7b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w002-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s9b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w002.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s9b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w003-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s11b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w003.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s11b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w004-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s38b0n0.can.fanta.hpc.amslabs.hpecorp.net.
ncn-w004.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s38b0n0.can.fanta.hpc.amslabs.hpecorp.net.
time-can.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s7b0n0.can.fanta.hpc.amslabs.hpecorp.net.
uan01.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	CNAME	x3000c0s19b0n0.can.fanta.hpc.amslabs.hpecorp.net.
x3000c0s11b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.141
x3000c0s13b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.136
x3000c0s15b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.135
x3000c0s17b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.134
x3000c0s19b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.144
x3000c0s1b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.139
x3000c0s36b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.133
x3000c0s38b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.140
x3000c0s3b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.138
x3000c0s5b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.137
x3000c0s7b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.143
x3000c0s9b0n0.can.fanta.hpc.amslabs.hpecorp.net	3600	IN	A	10.102.4.142
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

