### PR TITLE
CASMHMS-6288: Make status timeouts/retries configurable and update to latest hms-trs-app-api module

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.9
+    version: 2.0.10
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

This PR does two things

### Make the http timeout and retries configurable

The prior http timeout was hard coded for 30 seconds.  The change here is to make that configurable via the PCS helm chart.

Additionally, the http retry count was added and also made configurable via the PCS helm chart.

### Update to latest version hms-trs-app-api module (v2.1.1)

This version of TRS includes:

- Closure of each task's response body when the trs task list is closed.  We were likely leaking resources because they were not previously closed
- Update of the go-retryablehttp from v0.6.4 to v0.7.7, which in turn updates many of its dependencies to newer versions

Procedures I used to affect changes:

- Updated all go source files to reference /v2/ when importing hms-trs-app-api
- Ran `go get github.com/Cray-HPE/hms-trs-app-api/v2@v2.1.1`
- Ran `go mod tidy`
- Ran `go mod vendor`

Additionally had to add `-tags musl` to all `go build` and `go test` lines in dockerfiles in order to force confluent-kafka-go to use musl instead of glibc in the alpine images we use.

Finally, the new version of hms-trs-app-api also requires that PCS be compiled with 1.17 so I updated to this from 1.16.

Adopted app version 2.5.0 for CSM 1.5.3 (helm chart 2.0.10)

## Issues and Related PRs

* Resolves [CASMHMS-6288](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6288)

## Testing

Tested on:

  * `rocket`

- Confirmed status requests still being sent to BMCs and responses processed correctly.
- Did soft-restart of several BMCs to ensure responses to them timed out.  Status was updated to 'undefined' in etcd.  When BMCs were reachable again status was updated to 'on' in etcd.
- Ran many iterations of `run_hms_ct_tests.sh -t pcs` without any failures
- Monitored PCS and etcd logs for issues
- Captured resource utilization at deployment time and again after a long weekend.  Confirmed we still have resource leakage but consistent with observations prior to these changes
- Captured variety of other metrics to verify no regressions

Test Checklist

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [y] Version number(s) incremented, if applicable
- [y] Copyrights updated
- [y] License file intact
- [y] Target branch correct
- [y] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable