### PR TITLE
CASMTRIAGE-7359 Fix reference to bitnami/kubectl image in cray-precache-images config

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -67,7 +67,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
+      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS


### PR DESCRIPTION
## Summary and Scope

CASMSEC-499 updated version of `artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl` image to `1.31.0`, but reference in `cray-precache-images` chart config was not updated. This results in failure during upgrade, because upgrade script uses `cray-precache-images` config to pre-cache images before nexus upgrade.

## Issues and Related PRs

* Resolves CASMTRIAGE-7359
* caused by CASMSEC-499

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Updated `cray-precache-images` configmap manually, re-ran upgrade.

## Risks and Mitigations

Not known - fixing what's already broken.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

