### PR TITLE
CRAYSAT-1841: Backport SAT through 3.32.0

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.31.1
+      - 3.32.0
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Backport `sat` from 3.31.1 to 3.32.0 ._

## Issues and Related PRs

- Resolves [CRAYSAT-1841](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1841): https://github.com/Cray-HPE/sat/pull/263

## Testing

_See the linked PR._

## Risks and Mitigations

_See the linked PR._


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

