### PR TITLE
CASMSEC-499 : Fix CVEs in artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.3
+    version: 1.6.4
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bitnami kubectl 1.26.4 has been reported with many critical CVE's hence changing the cray-kyverno chart to use higher version of bitnami which 1.31.0.
cray-kyverno 1.6.4 will be using 1.31.0 of bitnami kubectl. This is the latest version of bitnami kubectl.

Testing
Kyverno installation, upgrade, rollback, policy listing, policy reports.

Tested on:
Surtur

Test description:
[CASMSEC-499-arti-chart-log.txt](https://github.com/user-attachments/files/17186790/CASMSEC-499-arti-chart-log.txt)
