### PR TITLE
CASMPET-7261/CASMPET-7263: Goss test fixes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.17.36-1.noarch
-    - goss-servers-1.17.36-1.noarch
+    - csm-testing-1.17.40-1.noarch
+    - goss-servers-1.17.40-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
Fixes two Goss test problems:
[CASMPET-7261](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7261) - Fix incorrect regex in `goss-validate-iscsi-sbps-config` test, which could cause it to be run on unintended nodes
[CASMPET-7263](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7263) - Delay starting Goss test servers until the node hostname has been assigned to an expected value

The test fixes by CASMPET-7261 does not exist in prior releases, but the fix for CASMPET-7263 has backports:
CSM 1.5: https://github.com/Cray-HPE/csm/pull/3740
CSM 1.4: https://github.com/Cray-HPE/csm/pull/3741