### PR TITLE
CASMPET-7064 / CASMPET-7065 - CFS updates to base cray-service chart.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -149,11 +149,11 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.20.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.11.0
+    version: 1.12.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.26.3
+    version: 1.27.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

These are the changes needed for the CFS services to update to the new cray-service base chart needed for the csm-1.6.0 release.

## Issues and Related PRs
* Resolves [CASMPET-7064](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7064)
* Resolves [CASMPET-7065](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7065)

## Testing
### Tested on:
  * `Fanta`

### Test description:

Installed the new version via helm (along with updated cfs-batcher), ran through image customization and post-boot personalization workflows. Also ran the cmsdev CT tests before and after the upgrade. Everything worked as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Required to match the version of k8s being shipped with csm 1.6.0

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
