### PR TITLE
CASMNET-2241 - Resolve external DNS test fails with port present in URL

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.74-1.noarch
-    - goss-servers-1.16.74-1.noarch
+    - csm-testing-1.16.76-1.noarch
+    - goss-servers-1.16.76-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
## Summary and Scope

The `Resolve external DNS` Goss test fails if LDAP has been configured with a port in the URL as the script doesn't remove the port from the hostname before issuing the DNS query.

```
FIRST_URL=ldap.example.com:636
host -4 -t A ldap.example.com:636
Host ldap.example.com:636 not found: 3(NXDOMAIN)
```

This PR changes the test to be able to correctly handle a URL with a port while maintaining backwards compatibility with URLs that do not.

## Issues and Related PRs

* Resolves [CASMNET-2241](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2241)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `drax`

### Test description:

#### URL without port
```bash
ncn-m002:~/cspiller # ./check_goss_k8s_resolve_external_dns.sh
SYSTEM_NAME=drax
SITE_DOMAIN=hpc.amslabs.hpecorp.net
SYSTEM_DOMAIN=drax.hpc.amslabs.hpecorp.net
INGRESS=https://auth.cmn.drax.hpc.amslabs.hpecorp.net
FORWARD_ADDR=16.110.135.51
LDAP_PROVIDER={
--snip--
Unbound and LDAP are configured
CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net
FIRST_URL=dcldap2.hpc.amslabs.hpecorp.net
Attempting to resolve (A record) dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has address 10.101.116.10
PASSED
```

<details>

```bash
ncn-m002:~/cspiller # ./check_goss_k8s_resolve_external_dns.sh
SYSTEM_NAME=drax
SITE_DOMAIN=hpc.amslabs.hpecorp.net
SYSTEM_DOMAIN=drax.hpc.amslabs.hpecorp.net
INGRESS=https://auth.cmn.drax.hpc.amslabs.hpecorp.net
FORWARD_ADDR=16.110.135.51
LDAP_PROVIDER={
  "id": "23ef31ae-1143-4e94-935d-4abec8b66836",
  "name": "shasta-user-federation-ldap",
  "providerId": "ldap",
  "providerType": "org.keycloak.storage.UserStorageProvider",
  "parentId": "d086f62a-b2a1-481a-88eb-4a2ae272858f",
  "config": {
    "fullSyncPeriod": [
      "-1"
    ],
    "pagination": [
      "true"
    ],
    "startTls": [
      "false"
    ],
    "usersDn": [
      "dc=dcldap,dc=dit"
    ],
    "connectionPooling": [
      "true"
    ],
    "cachePolicy": [
      "DEFAULT"
    ],
    "useKerberosForPasswordAuthentication": [
      "false"
    ],
    "importEnabled": [
      "true"
    ],
    "enabled": [
      "true"
    ],
    "usernameLDAPAttribute": [
      "uid"
    ],
    "changedSyncPeriod": [
      "-1"
    ],
    "lastSync": [
      "1728039651"
    ],
    "vendor": [
      "other"
    ],
    "uuidLDAPAttribute": [
      "uid"
    ],
    "allowKerberosAuthentication": [
      "false"
    ],
    "connectionUrl": [
      "ldaps://dcldap2.hpc.amslabs.hpecorp.net"
    ],
    "syncRegistrations": [
      "false"
    ],
    "authType": [
      "none"
    ],
    "debug": [
      "true"
    ],
    "searchScope": [
      "2"
    ],
    "useTruststoreSpi": [
      "ldapsOnly"
    ],
    "usePasswordModifyExtendedOp": [
      "false"
    ],
    "trustEmail": [
      "false"
    ],
    "priority": [
      "1"
    ],
    "userObjectClasses": [
      "posixAccount"
    ],
    "rdnLDAPAttribute": [
      "uid"
    ],
    "editMode": [
      "READ_ONLY"
    ],
    "validatePasswordPolicy": [
      "false"
    ],
    "batchSizeForSync": [
      "4000"
    ]
  }
}
Unbound and LDAP are configured
CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net
FIRST_URL=dcldap2.hpc.amslabs.hpecorp.net
Attempting to resolve (A record) dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has address 10.101.116.10
PASSED
```
</details>

#### URL with port

