### PR TITLE
FAS Chart to 3.1.8 to fix envro var issue

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,7 +53,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.6
+    version: 3.1.8
     namespace: services
     swagger:
     - name: firmware-action


### PR DESCRIPTION
## Summary and Scope

FAS Chart 3.1.8 fixes an error in the enviro var without quotes from chart 3.1.7

## Issues and Related PRs

CASMHMS-6259
