### PR TITLE
CASMCMS-9190: cfs-hwsync-agent: Discard components without IDs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.12.3
+    version: 1.12.4
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
This fixes an oversight in cfs-hwsync-agent that was causing it to create CFS components with empty ID fields, under certain circumstances.

Backports:
1.5: https://github.com/Cray-HPE/csm/pull/3757
1.4: https://github.com/Cray-HPE/csm/pull/3758