### PR TITLE
CASMCMS-9135: Update CSM services to use new base chart

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -41,7 +41,7 @@ KERNEL_VERSION='6.4.0-150600.23.17-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.2.9
+KUBERNETES_IMAGE_ID=6.2.10
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -49,13 +49,13 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.2.9
+PIT_IMAGE_ID=6.2.10
 PIT_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.2.9
+STORAGE_CEPH_IMAGE_ID=6.2.10
 STORAGE_CEPH_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
     "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
@@ -63,7 +63,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.2.9
+COMPUTE_IMAGE_ID=6.2.10
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
         "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,33 +120,33 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.12.2
+    version: 1.12.3
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.7.3
+    version: 1.7.4
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.14.1
+    version: 1.14.2
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.26.3
+    version: 2.27.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.26.3/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.27.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.20.0
+    version: 1.20.1
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.20.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.20.1/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0
@@ -188,11 +188,11 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.17.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
-    version: 1.9.0
+    version: 1.10.2
     namespace: services
   - name: cray-tftp-pvc
     source: csm-algol60
-    version: 1.9.0
+    version: 1.10.2
     namespace: services
   - name: csm-config
     source: csm-algol60
@@ -230,7 +230,7 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.6.2
+    version: 1.6.3
     namespace: services
 
   - name: gitea

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -161,12 +161,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.8.0
+    version: 1.8.1
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.3.0
+    version: 2.3.1
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
@@ -180,12 +180,12 @@ spec:
             tag: 2.5.2
   - name: cray-ims
     source: csm-algol60
-    version: 3.17.0
+    version: 3.17.1
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.17.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.17.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.10.2

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,12 +25,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.26.3-1.noarch
+    - bos-reporter-2.27.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.3-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.0-1.noarch
-    - cfs-trust-1.7.3-1.noarch
+    - cfs-trust-1.7.4-1.noarch
     - cray-cmstools-crayctldeploy-1.24.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.35.5-1.x86_64
@@ -42,8 +42,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.7-1.aarch64
     - csm-node-heartbeat-2.7-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
-    - csm-ssh-keys-1.6.2-1.noarch
-    - csm-ssh-keys-roles-1.6.2-1.noarch
+    - csm-ssh-keys-1.6.3-1.noarch
+    - csm-ssh-keys-roles-1.6.3-1.noarch
     - csm-testing-1.17.31-1.noarch
     - goss-servers-1.17.30-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64


### PR DESCRIPTION
This pulls in updates for the following CMS services/modules:
* bos
* cfs-hwsync-agent
* cfs-trust
* cms-ipxe
* cms-tftpd
* cfs
* csm-ssh-keys

The primary change was to use the update `cray-services` base chart, but this also pulls in some other minor fixes and dependency updates.

`node-images` PR: https://github.com/Cray-HPE/node-images/pull/1150