### PR TITLE
CASMTRIAGE-7259: Update hnc-manager for stability (1.6)

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -265,7 +265,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.10/docs/NLS_swagger.yaml
   - name: cray-hnc-manager
     source: csm-algol60
-    version: 0.1.0
+    version: 0.1.1
     namespace: hnc-system
     timeout: 10m0s
   - name: cray-k8s-encryption


### PR DESCRIPTION
## Summary and Scope

Improves hnc-manager stability.  Previously this pod was showing hundreds or even thousands of restarts on every system, and in some cases this was interfering with tenant creation.

## Issues and Related PRs

* Resolves CASMTRIAGE-7259

## Testing

### Tested on:

  * Noname and Fanta

### Test description:

Verified the stability via the logs, and verified the ability to create multiple tenants.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

