### PR TITLE
CASMTRIAGE-7405 bump goss-servers and csm-testing version to 1.17.36

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.17.35-1.noarch
-    - goss-servers-1.17.34-1.noarch
+    - csm-testing-1.17.36-1.noarch
+    - goss-servers-1.17.36-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Bump goss-servers and csm-testing version to 1.17.36.

The change to csm-testing made was making two goss-tests backwards compatible with CSM 1.5.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7405](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7405)

## Testing

### Tested on:

Tested the Goss tests on wasp (CSM 1.6) and drax (CSM 1.5).

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

