### PR TITLE
CASMTRIAGE-7440: TESTS: Update cmsdev BOS test to avoid false failure

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.0-1.noarch
     - cfs-trust-1.7.4-1.noarch
-    - cray-cmstools-crayctldeploy-1.24.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.24.1-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.5-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch


### PR DESCRIPTION
The cmsdev BOS test can report a false failure when run during the CSM upgrade process. This is very disruptive to the upgrade, and the fix is very low risk.

CSM 1.6.0 PR: https://github.com/Cray-HPE/csm/pull/3738
