### PR TITLE
CASMHMS-6287: Correct error in PCS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -111,7 +111,7 @@ spec:
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.4.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.4.1/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
This updates the URL for the PCS API spec, in order to autogenerate a fixed version of the API docs. No change was made to PCS itself -- only a fix to its API spec to correctly describe its behavior.

Backports:
https://github.com/Cray-HPE/csm/pull/3730
https://github.com/Cray-HPE/csm/pull/3731