### PR TITLE
CASMNET-2249 canu container CVE

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -23,8 +23,6 @@
 #
 artifactory.algol60.net/csm-docker/stable:
   images:
-    canu:
-      - 1.7.6
 
     # cray-sat is not included in any Helm charts
     cray-sat:


### PR DESCRIPTION
With CASMNET-2254 we are no longer shipping the canu container.
