### PR TITLE
CASMPET-7254 update csm-config version to 1.27.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.26.2
+    version: 1.27.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This change updates the csm-config build from 1.26.2 to 1.27.0 to pull in the fix for CASMPET-7254

This change should be backward compatible with previous uses of the SBPS playbook.

## Issues and Related PRs

* Resolves (https://jira-pro.it.hpe.com:8443/browse/CASMPET-7254)
* Change will also be needed in N/A
* Future work required by N/A
* Documentation changes required in N/A
* Merge with/before/after N/A
## Testing

Change was tested on gamora

### Tested on:

  * `gamora`
  
### Test description:

This change was tested in conjunction with an IUF upgrade on gamora using a test branch with these changes in place of the normal csm branch.   

- Were the install/upgrade-based validation checks/tests run:  Goss tests were run
- Were continuous integration tests run? If not, why?   This change only modifies image customization behavior which has no tests
- Was upgrade tested? If not, why?   Upgrade was test.
- Was downgrade tested? If not, why?    N/A
- Were new tests (or test issues/Jiras) created for this change?   N/A

## Risks and Mitigations

The shouldn't be any notable risks to this change.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

