### PR TITLE
CASMHMS-6284: Update cray-hms-rts-snmp chart version for Kubernetes 1.24

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -96,7 +96,7 @@ spec:
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
-    version: 4.0.2
+    version: 5.0.0
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

This PR to update cray-hms-rts-snmp chart version that was missed by the prior CSM PR for CASMHMS-6261.  cray-hms-rts was updated but cray-hms-rts-snmp was missed when both should update in unison.

In CSM 1.6 Kubernetes is being updated to 1.24.  This PR updates all of the dependencies in most of the HMS charts.

- Updated cray-service to 11.0.0 where applicable
- Updated docker-kubectl to 1.24.17 where applicable

## Issues and Related PRs

* Resolves [CASMHMS-6284](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6284)

## Testing

Tested on:

  * `fanta` (running Kubernetes v1.24.17)

Test description:

All testing was done with the new cray-service 10.0.6. After testing completed, was asked to use 11.0.0 instead of 10.0.6 but was informed that no testing of 11.0.0 was required to be done if already tested with 10.0.6 because it is the exact same, just a different version number.

- Upgraded to new charts with 'helm upgrade'
- Because pods don't restart after upgrade if there was no container change, manually restarted them with 'kubectl rollout restart deployment'
- Verified no errors in chart upgrade or restart of pods
- Ran CT tests where they existed
- Checked logs from service to verify nothing unusual present

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? N (none exist)
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable