### PR TITLE
CASMCMS-9190: cfs-hwsync-agent: Discard components without IDs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -147,7 +147,7 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.9.4
+    version: 1.9.5
     namespace: services
   - name: cfs-trust
     source: csm-algol60


### PR DESCRIPTION
CSM 1.4 backport of https://github.com/Cray-HPE/csm/pull/3756