### PR TITLE
CASMMON-432,CASMTRIAGE-7282 and CASMMON-436  fix set metricsBindAddress and VMINSERT drop metrics more labels

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.0.9
+    version: 1.0.10
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

CASMMON-436 - Migrate all the VM Rules to maintain consistency.
CASMMON-432 & CASMTRIAGE-7282 fix set metricsBindAddress and VMINSERT drop metrics more labels

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMMON-432
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7282
CASMMON-436

## Testing

_List the environments in which these changes were tested._

### Tested on: mug



VM not dropping metrics with morethan 40 lebels
 kubectl logs -n sysmgmt-health vminsert-vms-68d95cdfc7-92tmg
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:12   build version: vminsert-20231212-224957-tags-v1.96.0-cluster-0-gd59ee93d0
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:13   command-line flags
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -httpListenAddr=":8480"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -maxLabelsPerTimeseries="100"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -replicationFactor="2"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -storageNode="vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400,vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/app/vminsert/main.go:100        initializing netstorage for storageNodes [vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400 vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400]...
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/lib/memory/memory.go:42 limiting caches to 1288490188 bytes, leaving 858993460 bytes to the OS according to -memory.allowedPercent=60
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/app/vminsert/main.go:119        successfully initialized netstorage in 0.001 seconds
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/lib/httpserver/httpserver.go:101        starting http server at http://127.0.0.1:8480/
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/lib/httpserver/httpserver.go:102        pprof handlers are exposed at http://127.0.0.1:8480/debug/pprof/
2024-09-11T03:29:17.814Z        warn    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:269       cannot dial storageNode "vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400": dial tcp4: lookup vmstorage-vms-1.vmstorage-vms.sysmgmt-health on 10.16.0.10:53: no such host
2024-09-11T03:29:17.814Z        warn    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:269       cannot dial storageNode "vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400": dial tcp4: lookup vmstorage-vms-0.vmstorage-vms.sysmgmt-health on 10.16.0.10:53: no such host
2024-09-11T03:29:47.224Z        info    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:273       successfully dialed -storageNode="vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400"
2024-09-11T03:29:47.227Z        info    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:273       successfully dialed -storageNode="vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400"


![image](https://github.com/user-attachments/assets/03a0d241-ea35-4d4a-9e66-a62106e03678)


ncn-m001:/mnt/developer/shreni/alerts # kubectl get vmrule -n sysmgmt-health
NAME                                                       AGE
cray-sysmgmt-health-ceph-prometheus-alert.rules            6d2h
cray-sysmgmt-health-ceph-prometheus.rules                  6d2h
cray-sysmgmt-health-disk-space.rules                       6d2h
cray-sysmgmt-health-etcd                                   78m
cray-sysmgmt-health-general.rules                          78m
cray-sysmgmt-health-istio-alerts.rules                     6d2h
cray-sysmgmt-health-kea-dhcp-alerts.rules                  6d2h
cray-sysmgmt-health-kube-apiserver-slos                    68m
cray-sysmgmt-health-kube-state-metrics                     68m
cray-sysmgmt-health-kubernetes-apps                        68m
cray-sysmgmt-health-kubernetes-resources                   65m
cray-sysmgmt-health-kubernetes-storage                     68m
cray-sysmgmt-health-kubernetes-system                      68m
cray-sysmgmt-health-kubernetes-system-apiserver            68m
cray-sysmgmt-health-kubernetes-system-controller-manager   68m
cray-sysmgmt-health-kubernetes-system-kubelet              68m
cray-sysmgmt-health-kubernetes-system-scheduler            83m
cray-sysmgmt-health-mdraid-prometheus-alert.rules          6d2h
cray-sysmgmt-health-node-exporter                          81m
cray-sysmgmt-health-node-network                           83m
cray-sysmgmt-health-postgresql-prometheus-alert.rules      6d2h
cray-sysmgmt-health-switch-alerts.rules                    6d2h