### PR TITLE
MTL-1980 - Configure a bonded HSN connection on an NCN

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.24.2
+    version: 1.25.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Ansible role to configure a bonded HSN interface on NCNs.

This role is not enabled by default as it requires values that have to be supplied by the Slingshot administrator.

## Issues and Related PRs

* Resolves [MTL-1980](https://jira-pro.it.hpe.com:8443/browse/MTL-1980)
* Documentation changes to follow in [MTL-1981](https://jira-pro.it.hpe.com:8443/browse/MTL-1981)

## Testing

### Tested on:

  * `surtur`

### Test description:

Rebuilt ncn-w005 with Playbook enabled with the following settings
```
hsn_bond_mac: "b2:00:00:00:00:01"
hsn_bond_ip: "10.253.254.1"
hsn_bond_netmask: '255.255.0.0'
hsn_bond_enable: true
```
Verified bond was configured as expected.
```
Running ncn_hsn_bonding.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Configure HSN bonding] ***************************************************

TASK [csm.ncn.hsn_bonding : Create routing table] ******************************
changed: [x3000c0s31b0n0]

TASK [csm.ncn.hsn_bonding : Create macvlan interface definitions] **************
changed: [x3000c0s31b0n0] => (item=['hsn0', 'macvlan0'])
changed: [x3000c0s31b0n0] => (item=['hsn1', 'macvlan1'])

TASK [csm.ncn.hsn_bonding : Create bond interface] *****************************
changed: [x3000c0s31b0n0]

TASK [csm.ncn.hsn_bonding : Set bond sysctl values] ****************************
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.accept_local', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_filter', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_announce', 'value': 2})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_ignore', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_notify', 'value': 0})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_accept', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.drop_gratuitous_arp', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.rp_filter', 'value': 0})

TASK [csm.ncn.hsn_bonding : Set arp_filter sysctl for HSN NICs] ****************
changed: [x3000c0s31b0n0] => (item=hsn0)
changed: [x3000c0s31b0n0] => (item=hsn1)

TASK [csm.ncn.hsn_bonding : Set arp_ignore sysctl for HSN NICs] ****************
changed: [x3000c0s31b0n0] => (item=hsn0)
changed: [x3000c0s31b0n0] => (item=hsn1)

TASK [csm.ncn.hsn_bonding : Generate bond1 post-up script] *********************
changed: [x3000c0s31b0n0]
FAILED - RETRYING: Reload interfaces (3 retries left).

RUNNING HANDLER [csm.ncn.hsn_bonding : Reload interfaces] **********************
changed: [x3000c0s31b0n0]

PLAY RECAP *********************************************************************
x3000c0s31b0n0             : ok=11   changed=8    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
Rebooted ncn-w005, verified bond came up before CFS ran and that the Ansible playbook didn't perform any unnecessary configuration actions.
```
Running ncn_hsn_bonding.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Configure HSN bonding] ***************************************************

PLAY RECAP *********************************************************************
x3000c0s31b0n0             : ok=10   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```

## Risks and Mitigations

- Role is not enabled out of the box, it must be explicitly enabled.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

