### PR TITLE
CASMCMS-8681 - add inotify-tools to the console base images.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -161,12 +161,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.10.0
+    version: 1.11.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.4.0
+    version: 2.5.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

A customer has requested that the 'inotify-tools' package be added to the base image for some utilities they want to build for handling log file changes.

## Issues and Related PRs
* Resolves [CASMCMS-8681](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8681)

## Testing
### Tested on:
  * `drax`

### Test description:

I installed the updated package using helm to make sure that the utilities worked and the hotfix would work in a 1.5.2 context.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - just adding a utility package to the base image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
