### PR TITLE
CASMNET-2224 -- 1.6

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -184,7 +184,7 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/cilium/alpine-curl:
       - v1.6.0
     quay.io/cilium/json-mock:
-      - v1.3.3
+      - v1.3.8
     docker.io/coredns/coredns:
       - 1.10.0
 


### PR DESCRIPTION
## Summary and Scope

- update quay.io/cilium/json-mock container image

## Issues and Related PRs

- https://jira-pro.it.hpe.com:8443/browse/CASMNET-2224
- https://github.com/Cray-HPE/container-images/pull/633

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable