### PR TITLE
CASMPET-7263: goss-servers should delay start until hostname is set

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -24,8 +24,8 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - cray-node-exporter-1.5.0.1-1.noarch
-    - csm-testing-1.15.62-1.noarch
-    - goss-servers-1.15.62-1.noarch
+    - csm-testing-1.15.63-1.noarch
+    - goss-servers-1.15.63-1.noarch
     - python3-liveness-1.4.3-1.noarch
     - python3-requests-retry-session-0.1.5-1.noarch
     - python310-requests-retry-session-0.1.5-1.noarch

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -26,8 +26,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - canu-1.7.1-2.x86_64
     - cray-site-init-1.31.1-1.x86_64
     - craycli-0.74.4-1.x86_64
-    - csm-testing-1.15.62-1.noarch
-    - goss-servers-1.15.62-1.noarch
+    - csm-testing-1.15.63-1.noarch
+    - goss-servers-1.15.63-1.noarch
     - ilorest-3.5.1-1.x86_64
     - libcsm-0.0.4-1.noarch
     - msr-tools-1.3-bp153.1.11.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -34,9 +34,9 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - csm-node-identity-1.0.20-1.noarch
     - csm-ssh-keys-1.5.1-1.noarch
     - csm-ssh-keys-roles-1.5.1-1.noarch
-    - csm-testing-1.15.62-1.noarch
+    - csm-testing-1.15.63-1.noarch
     - dracut-metal-mdsquash-2.3.2-1.noarch
-    - goss-servers-1.15.62-1.noarch
+    - goss-servers-1.15.63-1.noarch
     - hpe-csm-scripts-0.4.6-1.noarch
     - iuf-cli-1.4.6-1.x86_64
     - libcsm-0.0.4-1.noarch


### PR DESCRIPTION
CSM 1.4 backport of CASMPET-7263 portion of https://github.com/Cray-HPE/csm/pull/3739