### PR TITLE
CASMPET-7207: Add vault access through the CMN and tenant aware authentication

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.34.4
+    version: 1.34.6
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
@@ -136,7 +136,7 @@ spec:
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -274,9 +274,9 @@ spec:
     namespace: tapms-operator
   - name: cray-tapms-operator
     source: csm-algol60
-    version: 1.7.1
+    version: 1.8.0
     namespace: tapms-operator
     swagger:
     - name: tapms-operator
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.7.1/docs/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.8.0/docs/openapi.yaml

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -384,7 +384,7 @@ spec:
           istio-ingressgateway-cmn:
             serviceAnnotations:
               metallb.universe.tf/address-pool: customer-management
-              external-dns.alpha.kubernetes.io/hostname: 'api.cmn.{{ network.dns.external }},auth.cmn.{{ network.dns.external }},nexus.cmn.{{ network.dns.external }}'
+              external-dns.alpha.kubernetes.io/hostname: 'api.cmn.{{ network.dns.external }},auth.cmn.{{ network.dns.external }},nexus.cmn.{{ network.dns.external }},vault.cmn.{{ network.dns.external }}'
           istio-ingressgateway-chn:
             serviceAnnotations:
               metallb.universe.tf/address-pool: customer-high-speed
@@ -569,6 +569,8 @@ spec:
             private_key: int_ca.key
             certificate: int_ca.crt
             ca_bundle: root_ca.crt
+        ingress:
+            host: vault.cmn.{{ network.dns.external }}
       cfs-ara:
         externalHostname: ara.cmn.{{ network.dns.external }}
       gitea:

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -384,7 +384,7 @@ spec:
           istio-ingressgateway-cmn:
             serviceAnnotations:
               metallb.universe.tf/address-pool: customer-management
-              external-dns.alpha.kubernetes.io/hostname: 'api.cmn.{{ network.dns.external }},auth.cmn.{{ network.dns.external }},nexus.cmn.{{ network.dns.external }},vault.cmn.{{ network.dns.external }}'
+              external-dns.alpha.kubernetes.io/hostname: 'api.cmn.{{ network.dns.external }},auth.cmn.{{ network.dns.external }},nexus.cmn.{{ network.dns.external }}'
           istio-ingressgateway-chn:
             serviceAnnotations:
               metallb.universe.tf/address-pool: customer-high-speed
@@ -569,8 +569,6 @@ spec:
             private_key: int_ca.key
             certificate: int_ca.crt
             ca_bundle: root_ca.crt
-        ingress:
-            host: vault.cmn.{{ network.dns.external }}
       cfs-ara:
         externalHostname: ara.cmn.{{ network.dns.external }}
       gitea:


### PR DESCRIPTION
## Summary and Scope

This only adds more permissions to the tapms operator to allow it to create policy and roles for tenant specific transit engines. The only change in how the auth policy works is allowing tapms-operator to create and delete specific policy only for tenant specific endpoints. Vault has no more openings only allowing new policy to be made.

## Issues and Related PRs

* Completes [CASMPET-7207](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7207)

## Testing
### Tested on:

  * Beau
  * Mug

### Test description:

The test was to put the new policy up and see if the tapms-operator has correct permissions.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Low risk as it only opens endpoints that the tapms-operator can access.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

