### PR TITLE
CASMHMS-6287: Correct error in PCS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -111,7 +111,7 @@ spec:
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.3.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.3.1/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/csm/pull/3729