### PR TITLE
CASMTRIAGE-7459 iscsid needs to run on compute/UAN

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.27.3
+    version: 1.27.4
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
This pulls in cfs-config v1.27.4

The iscsid service is the control path for iSCSI. It needs to be running when we are using iSCSI projection, so that if the worker nodes (target side) are rebooted or rebuilt, the iSCSI sessions will be recovered on the compute/UAN.

We also need to enable multipathd for when we are running with USS 1.1 for the hybrid solution (need SP5 on compute nodes for NVIDIA support).

## Issues and Related PRs

* Resolves [CASMTRIAGE-7459](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7459)

## Testing

### Tested on:

  * `gamora`

### Test description:
This change (having the `iscsid` service running) has been tested on `fanta`, `drax`, and `gamora`. When the `iscsid` service is running in the compute/UAN, then when a worker node is rebooted or rebuilt, the `iscsid` service is notified by the kernel of the failure, and it re-establishes the session.

If the `iscsid` service is not running, the session to that worker node enters the faulty state, and stays in that state.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
If images are still being booted via DVS, then the iscsid service isn't being used and doesn't necessarily need to be running. However, iscsid sits in a loop poll()ing for events, so if iSCSI projection isn't being used iscsid won't be doing anything.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

