### PR TITLE
CRAYSAT-1929: Update cray-sat to 3.32.9

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.6
+      - 3.32.9
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

This includes the important fix so that CFS fields will be included in the output of `sat status` when using CFS v3 (the default).

## Issues and Related PRs

* Resolves CRAYSAT-1929

## Testing

### Tested on:

  * drax

### Test description:

Performed a regression test using the `satverify.py` script on drax.

## Risks and Mitigations

Low risk. This version increment fixes a bug in `sat status` and the code change is confined to that area.

It does also technically include two other patch versions of `cray-sat`, and those fix two minor issues, which are removing unused code. See CRAYSAT-1913 and CRAYSAT-1916.

For extra assurance, I tested this version of sat with `satverify.py` to reduce the risk. I validated the behavior for CRAYSAT-1916 with a test of `sat bootsys`, and I also tested the behavior of CRAYSAT-1913 with a call to `sat bootprep` to create a CFS configuration that used a branch of a product VCS repo.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable