### PR TITLE
CASMTRIAGE-7252: Increase default IMS image build size

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -189,12 +189,12 @@ spec:
             tag: 2.4.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.17.2
+    version: 3.18.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.17.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.18.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.10.2


### PR DESCRIPTION
This just updates the default amount of space IMS allocates for image roots when building, to prevent failures that have been reported.

No backports.