### PR TITLE
MTL-2484 - Remove kube-api from all but NMN

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-trust-1.7.4-1.noarch
     - cray-cmstools-crayctldeploy-1.24.1-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cray-site-init-1.36.5-1.x86_64
+    - cray-site-init-1.36.6-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.89.0-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The kubeapi-vip only exists on the NMN however records for it get generated in other SLS networks resulting in DNS entries for services that don't exist.

This PR update CSI to remove kubeapi-vip from all SLS networks other than the NMN.

## Issues and Related PRs

* Resolves [MTL-2484](https://jira-pro.it.hpe.com:8443/browse/MTL-2484)

## Testing

### Tested on:

  * Local development environment

### Test description:

`csi config init` output was generated using seed data from surtur

Tested using local data

Old behaviour

```bash
$ jq -c '.Networks | to_entries[] | {"Network":.key, "VIP": .value.ExtraProperties.Subnets[] | select(.FullName|contains("Bootstrap")) | .IPReservations[] | select(.Name=="kubeapi-vip")}' sls_input_file.json
{"Network":"CHN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.102.193.196","Comment":"k8s-virtual-ip"}}
{"Network":"CMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.102.193.18","Comment":"k8s-virtual-ip"}}
{"Network":"HMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.254.1.2","Comment":"k8s-virtual-ip"}}
{"Network":"NMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.252.1.2","Aliases":["kubeapi-vip.local"],"Comment":"k8s-virtual-ip"}}
```

New behaviour

```bash
$ jq -c '.Networks | to_entries[] | {"Network":.key, "VIP": .value.ExtraProperties.Subnets[] | select(.FullName|contains("Bootstrap")) | .IPReservations[] | select(.Name=="kubeapi-vip")}' sls_input_file.json
{"Network":"NMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.252.1.3","Aliases":["kubeapi-vip.local"],"Comment":"k8s-virtual-ip"}}
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

