### PR TITLE
Add 1 parameter as iuf to pass exit code 1 condition in csm-testing goss framework

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -260,7 +260,7 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.15.5
+    version: 2.15.6
     namespace: spire
   - name: cray-spire
     source: csm-algol60


### PR DESCRIPTION

## Summary and Scope

 Add 1 parameter as iuf to pass exit code 1 condition in csm-testing goss framework This condition in ncn-k8s-combined-healthcheck-post-service-upgrade script from goss-test to know its called through iuf and return exit code 1 if there is a test case failure

## Issues and Related PRs

CASMTRIAGE-7320

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * surtur

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
yes
- Were continuous integration tests run?
yes
- Was upgrade tested?
yes
- Was downgrade tested?
yes

## Risks and Mitigations

No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

