### PR TITLE
CASMTRIAGE-7489: SBPS handle missing "etag"

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -65,7 +65,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python311-requests-retry-session-0.1.5-1.noarch
     - python312-requests-retry-session-0.1.5-1.noarch
     - python39-requests-retry-session-0.1.5-1.noarch
-    - sbps-marshal-0.0.8-1.noarch
+    - sbps-marshal-0.0.12-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
## Summary and Scope
Pull in sbps-marshal-0.0.12

o Gracefully handle the case where an IMS record is missing the "etag"
  field, by skipping the record rather than having the app crash.

o Restart the sbps-marshal service after it fails.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7489](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7489)

## Testing
### Tested on:

  * `odin`

### Test description:

Manually applied the changes to the worker nodes and restarted the `sbps-marshal` service.  Verified via the journalctl logs that the offending IMS record was identified and ignored.  Also verified via `targetcli ls` that images were being projected.

## Risks and Mitigations
There are no known risks

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

