### PR TITLE
CASMCMS-9142: Fix build problem with cray-product-catalog

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -186,7 +186,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.4.0
+            tag: 2.4.1
   - name: cray-ims
     source: csm-algol60
     version: 3.17.2
@@ -215,7 +215,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.4.0
+            tag: 2.4.1
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -254,7 +254,7 @@ spec:
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
     # Also update the catalog:image:tag value in the barebones recipe section.
-    version: 2.4.0
+    version: 2.4.1
     namespace: services
 
   # Spire service


### PR DESCRIPTION
This updates the product catalog version. There is no functional difference -- this new version just addresses a build issue, so it will be re-buildable, unlike the current version.