### PR TITLE
CASMCMS-9189: Correct errors in CFS API spec which allow invalid components to be created

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.20.2
+    version: 1.21.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.20.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.21.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
These corrections do impact how the CFS server code functions, as it will now reject invalid requests that previously it erroneously permitted.

Backports:
1.5: https://github.com/Cray-HPE/csm/pull/3760
1.4: https://github.com/Cray-HPE/csm/pull/3761