### PR TITLE
CASMTRIAGE-7445 iSCSI config wiped on all worker nodes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.27.2
+    version: 1.27.3
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
This pulls in cfs-config v1.27.3. It contains a change to the iSCSI SBPS ansible plays so that when they are re-run, if the LIO (iSCSI) system has already been initialized, it will skip wiping and re-initializing the LIO configuration.

This change is backwards compatible.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7445](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7445)

## Testing

### Tested on:

  * `gamora` and `drax`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
No known issues

## Pull Request Checklist

- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

