### PR TITLE
CRAYSAT-1919: Update to cfs-config-util version 5.1.1

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -52,4 +52,4 @@ BUILDDIR=${BUILDDIR:-${ROOTDIR}/dist/${RELEASE}}
 CSM_BASE_VERSION=${CSM_BASE_VERSION:-}
 
 # Use a newer version of cfs-config-util that hasn't rolled out to other products yet
-CFS_CONFIG_UTIL_IMAGE="artifactory.algol60.net/csm-docker/stable/cfs-config-util:5.0.0"
+CFS_CONFIG_UTIL_IMAGE="artifactory.algol60.net/csm-docker/stable/cfs-config-util:5.1.1"


### PR DESCRIPTION
## Summary and Scope

The cfs-config-util image is used by the `update-mgmt-ncn-cfs-config.sh` script, which is used during patch installs. This script updates the CFS configuration assigned to management nodes so that it uses the latest version of the Ansible content from the csm-config-management repo in VCS.

This new version of cfs-config-util adds support for CFS v3, and it fixes a couple bugs that resulted in data being lost from configurations that were modified with this tool (`additional_inventory` and `special_parameters`). It also better handles unknown fields in CFS configurations, so if, in the future, additional fields are added to CFS configurations, they won't be lost.

## Issues and Related PRs

* Resolves CRAYSAT-1919

## Testing

### Tested on:

  * drax

### Test description:

Built a CSM release distribution that contained the shell script and the latest version of the cfs-config-util image and copied it to drax. Mocked out a new CSM release and associated branch in the csm-config-management repo in VCS. Then executed the script to update the configuration currently assigned to management nodes. The script successfully updated 3 configurations assigned to those nodes and then waited for the nodes to reach a configured status.

## Risks and Mitigations

This is pretty low risk, especially for CSM 1.6.0. I do not think this script currently gets used in the normal installation of CSM 1.6.0. As far as I'm aware it has only been used in the installation of CSM 1.4 and 1.5 patch versions (e.g. 1.5.2). It is good to get this fixed well before we have to release CSM 1.6.z patches though.

I will also backport to CSM 1.5 so that the fix will be in place for the next CSM 1.5 patch release, if any.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable