### PR TITLE
CASMHMS-6287: Correct error in PCS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -137,7 +137,7 @@ spec:
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.4.2/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v1.4.3/api/swagger.yaml
 
   # CMS
   # These are (mostly) alphabetized; please keep them so (when possible).


### PR DESCRIPTION
CSM 1.4 backport of https://github.com/Cray-HPE/csm/pull/3729