### PR TITLE
CASMTRIAGE-7187: pre-install-check displays "failed to upgrade kyverno-policy chart"

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.4
+    version: 1.6.5
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Intermittently, Kyverno timeout issues is encountered during CSM upgrade. By introducing delay in post install hook we are forcing to wait till Kyverno pods are stabilized and then going ahead with Kyverno policy upgrade.

## Testing

Kyverno Installation, Rollback, policy status, policy report, cluster policy status.

### Tested on:

MUG

### Test description:

[kyverno_logs_1_5_5_to_1_6_5.txt](https://github.com/user-attachments/files/17253910/kyverno_logs_1_5_5_to_1_6_5.txt)
[kyverno_logs_1_6_0_to_1_6_5.txt](https://github.com/user-attachments/files/17253911/kyverno_logs_1_6_0_to_1_6_5.txt)
[kyverno_logs_1_6_5_fresh_install.txt](https://github.com/user-attachments/files/17253912/kyverno_logs_1_6_5_fresh_install.txt)
[kyverno_logs_1_6_5_to_1_6_6.txt](https://github.com/user-attachments/files/17254360/kyverno_logs_1_6_5_to_1_6_6.txt)


