### PR TITLE
CRAYSAT-1911: Update the csm-manifest to have latest sat-container

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -28,7 +28,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.1
+      - 3.32.4
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Backport the sat container to 3.32.4_

## Issues and Related PRs

_This backports the following fixes._

1. [CASMTRIAGE-7272](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7272):
-  https://github.com/Cray-HPE/python-csm-api-client/pull/40
-  https://github.com/Cray-HPE/sat/pull/267

2. [CRAYSAT-1843](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1843), [CRAYSAT-1899](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1899): 
- https://github.com/Cray-HPE/sat/pull/268

3. [CRAYSAT-1900](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1900): https://github.com/Cray-HPE/sat/pull/265


## Testing

_See the linked PRS._

## Risks and Mitigations

_See the linked PRs_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

