### PR TITLE
CASMTRIAGE-6953: IMS import tool: More accurately determine IMS data file paths

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -189,12 +189,12 @@ spec:
             tag: 2.4.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.17.1
+    version: 3.17.2
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.17.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.17.2/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.10.2


### PR DESCRIPTION
No backports needed