### PR TITLE
CRAYSAT-1917: Update cray-sat to 3.32.10

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.9
+      - 3.32.10
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Update the sat container image to 3.32.10_

## Issues and Related PRs

_This backports the following fixes._

* Resolves [CRAYSAT-1917](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1917): https://github.com/Cray-HPE/sat/pull/280

## Testing

_See the linked PR._

## Risks and Mitigations

_See the linked PR_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

