### PR TITLE
CASMPET-7221 - Remove unused docker-kubectl reference

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -45,7 +45,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.4 # update platform.yaml cray-precache-images with this
+    version: 0.11.5 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -71,7 +71,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.4
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.5
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

Removing specific override so that the correct version in the cray-service chart is used.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`

### Test description:

Deployed new chart on surtur, verified service came up as expected and verified Kea has leases.

```
ncn-m001:~ # curl -sH "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq  .[].text
"69 IPv4 lease(s) found."
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

