### PR TITLE
CASMMON-435 fix metallb rules issues and vmselect pod metallb errors

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.8
+    version: 1.0.9
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
fix metallb rules issues and vmselect pod metallb errors
fix metallb rules issues and vmselect pod metallb errors
## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMMON-435
Tested on mug

solved  metallb rules issues and vmselect pod metallb errors

addressed grafana pod error failed to load dashboard from " file=/var/lib/grafana/dashboards/default/nodeexporter.json error=EOF