### PR TITLE
CRAYSAT-1893: Backport SAT through 3.31.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.30.2
+      - 3.31.1
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Backport `sat` from `3.30.2` to `3.31.1` ._

## Issues and Related PRs

_This includes the following fixes_

* [CRAYSAT-1884](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1884): https://github.com/Cray-HPE/sat/pull/258
* [CRAYSAT-1893](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1893): https://github.com/Cray-HPE/sat/pull/259.

## Testing

_See the linked PRs_

## Risks and Mitigations

_See the linked PRs_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

