### PR TITLE
Update sbps-marshal rpm version to include,

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -65,7 +65,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python311-requests-retry-session-0.1.5-1.noarch
     - python312-requests-retry-session-0.1.5-1.noarch
     - python39-requests-retry-session-0.1.5-1.noarch
-    - sbps-marshal-0.0.6-1.noarch
+    - sbps-marshal-0.0.7-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
 - Fix for "CASMPET-7225: iSCSI SBPS: Fallback to default IMS user policy for CPS"
 - CASMPET-7214: Documentation for Goss tests for iSCSI SBPS

## Summary and Scope

[1] **CASMPET-7225: iSCSI SBPS: Fallback to default IMS user policy for CPS:** Need write access "/var/lib/cps-local/boot-images" (mount path of boot-images bucket) for CPS to function or when user want to disable CPS. Need to fallback from current s3 read only policy to default IMS user policy till CPS is removed.
[2] **CASMPET-7214:** Need to document Goss tests for iSCSI SBPS

## Issues and Related PRs
https://github.com/Cray-HPE/sbps-marshal/pull/13
https://github.com/Cray-HPE/sbps-marshal/pull/12

## Testing

bare metal surtur

### Tested on:

bare metal surtur

### Test description:

Verified sbps-marshal agent referring to earlier IMS s3 credential file for image mapping (from "boot-images" bucket) along with verification of node personalization with CFS plays (with disablement of s3fs mount of boot-images bucket with new read only policy and observed that it fallback to default IMS user policy for image mapping and s3fs mount of "boot-images" bucket.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

