### PR TITLE
CASMCMS-9207/CASMCMS-9208/CASMCMS-9210/CASMCMS-9211: CFS fixes/improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,14 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.23.2
+    version: 1.23.4
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      # The version in the following URL does not match the service version because it
-      # only contains changes to the API spec which do not alter the service behavior
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.3/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.4/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.23.4
+    version: 1.23.5
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.4/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.5/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -146,7 +146,9 @@ spec:
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.2/api/openapi.yaml
+      # The version in the following URL does not match the service version because it
+      # only contains changes to the API spec which do not alter the service behavior
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.23.3/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
* CASMCMS-9207: Correct incorrect status code in CFS API spec
* CASMCMS-9208: Fix bug in new POST sources/{source_id} action
* CASMCMS-9210: Correctly check additional_inventory layers when seeing if a source is in use
* CASMCMS-9211: Improve performance of configuration delete operation

CSM 1.5 backport: https://github.com/Cray-HPE/csm/pull/3775
