### PR TITLE
CASMNET-2031 - Bump CANU version

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-2.30.3-1.noarch
     - cani-0.4.0-1.x86_64
-    - canu-1.9.3-1.x86_64
+    - canu-1.9.4-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.0-1.noarch
     - cfs-trust-1.7.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

This change updates many libraries in CANU to fix CVEs and simplifies the build structure.  This version of CANU also adds EX2500 hardware.  Note that switch configuration generation of EX2500 hardware remains via custom-configuration.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-2037](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2037)

## Testing

* EX2500 tests on Baldar data as well as one customer system.
* Library updates were tested on Redbull and Surtur.

### Test description:

* EX2500 changes were SHCD only.  Ensured that Mountain cabinets attached directly to spines are valid.
* For library updates requiring network connections, canu was manually run with `canu test`, `canu report`, and `canu validate paddle-cabling` to exercise the new code.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? No.  Affects only early install/update data and not runtime.
- Was upgrade tested? N/A
- Was downgrade tested? N/A
- Were new tests.  No.

## Risks and Mitigations

No


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

