### PR TITLE
CASMINST-2551 - Remove unused cray-dns-unbound and cray-dhcp-kea external-dns annotations

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -45,17 +45,17 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.11.5 # update platform.yaml cray-precache-images with this
+    version: 0.11.6 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.8.3 # update platform.yaml cray-precache-images with this
+    version: 0.8.4 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.8.3
+        appVersion: 0.8.4
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -71,8 +71,8 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.5
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.3
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

The `cray-dhcp-kea` and `cray-dns-unbound` services all have erroneous external-dns annotations which lack the system domain so external-dns cannot create the records in PowerDNS.

```
time="2024-11-05T10:05:42Z" level=debug msg="ignoring record cray-dhcp-kea that does not match domain filter"
time="2024-11-05T10:05:42Z" level=debug msg="ignoring record cray-dns-unbound that does not match domain filter"
```

These annotations are not required and this PR removes them.

## Issues and Related PRs

* Resolves [CASMINST-2551](https://jira-pro.it.hpe.com:8443/browse/CASMINST-2551)

## Testing


### Tested on:

  * `wasp`
  * Local development environment
  * Virtual Shasta

### Test description:

Deployed code and verified external-dns messages for these two records are no longer logged.

Verified function of DNS and that Kea still had leases.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

