### PR TITLE
CASMPET-7225: iSCSI SBPS: Fallback to default IMS user policy for CPS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.24.2
+    version: 1.26.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
  - iSCSI SBPS: fix to fallback to default IMS user policy for CPS to function

## Summary and Scope
We must have writable access to "/var/lib/cps-local/boot-images" mount directory of "boot-images" bucket order for CPS to function. CPS creates cos-config-data under "/var/lib/cps-local/boot-images"(information for the contents projected by DVS.  User also need write access while removing cos-config-data under "/var/lib/cps-local/boot-images", when he wants to disable CPS.

Since for CSM-1.6 and USS-1.2 we are supporting CPS, we need to make it writable.  When CPS will be removed in USS-1.3, we can fallback again to dedicated s3fs read-only policy.

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7225

## Testing

bare metal surtur

### Tested on:

bare metal surtur

### Test description:
Verified sbps-marshal agent referring to earlier IMS s3 credential file for image mapping (from "boot-images" bucket) along with verification of node personalization with CFS plays (with disablement of s3fs mount of boot-images bucket with new read only policy and observed that it fallback to default IMS user policy for image mapping and s3fs mount of "boot-images" bucket.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

