### PR TITLE
CASMHMS-6279: Fix tavern functional test for new eth int name and fix CT/Unit test pipeline

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.5.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.17
+    version: 7.1.18
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
## Summary and Scope

Changes included in this fix:

- Updated tavern functional test to match the ethernet interface name that the customer in the CAST is using
- Fix broken pipeline CT/Unit tests by using "docker compose" instead of "docker-compose"

Adopted app version 2.29.0 for CSM 1.6 (helm chart 7.1.18)

## Issues and Related PRs

* Resolves [CASMHMS-6279](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6279)

## Testing

Tested on:

  * `tyr`

Test description:

Upgraded to new chart on tyr and ran `run_hms_ct_tests.sh -t hsm` to ensure functional tests still ran correctly.  I'm not aware of any systems that have a similar interface name as the one described in the CAST so that aspect could not be tested.  However, this is an extremely simple change very unlikely to be incorrect or cause issues.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

