### PR TITLE
CRAYSAT-1920: Backport `sat bmccreds` improvements to SAT 2.6/CSM 1.5

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -24,7 +24,7 @@
 artifactory.algol60.net/sat-docker/stable:
   images:
     cray-sat:
-      - 3.25.14
+      - 3.25.15
 
 artifactory.algol60.net/csm-docker/stable:
   images:

--- a/lib/setup-nexus.sh
+++ b/lib/setup-nexus.sh
@@ -60,7 +60,7 @@ skopeo-sync "${ROOTDIR}/docker"
 
 # Tag SAT image as csm-latest
 sat_image="artifactory.algol60.net/sat-docker/stable/cray-sat"
-sat_version="3.25.14"
+sat_version="3.25.15"
 skopeo-copy "${sat_image}:${sat_version}" "${sat_image}:csm-latest"
 
 nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"


### PR DESCRIPTION
## Summary and Scope

_This backports `sat bmccreds` improvements to release/1.5 for inclusion in CSM 1.5._
- https://github.com/Cray-HPE/sat/pull/202

## Issues and Related PRs

_Resolves [CRAYSAT-1920](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1920)._

## Testing

_See linked PR._

## Risks and Mitigations

_See linked PR._


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable