### PR TITLE
CASMHMS-6281 BSS change to print imgstat after initrd download

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.2.2
+    version: 3.2.3
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

BSS changed to print imgstat after initrd download

## Issues and Related PRs

* Resolves [CASMHMS-6281](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6281)

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

