### PR TITLE
CASMPET-7242: use updated pause and alpine images

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -56,7 +56,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.5
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -260,11 +260,11 @@ spec:
   # Spire service
   - name: spire
     source: csm-algol60
-    version: 2.15.6
+    version: 2.15.7
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.5
+    version: 1.6.6
     namespace: spire
 
   # Tapms service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.17.33-1.noarch
-    - goss-servers-1.17.30-1.noarch
+    - csm-testing-1.17.34-1.noarch
+    - goss-servers-1.17.34-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Use updated pause and alpine images for CSM 1.6 release.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7242](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7242)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

