### PR TITLE
CASMPET-7262/CASMPET-7266/CASMINST-6951/CASMTRIAGE-7457: csm-testing/goss-servers fixes and improvements.

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.1-1.noarch
-    - goss-servers-1.18.1-1.noarch
+    - csm-testing-1.18.2-1.noarch
+    - goss-servers-1.18.2-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.0-1.noarch
-    - goss-servers-1.18.0-1.noarch
+    - csm-testing-1.18.1-1.noarch
+    - goss-servers-1.18.1-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.17.43-1.noarch
-    - goss-servers-1.17.43-1.noarch
+    - csm-testing-1.18.0-1.noarch
+    - goss-servers-1.18.0-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.17.42-1.noarch
-    - goss-servers-1.17.42-1.noarch
+    - csm-testing-1.17.43-1.noarch
+    - goss-servers-1.17.43-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
Contains:
* CASMPET-7266: goss-servers: Fix regex preventing goss-servers from starting on PIT nodes
* CASMINST-6951: csm-testing: Install Python code into virtual environment
* CASMPET-7262: After install/upgrade of csm-testing, automatically restart goss-servers service
* CASMTRIAGE-7457: csm-testing: Create missing Python symlinks

Backports for CASMPET-7266 and CASMPET-7262: (CASMINST-6951 and CASMTRIAGE-7457 are not being backported).
1.5: https://github.com/Cray-HPE/csm/pull/3751
1.4: https://github.com/Cray-HPE/csm/pull/3752

The version of goss-servers that has the CASMPET-7266 and CASMTRIAGE-7457 bugs is not in the CSM 1.6.0 branch, so no backport is needed there.