### PR TITLE
CASMTRIAGE-7413: Split product catalog into 2 repos to prevent automatic rebuilds of Python package

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -186,7 +186,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.4.1
+            tag: 2.5.0
   - name: cray-ims
     source: csm-algol60
     version: 3.20.0
@@ -215,7 +215,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.4.1
+            tag: 2.5.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -254,7 +254,7 @@ spec:
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
     # Also update the catalog:image:tag value in the barebones recipe section.
-    version: 2.4.1
+    version: 2.5.0
     namespace: services
 
   # Spire service


### PR DESCRIPTION
This updates the product catalog version, but there are no functional differences. This ticket split the cray-product-catalog repo into two different repos, to prevent the Python package from being automatically rebuilt every time the Docker image was. The split caused no functional changes, but did result in new version numbers.