### PR TITLE
MTL-2437 - Bump CSI version to enable VLAN checking

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-trust-1.7.4-1.noarch
     - cray-cmstools-crayctldeploy-1.24.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cray-site-init-1.36.2-1.x86_64
+    - cray-site-init-1.36.4-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.88.0-1.aarch64


### PR DESCRIPTION
## Summary and Scope

CSI previously allowed overlaps and re-use of VLANs in `csi config init` which lead to unusable switch configurations. This change alerts CSI users to duplicate and overlapping VLANs in system creational data from `system_config.yaml` or the CLI. This is for initial system install.  This part of CSI is not used for system upgrades.

This change is not backported to previous releases.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-2437](https://jira-pro.it.hpe.com:8443/browse/MTL-2437) [#432](https://github.com/Cray-HPE/cray-site-init/pull/432)

## Testing

This was tested on CSI data for all internal systems as well as a couple customer systems. Unit tests were also added to CSI.

### Tested on:

  * Odin, Surtur and eight other test/dev systems.

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Was upgrade tested? - No, this is a system install only change.
- Was downgrade tested? - No, this is a system install only change
- Were new tests (or test issues/Jiras) created for this change? - No Goss tests were created, CSI unit tests were created.

## Risks and Mitigations

No known risks.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

