### PR TITLE
CASMTRIAGE-7210/CASMTRIAGE-7342 - PostgreSQL cannot set transaction read-write mode during recovery errors

### DIFF
--- a/hooks/management-nodes-rollout-prehook.sh
+++ b/hooks/management-nodes-rollout-prehook.sh
@@ -118,4 +118,8 @@ else
     echo "INFO ncn-k8s-combined-healthcheck has previously been completed"
 fi
 
+echo "INFO Applying control-plane node PostgreSQL failover resiliency fix"
+echo "INFO All PostgreSQL clusters will be restarted in the background by the operator"
+kubectl -n services patch cm postgres-nodes-pod-env -p '{"data":{"PATRONI_KUBERNETES_BYPASS_API_SERVICE":"true"}}'
+
 echo "INFO Prehook for management nodes rollout completed"


### PR DESCRIPTION
## Summary and Scope

This PR applies the workaround for [CASMTRIAGE-7120](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7120) automatically at the end of the `management-nodes-rollout-prehook.sh` script.

The `cray-postgres-operator` will then do a rolling restart of the PostgreSQL clusters to apply the change.

It is run right at the end of the script after validation as there is simply no nice way of monitoring that the change has occurred. When the `postgres-nodes-pod-env` ConfigMap is patched the `cray-postgres-operator` will update the clusters in no particular order, it does not change the cluster state from `Running` to `Updating` while doing so, and none of the StatefulSets can be monitored with `kubectl rollout status` due to their OnDelete strategy.

Without this change, every time a system is upgraded from 1.6 to 1.6 the `PATRONI_KUBERNETES_BYPASS_API_SERVICE` parameter is removed from the `postgres-nodes-pod-env` ConfigMap undoing the workaround which then leads to problems when the master nodes are rebuilt.

This change would be better built into the `cray-postgres-operator` Helm chart however it's not currently buildable because Zalando have removed version of the chart we are using (v1.8.2) from their public chart repo as it's two years old and scheduled to be upgraded in CSM 1.7.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7342](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7342)

## Testing

### Tested on:

  * `surtur`
  * `gamora`
  * `fanta`
  * `tyr`

### Test description:

The change has been tested manually on a number of systems however needs to be tested as part of a CSM iuf upgrade.

## Risks and Mitigations

This change can be left out but doing so means we run a greater risk of a master node rebuild causing PostgreSQL cluster problems as documented in https://github.com/Cray-HPE/docs-csm/blob/release/1.6/troubleshooting/known_issues/postgres_database_recovery.md


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

