### PR TITLE
CASMTRIAGE-7425 bump cray-nls and cray-iuf version to 4.1.0 for CSM 1.6.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -252,11 +252,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.0.15
+    version: 4.1.0
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.0.15
+    version: 4.1.0
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION

## Summary and Scope

Bump cray-nls and cray-iuf version to 4.1.0 for CSM 1.6.1.
This change in cray-nls fixed a race condition in the pod that was causing issues with the IUF CLI.

## Issues and Related PRs


* Resolves [CASMTRIAGE-7425](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7425)
* Relates to [CASMTRIAGE-7402](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7402)

## Testing

Tested upgrading and re-installing this chart on Beau.


## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

