### PR TITLE
CASMPET-7271/CASMCMS-9199: csm-testing/product catalog updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -186,7 +186,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.5.0
+            tag: 2.6.0
   - name: cray-ims
     source: csm-algol60
     version: 3.20.0
@@ -215,7 +215,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.5.0
+            tag: 2.6.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -254,7 +254,7 @@ spec:
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
     # Also update the catalog:image:tag value in the barebones recipe section.
-    version: 2.5.0
+    version: 2.6.0
     namespace: services
 
   # Spire service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.3-1.noarch
-    - goss-servers-1.18.3-1.noarch
+    - csm-testing-1.18.4-1.noarch
+    - goss-servers-1.18.4-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.4-1.noarch
-    - goss-servers-1.18.4-1.noarch
+    - csm-testing-1.18.5-1.noarch
+    - goss-servers-1.18.5-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
* CASMPET-7271: Remove Python requests dependencies from csm-testing virtual environment. This addresses the SSL certificate errors and requests dependency warnings seen on the most recent CSM 1.6.1-alpha.2 build.
* CASMCMS-9199: Mark Cray Product Catalog Python package as supporting Python 3.6; Add it to csm-testing virtual environment

No backports needed to CSM 1.6.0 or to any earlier releases -- the problem CASMPET-7271 addresses is only in CSM 1.6.1, and the csm-testing virtual environment only is present in CSM 1.6.1.