### PR TITLE
CRAYSAT-1902: Backport sat-container to 3.32.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.0
+      - 3.32.1
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Backport sat container through 3.32.1_

## Issues and Related PRs

_Resolves [CRAYSAT-1902](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1902): https://github.com/Cray-HPE/sat/pull/264._

## Testing

_See the linked PR._

## Risks and Mitigations

_See the linked PR_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

