### PR TITLE
CASMTRIAGE-7355: Update tapms to fix tenant deletion (1.6)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -270,13 +270,13 @@ spec:
   # Tapms service
   - name: cray-tapms-crd
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: tapms-operator
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: tapms-operator
     swagger:
     - name: tapms-operator
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.7.0/docs/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.7.1/docs/openapi.yaml


### PR DESCRIPTION
## Summary and Scope

Fixes an issue where deletion events were triggering the mutation web hook, which does not receive the old object information and fails.  Now only validation web hooks will trigger the delete events.

## Issues and Related PRs

* Resolves CASMTRIAGE-7355

## Testing

### Tested on:

  * Fanta

### Test description:

Validated tenant creation, update and deletion.  Previously tenants could not be deleted.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

