### PR TITLE
CASMTRIAGE-7301: Fix bug causing iSCSI configuration playbook to fail

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.26.0
+    version: 1.26.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
This fixes a bug in `csm-config` that was preventing the iSCSI configuration playbook from succeeding.

Source PR:
https://github.com/Cray-HPE/csm-config/pull/305

Jira:
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7301