### PR TITLE
CASMPET-7219 update cray-nls cray-iuf cray-sts chart versions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -216,7 +216,7 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.8.2
+    version: 0.8.3
     namespace: services
     swagger:
     - name: sts
@@ -252,11 +252,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.14
+    version: 4.0.15
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.14
+    version: 4.0.15
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

This PR updates cray-nls, cray-iuf, and cray-sts chart versions. Each of these charts were updated to pick up cray-service version 11.0.0 for k8s 1.24 in CSM 1.6.

## Issues and Related PRs

* Relates to [CASMPET-7219](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7219)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * On beau, I upgraded cray-nls and cray-sts charts and both upgraded successfully.
  
## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

