### PR TITLE
CASMTRIAGE-7221: Sat unable to pull image

### DIFF
--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -42,6 +42,9 @@ nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp5"         "csm-${RELEASE_VERS
 nexus-upload raw "${ROOTDIR}/rpm/cray/csm/sle-15sp6"         "csm-${RELEASE_VERSION}-sle-15sp6"
 nexus-upload raw "${ROOTDIR}/rpm/embedded"                   "csm-${RELEASE_VERSION}-embedded"
 
+# Update the cray-sat-podman package to ensureversion consistency
+zypper update cray-sat-podman
+
 clean-install-deps
 
 set +x


### PR DESCRIPTION
## Summary and Scope

_Sat unable to pull the image on Tyr after a CSM 1.6.0-alpha.55 upgrade_
_Solution: Add a zypper update cray-sat-podman after CSM 1.6 RPMs are uploaded to Nexus_

## Issues and Related PRs

_Resolves [CASMTRIAGE-7221](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7221)._

## Testing

_List the environments in which these changes were tested._

### Tested on:

  starlord

### Test description:

_Test the setup-nexus.sh script of management nodes rollout stage when upgrading starlord from sm 1.5 to to 1.6_

## Risks and Mitigations

_Low_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

