### PR TITLE
CASM-4908 Runtime container image signature validation

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -47,8 +47,8 @@ pipeline {
         ARTIFACTORY = credentials('artifactory-algol60-readonly')
         PARALLEL_JOBS = "75%"
         SNYK_TOKEN = credentials('SNYK_TOKEN')
-        SLACK_CHANNEL_NOTIFY = "${isPublishedRelease() ? "#casm_release_management" : ""}"
-        SLACK_CHANNEL_ALERTS = "${isPublishedRelease() ? "#csm-release-alerts" : ""}"
+        SLACK_CHANNEL_NOTIFY = "${env.TAG_NAME ? "@mikhail.tupitsyn" : ""}"
+        SLACK_CHANNEL_ALERTS = ""
     }
 
     stages {
@@ -275,20 +275,22 @@ pipeline {
                 - Deprecated API usage: <${env.BUILD_URL}/artifact/dist/pluto-report.txt|pluto-report.txt>
                 - Snyk results: <${env.SNYK_RESULTS_SHEET_URL}|${env.SNYK_RESULTS_SHEET}> (raw scan results: <${env.SNYK_RESULTS_URL}|${env.SNYK_RESULTS_FILENAME}>)
                 """.stripIndent().trim())
-                if ( isPublishedRelease() ) {
+                if ( env.TAG_NAME ) {
                     // Fresh install current build on yasha
-                    build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
+                    build(job: "Cray-HPE/csm-vshasta-deploy/feature%2Fidempotency-scale-kyverno", wait: false, parameters: [
                         // Test fresh installs on yasha
-                        string(name: "ENVIRONMENT", value: "yasha"),
+                        string(name: "ENVIRONMENT", value: "scanlan"),
                         // Install version which was just built
                         string(name: "CSM_RELEASE", value: env.RELEASE_VERSION),
                         // Where to report results
-                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY)
+                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY),
+                        // string(name: "POSTINSTALL_DESTROY", value: "on_success"),
+                        string(name: "DOCS_CSM_VERSION", value: csmUtils.findDocsCsmByBranch("feature/prepend-registry"))
                     ])
                     // Upgrade last previous release to current build on vex
-                    build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
+                    build(job: "Cray-HPE/csm-vshasta-deploy/feature%2Fidempotency-scale-kyverno", wait: false, parameters: [
                         // Test upgrades on vex
-                        string(name: "ENVIRONMENT", value: "vex"),
+                        string(name: "ENVIRONMENT", value: "taryon"),
                         // Automatically evaluate last previous release e.g. 1.4.3
                         string(name: "CSM_RELEASE", value: ""),
                         // Upgrade to what had been just built
@@ -296,11 +298,14 @@ pipeline {
                         // Upgrade after fresh install
                         booleanParam(name: "UPGRADE", value: true),
                         // Where to report
-                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY)
+                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY),
+                        // string(name: "LGI_BRANCH", value: "feature/idempotency-scale-kyverno"),
+                        // string(name: "POSTINSTALL_DESTROY", value: "never"),
+                        string(name: "DOCS_CSM_VERSION_UPGRADE", value: csmUtils.findDocsCsmByBranch("feature/prepend-registry"))
                     ])
-                    build(job: "Cray-HPE/csm-release-internal-upload/main", wait: false, parameters: [
-                        string(name: "RELEASE_VERSION", value: "${env.RELEASE_VERSION}"),
-                    ])
+                    // build(job: "Cray-HPE/csm-release-internal-upload/main", wait: false, parameters: [
+                    //     string(name: "RELEASE_VERSION", value: "${env.RELEASE_VERSION}"),
+                    // ])
                 }
             }
         }

--- a/assets.sh
+++ b/assets.sh
@@ -41,34 +41,34 @@ KERNEL_VERSION='6.4.0-150600.23.17-default'
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.2.28
+KUBERNETES_IMAGE_ID=6a06182-1729191915803
 KUBERNETES_ASSETS=(
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/initrd.img-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.xz"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/kubernetes/${KUBERNETES_IMAGE_ID}/initrd.img-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.xz"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.2.28
+PIT_IMAGE_ID=6a06182-1729191915803
 PIT_ASSETS=(
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.2.28
+STORAGE_CEPH_IMAGE_ID=6a06182-1729191915803
 STORAGE_CEPH_ASSETS=(
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/initrd.img-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.xz"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/initrd.img-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.xz"
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.2.28
+COMPUTE_IMAGE_ID=6a06182-1729191915803
 for arch in "${CN_ARCH[@]}"; do
     eval "COMPUTE_${arch}_ASSETS"=\( \
-        "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \
-        "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/${KERNEL_VERSION}-${COMPUTE_IMAGE_ID}-${arch}.kernel" \
-        "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/initrd.img-${COMPUTE_IMAGE_ID}-${arch}.xz" \
+        "https://artifactory.algol60.net/artifactory/csm-images/unstable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \
+        "https://artifactory.algol60.net/artifactory/csm-images/unstable/compute/${COMPUTE_IMAGE_ID}/${KERNEL_VERSION}-${COMPUTE_IMAGE_ID}-${arch}.kernel" \
+        "https://artifactory.algol60.net/artifactory/csm-images/unstable/compute/${COMPUTE_IMAGE_ID}/initrd.img-${COMPUTE_IMAGE_ID}-${arch}.xz" \
     \)
 done
 

--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -95,7 +95,8 @@ function extract-images() {
     ## Second: attempt to extract images from fully templated manifests (avoiding CRDs)
 
     # cray-service chart refers to postgresql.connectionPooler image as .dockerImage
-    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition") | .. | (.image?, .dockerImage?) | select(type == "!!str")' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
+    # ClusterPolicy in kyverno-policies chart may have "image:" field which has nothing to do with image definitions
+    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition" and .kind? != "ClusterPolicy") | .. | (.image?, .dockerImage?) | select(type == "!!str")' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
 
     ## Third: support "{image: {repository: aaa, tag: bbb}}" construct from cray-sysmgmt-health chart
     printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition") | .. | select(.image?|type == "!!map") | (.image.repository + ":" + .image.tag)' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"

--- a/build/images/inspect.sh
+++ b/build/images/inspect.sh
@@ -11,27 +11,17 @@ function usage() {
     exit 255
 }
 
-function resolve_canonical() {
-    local image="${1#docker://}"
-    if [[ "${image}" != *.*:* ]]; then
-        # alpine:latest > docker.io/library/alpine:latest
-        echo "docker.io/library/${image}"
-    else
-        # nothing needs to be changed
-        echo "${image}"
-    fi
-}
-
-# All images must come from artifactory.algol60.net/csm-docker/stable. Otherwise, we
-# can't guarantee reproducibility of builds, when CSM_BASE_VERSION is set.
+# We don't pull external images into CSM, all images must come from artifactory.algol60.net and have
+# valid signature.
 function resolve_mirror() {
-    local image="${1#docker://}"
-    if [[ "$image" == artifactory.algol60.net/csm-docker/stable/* ]]; then
+    local image="${1}"
+    if [[ "$image" == artifactory.algol60.net/* ]]; then
         # nothing needs to be changed
         echo "${image}"
     else
         # docker.io/library/alpine:latest > artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:latest
         # quay.io/skopeo/stable:v1.4.1 > artifactory.algol60.net/csm-docker/stable/quay.io/skopeo/stable:v1.4.1
+        # quay.io/reactiveops/ci-images:v11-alpine > artifactory.algol60.net/csm-docker/stable/quay.io/reactiveops/ci-images:v11-alpine
         echo "artifactory.algol60.net/csm-docker/stable/${image}"
     fi
 }
@@ -39,8 +29,7 @@ function resolve_mirror() {
 [[ $# -gt 0 ]] || usage
 
 while [[ $# -gt 0 ]]; do
-    # Resolve image to canonical form, e.g., alpine -> docker.io/library/alpine
-    image="$(resolve_canonical "${1#docker://}")"
+    image="${1#registry.local/}"
 
     # Resolve image as an artifactory.algol60.net mirror
     image_mirror="$(resolve_mirror "$image")"

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -110,6 +110,16 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/zeromq/zeromq:
       - v4.0.5
 
+    # During 1.5 > 1.6 upgrade, pre-upgrade Helm hooks do restarts of etcd and kafka clusters.
+    # We need to include older 1.5 images again into 1.6, to re-upload them to Nexus, together
+    # with their signatures. Otherwise restarted services won't start, claiming absence of signatures.
+    docker.io/bitnami/etcd:
+      - 3.5.9-debian-11-r15-patch
+    docker.io/bitnami/bitnami-shell:
+      - 11-debian-11-r128
+    quay.io/strimzi/kafka:
+      - 0.27.1-noJSM-chainsaw-kafka-2.8.1
+
     # XXX Missing from a SPIRE chart?
     gcr.io/spiffe-io/oidc-discovery-provider:
       - 0.12.2

--- a/hack/embedded-repo.sh
+++ b/hack/embedded-repo.sh
@@ -12,9 +12,9 @@ if [ $# -ne 1 ] || ([ "${1}" != "--validate" ] && [ "${1}" != "--download" ]); t
     echo "Lists of packages and repo configurations, installed onto NCN images, "
     echo "are expected to be published along with NCN image files as:"
     echo ""
-    echo "    csm-images/stable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.packages"
-    echo "    csm-images/stable/<ncn_type>/<ncn_version>/installed.deps-<ncn_version>-<arch>.packages"
-    echo "    csm-images/stable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.repos"
+    echo "    csm-images/unstable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.packages"
+    echo "    csm-images/unstable/<ncn_type>/<ncn_version>/installed.deps-<ncn_version>-<arch>.packages"
+    echo "    csm-images/unstable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.repos"
     echo ""
     echo "With --validate, validate presence of all RPM packages in repositories."
     echo "With --download, download RPMs into ${BUILDDIR}/rpm/embedded, filtering out those which are alredy in ${BUILDDIR}/rpm,"
@@ -34,7 +34,7 @@ for LIST_TYPE in installed installed.deps; do
         "pre-install-toolkit/${PIT_IMAGE_ID}/${LIST_TYPE}-${PIT_IMAGE_ID}-${NCN_ARCH}.packages" \
         "kubernetes/${KUBERNETES_IMAGE_ID}/${LIST_TYPE}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.packages" \
         "storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${LIST_TYPE}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.packages"; do
-            curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/stable/${LIST_URL}"
+            curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/unstable/${LIST_URL}"
     done
 done | tr '=' '-' | sort -u > "${TMPDIR}/ncn.rpm-list"
 
@@ -53,7 +53,7 @@ for REPOS_URL in \
     "pre-install-toolkit/${PIT_IMAGE_ID}/installed-${PIT_IMAGE_ID}-${NCN_ARCH}.repos" \
     "kubernetes/${KUBERNETES_IMAGE_ID}/installed-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.repos" \
     "storage-ceph/${STORAGE_CEPH_IMAGE_ID}/installed-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.repos"; do
-        curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/stable/${REPOS_URL}"
+        curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/unstable/${REPOS_URL}"
 done | grep -E '^baseurl=https://' \
      | sed -e 's/^baseurl=//' \
      | sed -e 's|https://[^@]*@|https://|' \

--- a/manifests/kyverno.yaml
+++ b/manifests/kyverno.yaml
@@ -1,0 +1,92 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: platform
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: cray-drydock
+    source: csm-algol60
+    version: 2.18.4
+    namespace: loftsman
+    values:
+      kubectl:
+        image:
+          repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl
+          tag: 1.24.17
+      sonar:
+        jobsWatcher:
+          image:
+            repository: registry.local/artifactory.algol60.net/csm-docker/stable/cray-sonar
+  - name: cray-kyverno
+    source: csm-algol60
+    version: 1.6.5
+    namespace: kyverno
+    values:
+      kyverno:
+        admissionController:
+          initContainer:
+            image:
+              registry: registry.local/artifactory.algol60.net
+              repository: csm-docker/stable/ghcr.io/kyverno/kyvernopre
+          container:
+            image:
+              registry: registry.local/artifactory.algol60.net
+        test:
+          image:
+            repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox
+        cleanupController:
+          image:
+            registry: registry.local/artifactory.algol60.net
+        reportsController:
+          image:
+            registry: registry.local/artifactory.algol60.net
+        backgroundController:
+          image:
+            registry: registry.local/artifactory.algol60.net
+        cleanupJobs:
+          admissionReports:
+            image:
+              registry: registry.local/artifactory.algol60.net
+          clusterAdmissionReports:
+            image:
+              registry: registry.local/artifactory.algol60.net
+        webhooksCleanup:
+          image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
+        buildKyvernoTrust:
+          image:
+            registry: registry.local/artifactory.algol60.net
+  - name: kyverno-policy
+    source: csm-algol60
+    version: 1.6.2
+    namespace: kyverno
+  - name: cray-kyverno-policies-upstream
+    source: csm-algol60
+    version: 1.0.0
+    namespace: kyverno

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -35,69 +35,59 @@ spec:
     source: csm-algol60
     version: 0.5.0
     namespace: kube-system
-  - name: cray-drydock
-    source: csm-algol60
-    version: 2.18.4
-    namespace: loftsman
+    values:
+      image:
+        repository: registry.local/artifactory.algol60.net/csm-docker/stable/registry.k8s.io/metrics-server/metrics-server
   - name: cray-precache-images
     source: csm-algol60
     version: 0.6.0
     namespace: nexus
     timeout: 20m0s
     values:
+      image:
+        repository: registry.local/artifactory.algol60.net/csm-docker/stable/github.com/kubernetes-sigs/cri-tools
+        tag: v1.24.2
       cacheRefreshSeconds: "120"
       cacheImages:
       # Kubernetes
-      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
+      - registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
+      - registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
+      - registry.local/artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
+      - registry.local/artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
+      - registry.local/artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
+      - registry.local/artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
+      - registry.local/artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
+      - registry.local/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
+      - registry.local/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
+      - registry.local/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
+      - registry.local/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
+      - registry.local/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      - registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
       # OPA
-      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
+      - registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.5
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.3
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
+      - registry.local/artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.5
+      - registry.local/artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.3
+      - registry.local/artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
+      - registry.local/artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
-      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
+      - registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+      - registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+      - registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
       # cray-nexus
-      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
-  - name: cray-kyverno
-    source: csm-algol60
-    version: 1.6.5
-    namespace: kyverno
-  - name: kyverno-policy
-    source: csm-algol60
-    version: 1.6.1
-    namespace: kyverno
-  - name: cray-kyverno-policies-upstream
-    source: csm-algol60
-    version: 1.0.0
-    namespace: kyverno
+      - registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
+      - registry.local/artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
   - name: cray-psp
     source: csm-algol60
     version: 0.4.5
@@ -106,14 +96,27 @@ spec:
     source: csm-algol60
     version: 1.6.3-3
     namespace: velero
+    values:
+      velero:
+        image:
+          repository: registry.local/artifactory.algol60.net/csm-docker/stable/velero/velero
+          tag: v1.6.3
   - name: sealed-secrets
     source: csm-algol60
     version: 0.4.1
     namespace: kube-system
+    values:
+      sealed-secrets:
+        image:
+          registry: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io
   - name: cray-node-problem-detector
     source: csm-algol60
     version: 1.10.0
     namespace: kube-system
+    values:
+      node-problem-detector:
+        image:
+          repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/node-problem-detector
   - name: cray-istio-operator
     source: csm-algol60
     version: 2.0.0
@@ -182,6 +185,44 @@ spec:
     source: csm-algol60
     version: 1.8.5
     namespace: services
+    values:
+      kubectl:
+        image:
+          repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl
+      postgres-operator:
+        image:
+          registry: registry.local/artifactory.algol60.net
+        configGeneral:
+          docker_image: registry.local/artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+          sidecars:
+            - name: "exporter"
+              image: "registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2"
+              ports:
+                - name: http
+                  containerPort: 9187
+                  protocol: TCP
+              resources:
+                # Note - https://github.com/Cray-HPE/cray-postgres-operator/blob/master/kubernetes/cray-postgres-operator/values.yaml
+                # has indentation error
+                limits:
+                  cpu: 500m
+                  memory: 256M
+                requests:
+                  cpu: 100m
+                  memory: 200M
+              env:
+                - name: "DATA_SOURCE_URI"
+                  value: "localhost:5432/postgres?sslmode=require"
+                - name: "DATA_SOURCE_USER"
+                  value: $(POSTGRES_USER)
+                - name: "DATA_SOURCE_PASS"
+                  value: $(POSTGRES_PASSWORD)
+                - name: "PG_EXPORTER_AUTO_DISCOVER_DATABASES"
+                  value: "true"
+        configLogicalBackup:
+          logical_backup_docker_image: "registry.local/artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.8.2"
+        configConnectionPooler:
+          connection_pooler_image: "registry.local/artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-22"
   - name: cray-kafka-operator
     source: csm-algol60
     version: 1.2.1
@@ -242,6 +283,9 @@ spec:
     source: csm-algol60
     version: 0.2.2
     namespace: kube-system
+    values:
+      image:
+        repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/roffe/kube-etcdbackup
   - name: cray-node-labels
     source: csm-algol60
     version: 0.5.0
@@ -272,6 +316,9 @@ spec:
     source: csm-algol60
     version: 0.1.0
     namespace: kube-system
+    values:
+      image:
+        repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl
   - name: cray-vpa
     source: csm-algol60
     version: 0.0.2

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -12,7 +12,58 @@ spec:
     source: csm-algol60
     namespace: ceph-rbd
     version: 3.6.2-1
+    values:
+      kubectl:
+        image:
+          repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl
+      ceph-csi-rbd:
+        nodeplugin:
+          registrar:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar
+          plugin:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
+        provisioner:
+          provisioner:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner
+          attacher:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher
+          resizer:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer
+          snapshotter:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs
     version: 3.6.3-1
+    values:
+      kubectl:
+        image:
+          repository: registry.local/artifactory.algol60.net/csm-docker/stable/docker-kubectl
+      ceph-csi-cephfs:
+        nodeplugin:
+          registrar:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar
+          plugin:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
+        provisioner:
+          provisioner:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner
+          attacher:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher
+          resizer:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer
+          snapshotter:
+            image:
+              repository: registry.local/artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter
+

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,6 +67,9 @@ echo "These charts will later be deployed in the services namespace."
 undeploy -n operators cray-etcd-backup
 undeploy -n operators cray-etcd-defrag
 
+# Deploy Kyverno to perform image registry mutation and signature validation for all other charts
+deploy "${BUILDDIR}/manifests/kyverno.yaml"
+
 # Deploy services critical for Nexus to run
 echo "Deploying new ceph csi provisioners"
 deploy "${BUILDDIR}/manifests/storage.yaml"

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -587,9 +587,9 @@ spec:
             authJwksUrl: http://cray-keycloak-http.services.svc.cluster.local/keycloak/realms/shasta/protocol/openid-connect/certs
       kyverno-policy:
         checkImagePolicy:
-          validationFailureAction: Audit
-          failurePolicy: Ignore
-          background: true
+          validationFailureAction: Enforce
+          failurePolicy: Fail
+          background: false
           rules:
             - name: check-image
               # Refer to `kubectl explain clusterpolicy.spec.rules.exclude` for exclude block syntax.
@@ -597,9 +597,24 @@ spec:
                 any:
                 - resources:
                     names:
+                    # https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7288
+                    - '*-dns-*'
                     - munge-vault-loader-*
                     namespaces:
                     - services
+                - resources:
+                    names:
+                    # Nexus Pod is a singleton. If restarted, it will fail to start again, as signature is also stored in Nexus.
+                    - 'nexus-*'
+                    namespaces:
+                    - nexus
+                - resources:
+                    names:
+                    # On vShasta, static route always goes to ncn-w001, so cray-ope-ingressgateway is a signleton. When 
+                    # cray-opa-ingressgateway pod on ncn-w001 is down, Nexus is not available and signature can not be validated.
+                    - cray-opa-ingressgateway-*
+                    namespaces:
+                    - opa
                 - resources:
                     kinds:
                     - Pod
@@ -620,7 +635,7 @@ spec:
                     # and "failurePolicy: Ignore", so we have to turn it off by limiting to non existent namespace.
                     # JIRA: https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7291
                     namespaces:
-                    - non-existent
+                    - '*'
               verifyImages:
               - imageReferences:
                 - '*'


### PR DESCRIPTION
## Summary and Scope

During initial testing of image signature validation, it was discovered that Kyverno tries to contact https://artifactory.alogl60.net/ for image verification, and this blocks deployments in air-gapped environments, even in Audit mode ([CASMTRIAGE-7283](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7283)). We need to set Kyverno to contact local registry instead, for both images and their respective signatures. This will allow us to turn on signature validation in runtime (during initial deployments, upgrades and in background on running clusters).

Proposed solution involves these key steps:
* Deploy new Kyverno cluster policy `prepend-registry`, which will automatically add `registry.local/` to the beginning of image spec for any new pod (if it doesn't already start with `registry.local/`).
* Add a mirroring rule to containerd configuration, so that images with names starting from `registry.local/` are looked in `https://pit.nmn` first and in `https://registry.local/` second. This rule is needed to support a switch from PIT Nexus to Cloud Nexus during initial install. It is similar to already existing rule for image names starting from `artifactory.algol60.net`, which now becomes obsolete.
* Move Kyverno and policies deployment into separate manifest, and deploy it early in install/upgrade pipeline, thus ensuring that image name mutation and signature validation happen to all deployments after Kyverno.
* For the duration of fresh install, when images are downloaded from PIT Nexus, put a temporary hosts record override into CoreDNS ConfigMap. This override will point to PIT Nexus instead of Cloud Nexus. It is needed for Kyverno admission controller to look for images and their signatures in the right location during fresh install (when Cloud Nexus is not yet deployed).

This change consists of the following PR's:
* https://github.com/Cray-HPE/csm/pull/3703
* https://github.com/Cray-HPE/docs-csm/pull/5455
* https://github.com/Cray-HPE/node-images/pull/1172
* https://github.com/Cray-HPE/cray-kyverno-policies/pull/17

## Issues and Related PRs

* Resolves [CASM-4908](https://jira-pro.it.hpe.com:8443/browse/CASM-4908)
* Resolves [CASMTRIAGE-7283](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7283)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

* Created custom builds of CSM and docs-csm with changes outlined above
* Performed multiple automated deployments on vShasta in different combinations: fresh install and upgrade, with `validationFailureAction` set to `Audit` and `Enforce`.

## Risks and Mitigations

None known ATM.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

