### PR TITLE
CASMCMS-9132 - update cfs-ara, gitea, cray-product-catalog for k8s 1.24.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -116,7 +116,7 @@ spec:
   # CMS
   - name: cfs-ara
     source: csm-algol60
-    version: 1.2.0
+    version: 1.3.0
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
@@ -177,7 +177,16 @@ spec:
       cray-import-kiwi-recipe-image:
         import_image:
           image:
+            # The following version needs to match the above cray-csm-barebones-recipe-install
+            # version. Due to included helm charts, it needs to be overridden here as well.
             tag: 2.5.2
+        catalog:
+          image:
+            # The following version is the cray-product-catalog version.
+            # Unless there is a specific reason not to, this version should be
+            # updated whenever the cray-product-catalog chart version is updated, and
+            # vice versa.
+            tag: 2.4.0
   - name: cray-ims
     source: csm-algol60
     version: 3.17.0
@@ -206,7 +215,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.3.1
+            tag: 2.4.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -235,7 +244,7 @@ spec:
 
   - name: gitea
     source: csm-algol60
-    version: 2.7.0
+    version: 2.8.0
     namespace: services
 
   # Cray Product Catalog
@@ -244,7 +253,8 @@ spec:
     # Unless there is a specific reason not to, this version should be
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
-    version: 2.3.1
+    # Also update the catalog:image:tag value in the barebones recipe section.
+    version: 2.4.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

Update base charts and base images to match k8s 1.24 for csm-1.6.0.

## Issues and Related PRs
* Resolves [CASMCMS-9132](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9132)
* Resolves [CASMCMS-9133](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9133)
* Resolves [CASMCMS-9134](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9134)

## Testing
### Tested on:
  * `Fanta` and `Mug`

### Test description:

Installed new versions via loftsman, verified everything works correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk changes to pull in modifications in base charts and images to match k8s upgrade to 1.24.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