```bash
ncn-m002:~/cspiller # ./check_goss_k8s_resolve_external_dns.sh
SYSTEM_NAME=drax
SITE_DOMAIN=hpc.amslabs.hpecorp.net
SYSTEM_DOMAIN=drax.hpc.amslabs.hpecorp.net
INGRESS=https://auth.cmn.drax.hpc.amslabs.hpecorp.net
FORWARD_ADDR=16.110.135.51
LDAP_PROVIDER={
--snip--
Unbound and LDAP are configured
CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net:636
FIRST_URL=dcldap2.hpc.amslabs.hpecorp.net
Attempting to resolve (A record) dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has address 10.101.116.10
PASSED
```
<details>

```bash
ncn-m002:~/cspiller # ./check_goss_k8s_resolve_external_dns.sh
SYSTEM_NAME=drax
SITE_DOMAIN=hpc.amslabs.hpecorp.net
SYSTEM_DOMAIN=drax.hpc.amslabs.hpecorp.net
INGRESS=https://auth.cmn.drax.hpc.amslabs.hpecorp.net
FORWARD_ADDR=16.110.135.51
LDAP_PROVIDER={
  "id": "23ef31ae-1143-4e94-935d-4abec8b66836",
  "name": "shasta-user-federation-ldap",
  "providerId": "ldap",
  "providerType": "org.keycloak.storage.UserStorageProvider",
  "parentId": "d086f62a-b2a1-481a-88eb-4a2ae272858f",
  "config": {
    "fullSyncPeriod": [
      "-1"
    ],
    "pagination": [
      "true"
    ],
    "startTls": [
      "false"
    ],
    "usersDn": [
      "dc=dcldap,dc=dit"
    ],
    "connectionPooling": [
      "true"
    ],
    "cachePolicy": [
      "DEFAULT"
    ],
    "useKerberosForPasswordAuthentication": [
      "false"
    ],
    "importEnabled": [
      "true"
    ],
    "enabled": [
      "true"
    ],
    "usernameLDAPAttribute": [
      "uid"
    ],
    "changedSyncPeriod": [
      "-1"
    ],
    "lastSync": [
      "1728039651"
    ],
    "vendor": [
      "other"
    ],
    "uuidLDAPAttribute": [
      "uid"
    ],
    "connectionUrl": [
      "ldaps://dcldap2.hpc.amslabs.hpecorp.net:636"
    ],
    "allowKerberosAuthentication": [
      "false"
    ],
    "syncRegistrations": [
      "false"
    ],
    "authType": [
      "none"
    ],
    "debug": [
      "true"
    ],
    "searchScope": [
      "2"
    ],
    "useTruststoreSpi": [
      "ldapsOnly"
    ],
    "usePasswordModifyExtendedOp": [
      "false"
    ],
    "trustEmail": [
      "false"
    ],
    "priority": [
      "1"
    ],
    "userObjectClasses": [
      "posixAccount"
    ],
    "rdnLDAPAttribute": [
      "uid"
    ],
    "editMode": [
      "READ_ONLY"
    ],
    "validatePasswordPolicy": [
      "false"
    ],
    "batchSizeForSync": [
      "4000"
    ]
  }
}
Unbound and LDAP are configured
CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net:636
FIRST_URL=dcldap2.hpc.amslabs.hpecorp.net
Attempting to resolve (A record) dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has address 10.101.116.10
PASSED
```
</details>

#### Multiple URLs

```bash
ncn-m002:~/cspiller # ./check_goss_k8s_resolve_external_dns.sh
SYSTEM_NAME=drax
SITE_DOMAIN=hpc.amslabs.hpecorp.net
SYSTEM_DOMAIN=drax.hpc.amslabs.hpecorp.net
INGRESS=https://auth.cmn.drax.hpc.amslabs.hpecorp.net
FORWARD_ADDR=16.110.135.51
LDAP_PROVIDER={
--snip--
Unbound and LDAP are configured
CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net:636 ldaps://dcldap3.hpc.amslabs.hpecorp.net:636
FIRST_URL=dcldap2.hpc.amslabs.hpecorp.net
Attempting to resolve (A record) dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has address 10.101.116.10
PASSED
```

<details>

