### PR TITLE
CASMPET-7269/CASMPET-7270: csm-testing fixes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.2-1.noarch
-    - goss-servers-1.18.2-1.noarch
+    - csm-testing-1.18.3-1.noarch
+    - goss-servers-1.18.3-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
Addresses the following:
* CASMPET-7269: Fix broken Python symlink creation
* CASMPET-7270: Remove dependency on `requests-retry-session` RPM

No backports needed -- these issues only exist in CSM 1.6.1