### PR TITLE
CASMCMS-9190: cfs-hwsync-agent: Discard components without IDs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -120,7 +120,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.11.1
+    version: 1.11.2
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/csm/pull/3756