### PR TITLE
CASMINST-7000: hooks scripts should call system copy of docs-csm scripts

### DIFF
--- a/hooks/pre-install-check-prehook.sh
+++ b/hooks/pre-install-check-prehook.sh
@@ -81,7 +81,7 @@ fi
 
 # run the pre-requisites script to set up nexus, s3, vcs and updating the cray-product-caralog 
 echo "INFO Setting up the prerequisites for CSM upgrade"
-result=$(docs/upgrade/scripts/upgrade/prerequisites.sh --csm-version "${CSM_RELEASE}" 2>&1)
+result=$(/usr/share/doc/csm/upgrade/scripts/upgrade/prerequisites.sh --csm-version "${CSM_RELEASE}" 2>&1)
 if [ $? -ne 0 ]; then
     echo "ERROR Setting up prerequisites for CSM upgrade failed: ${result}"
     exit 1


### PR DESCRIPTION
Currently one of the scripts in the hooks directory calls a docs-csm script inside the tarball, rather than the one installed on the system. This PR modifies that script (`hooks/pre-install-check-prehook.sh`) to correct this.

No backports needed as these scripts are new in CSM 1.6