### PR TITLE
Backport  cray-sat container image through 3.32.8

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.6
+      - 3.32.8
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Backport  `cray-sat` container image from `3.32.6` to `3.32.8`_

## Issues and Related PRs

- [CRAYSAT-1913](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1913): https://github.com/Cray-HPE/python-csm-api-client/pull/43, https://github.com/Cray-HPE/sat/pull/276
- [CRAYSAT-1916](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1916): https://github.com/Cray-HPE/sat/pull/277

## Testing

_See the linked PRs._

## Risks and Mitigations

_See the linked PRs._


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable