### PR TITLE
MTL-2508/CASMTRIAGE-7424 - node not PXE booting from the PIT

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-trust-1.7.4-1.noarch
     - cray-cmstools-crayctldeploy-1.24.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cray-site-init-1.36.4-1.x86_64
+    - cray-site-init-1.36.5-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.89.0-1.aarch64


### PR DESCRIPTION
## Summary and Scope

[MTL-2437](https://jira-pro.it.hpe.com:8443/browse/MTL-2437) prevented VLAN re-use and duplication. Previous to that change both BICAN and MTL used VLAN 0. This, for several reasons, is wrong. [MTL-2437](https://jira-pro.it.hpe.com:8443/browse/MTL-2437) changed the default MTL VLAN to 1 from 0, which had no downstream impact on CANU or switch configs. However, VLAN 0 was hard coded in ifcfg file generation and dnsmasq file generation so the change in MTL VLANs broke the PIT interfaces (both bond0 and bond0.mtl0 were IP'd with the same IP address. Additionally, a dnsmasq file was generated for bond0.mtl0 which is erroneous.

This change fixes the problem in two ways. First the MTL VLAN variable is used in ifcfg file generation. Second, because of circular dependencies the dnsmasq file generation code adds VLAN 1 to the existing VLAN 0.

## Issues and Related PRs

* Resolves [MTL-2437](https://jira-pro.it.hpe.com:8443/browse/MTL-2437), [MTL-2508](https://jira-pro.it.hpe.com:8443/browse/MTL-2508), [CASMTRIAGE-7424](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7424)

## Testing

### Tested on:

  * `surtur`
  * Local development environment

### Test description:

Tested on surtur by performing an end to end install using csi config init output generated using this change.

All NCNs deployed without issue and validation checks passed
CSM services installed without issue and validation checks passed
Final NCN was also successfully booted into the cluster

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

