### PR TITLE
CASMTRIAGE-7428: iSCSI SBPS: Fix node personalization issue with boot…

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.27.0
+    version: 1.27.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
…prep (management rollout)

  - new version of csm-config to include fix for CASMTRIAGE-7428

## Summary and Scope
CASMTRIAGE-7428: iSCSI SBPS: Fix node personalization issue with bootprep (management rollout).
- Fixed DNS SRV A records creation for worker nodes in order to make it work with management rollout.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing
drax bare metal system

### Tested on:
drax bare metal system with rc.2 bits + fix

### Test description:
Here is the list of test scenarios covered with fix for this issue on drax (rc2 build).

[A] Unit testing:
Manual way of kick starting the worker node personalization via CFS config/ CFS session - [Done] - Looks Good.

[B] Update/ reapply CFS config (No IUF/ No bootprep involved)

[B.1] CFS config update [ Done] – Looks Good
[B.2] CFS Components update [ Done] – Looks Good
[C] Apply CFS config/ layer via bootprep (IUF) – [Done] Looks Good

[D] Re-run the IUF prepare images - creates new images and sessions template – [Done] – Looks Good]
[D.1] Image creation via iuf method
[D.2] Management rollout of worker nodes with IUF method <= wipeout and scratch rebuild [ Done] – Looks Good

[E] Compute node(s) booting
[E.1] Without compute node image creation – [ Done] – Looks Good
[E.2] With compute node image creation – [ Done] – Looks Good

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable