### PR TITLE
CASMCMS-9129: TESTS: cmsdev: BOS test should pass if BOS migration pod exists and Succeeded

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.0-1.noarch
     - cfs-trust-1.7.3-1.noarch
-    - cray-cmstools-crayctldeploy-1.23.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.24.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.35.4-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch


### PR DESCRIPTION
Currently the cmsdev test fails if the BOS migration pod exists and is Succeeded. This is because the test does not expect that pod to exist when the test is run. Upcoming changes to BOS will make it more likely that the migration pod will still exist when the test is running. This PR updates the test to pass in this case.

No backports needed.