### PR TITLE
CASMCMS-9196/CASMCMS-9197/CASMCMS-9198/CASMCMS-9200/CASMCMS-9202/CASMCMS-9206: CFS bug fixes and improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.22.0
+    version: 1.23.1
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.22.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.1/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.23.1
+    version: 1.23.2
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.2/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.21.0
+    version: 1.22.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.21.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.22.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
* [CASMCMS-9196](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9196) - Fix CFS Exception when trying to create Source
* [CASMCMS-9197](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9197) - Bypass needless work in some CFS queries
* [CASMCMS-9198](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9198) - Prevent invalid option values from causing CFS CLBO
* [CASMCMS-9200](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9200) - Fix a thread safety bug and performance issue in CFS server
* [CASMCMS-9202](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9202) - Add CFS v3 API option to enable restoring Source data from backup
* [CASMCMS-9206](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9206) - Fix bug preventing creation of some V3 configurations

All of these issues also exist in CSM 1.5, but not earlier versions.

Given that all of these problems also exist in CSM 1.5, I doubt they will be approved to get pulled into CSM 1.6.0, so I'm not making that backport.

CSM 1.5 backport: https://github.com/Cray-HPE/csm/pull/3771