```bash
ncn-m002:~/cspiller # ./check_goss_k8s_resolve_external_dns.sh
SYSTEM_NAME=drax
SITE_DOMAIN=hpc.amslabs.hpecorp.net
SYSTEM_DOMAIN=drax.hpc.amslabs.hpecorp.net
INGRESS=https://auth.cmn.drax.hpc.amslabs.hpecorp.net
FORWARD_ADDR=16.110.135.51
LDAP_PROVIDER={
  "id": "23ef31ae-1143-4e94-935d-4abec8b66836",
  "name": "shasta-user-federation-ldap",
  "providerId": "ldap",
  "providerType": "org.keycloak.storage.UserStorageProvider",
  "parentId": "d086f62a-b2a1-481a-88eb-4a2ae272858f",
  "config": {
    "fullSyncPeriod": [
      "-1"
    ],
    "pagination": [
      "true"
    ],
    "startTls": [
      "false"
    ],
    "connectionPooling": [
      "true"
    ],
    "usersDn": [
      "dc=dcldap,dc=dit"
    ],
    "cachePolicy": [
      "DEFAULT"
    ],
    "useKerberosForPasswordAuthentication": [
      "false"
    ],
    "importEnabled": [
      "true"
    ],
    "enabled": [
      "true"
    ],
    "changedSyncPeriod": [
      "-1"
    ],
    "usernameLDAPAttribute": [
      "uid"
    ],
    "lastSync": [
      "1728039651"
    ],
    "vendor": [
      "other"
    ],
    "uuidLDAPAttribute": [
      "uid"
    ],
    "connectionUrl": [
      "ldaps://dcldap2.hpc.amslabs.hpecorp.net:636 ldaps://dcldap3.hpc.amslabs.hpecorp.net:636"
    ],
    "allowKerberosAuthentication": [
      "false"
    ],
    "syncRegistrations": [
      "false"
    ],
    "authType": [
      "none"
    ],
    "debug": [
      "true"
    ],
    "searchScope": [
      "2"
    ],
    "useTruststoreSpi": [
      "ldapsOnly"
    ],
    "usePasswordModifyExtendedOp": [
      "false"
    ],
    "trustEmail": [
      "false"
    ],
    "priority": [
      "1"
    ],
    "userObjectClasses": [
      "posixAccount"
    ],
    "rdnLDAPAttribute": [
      "uid"
    ],
    "editMode": [
      "READ_ONLY"
    ],
    "validatePasswordPolicy": [
      "false"
    ],
    "batchSizeForSync": [
      "4000"
    ]
  }
}
Unbound and LDAP are configured
CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net:636 ldaps://dcldap3.hpc.amslabs.hpecorp.net:636
FIRST_URL=dcldap2.hpc.amslabs.hpecorp.net
Attempting to resolve (A record) dcldap2.hpc.amslabs.hpecorp.net
dcldap2.hpc.amslabs.hpecorp.net has address 10.101.116.10
PASSED
```
</details>

#### CSM health validation using old script
Using `CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net:636 ldaps://dcldap3.hpc.amslabs.hpecorp.net:636`
```
ncn-m001:~ # /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
NCN and Kubernetes Checks
------------------------------

DEBUG: cmsdev_test_list='bos cfs conman ims tftp vcs'
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20241029_112901.152373-935911-MV3uMl4m/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-m001.hmn:8998/ncn-healthcheck-master-single
Test Name: Resolve external DNS
Description: Validates that an external DNS name resolves.

The test passes if LDAP is not configured or if LDAP is configured and the first configured LDAP server hostname can be resolved.
The test fails in any of the following cases:

* Unbound is not configured
* The LDAP 'providerId' is configured but the LDAP 'connectionURL' is not.
* The LDAP server hostname fails to resolve.

In the case of failure, manually run /opt/cray/tests/install/ncn/scripts/check_goss_k8s_resolve_external_dns.sh on a Kubernetes NCN to see why the test failed.
Refer to 'operations/network/dns/Troubleshoot_Common_DNS_Issues.md' in the CSM documentation to troubleshoot external DNS issues.

Test Summary: Command: resolve_external_dns: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000020930 seconds
Node: ncn-m001



GRAND TOTAL: 647 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```
#### CSM health validation using new script 
Using `CONNECTION_URLS=ldaps://dcldap2.hpc.amslabs.hpecorp.net:636 ldaps://dcldap3.hpc.amslabs.hpecorp.net:636`
```
ncn-m001:~ # /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
NCN and Kubernetes Checks
------------------------------

DEBUG: cmsdev_test_list='bos cfs conman ims tftp vcs'
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20241029_113238.851943-960144-SAcnEddu/out

Running tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 648 passed, 0 failed

PASSED
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

