### PR TITLE
CASMCMS-9175 - add inotify-tools to console services.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -163,12 +163,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.8.0
+    version: 1.8.2
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.2.1
+    version: 2.3.2
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

Customer has requested that 'inotify-tools' be added to the console services images. This just adds those and makes no changes to the functionality of the services themselves.

## Issues and Related PRs
* Resolves [CASMCMS-9175](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9175)

## Testing
### Tested on:
  * `Drax`

### Test description:

Updated via helm to the new version and insured that all normal functionality was unaffected by the additional tools in the container images.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just adding a tool to the images for the customer to use.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

