### PR TITLE
CASMTRIAGE-7373: Fix SBPS Spire hard link location

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.26.1
+    version: 1.26.2
     namespace: services
     values:
       cray-import-config:

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -65,7 +65,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python311-requests-retry-session-0.1.5-1.noarch
     - python312-requests-retry-session-0.1.5-1.noarch
     - python39-requests-retry-session-0.1.5-1.noarch
-    - sbps-marshal-0.0.7-1.noarch
+    - sbps-marshal-0.0.8-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
I am creating this manifest PR on behalf of @ravikanth-nalla-hpe , since it's night time for him right now. This fixes [CASMTRIAGE-7373](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7373) by:
* updating the `sbps-marshal` RPM to create its hard link in the correct location
* updating `csm-config` to require the new RPM version and to reference the new hard link location.
