### PR TITLE
CASMTRIAGE-7447: iSCSI SBPS: CMN iSCSI portal can be used off system …

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.27.0
+    version: 1.27.2
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
…without authentication:

  - new csm-config version with a fix to remove iSCSI CMN portal creation from LIO provisioning

## Summary and Scope
CASMTRIAGE-7447: iSCSI SBPS: CMN iSCSI portal can be used off system without authentication:
Since we don't use CMN iSCSI portal unlike HSN and NMN for any projection we can remove CMN iSCSI portal creation
from the LIO provisioning to avoid security issue of discovering and login into the iSCSI targets over CMN from the UAN.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies.

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

On drax bare metal system

### Tested on:
On drax bare metal (rc2) + fix

### Test description:
Tested the fixe with below cases successfully:
- CFS config of node personalization applied with booteprep - successful
- tested compute node booting with new config - successful
- CMN portal should not be configured/ listed under target cli - successful
- We should reject login to iSCSI targets (workers) over CMN - successful
- iSCSI targets should not be discovered via CMN with "iscsiadm -m discovery" - successful

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable