### PR TITLE
CRAYSAT-1895: Updated the version number for cray-sat to 3.32.11

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.11
+      - 3.32.12
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.10
+      - 3.32.11
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope



This change resolves both [CRAYSAT-1895](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1895) and [CRAYSAT-1551](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1551) by incrementing the version number to 3.32.12


## Issues and Related PRs

* Resolves [CRAYSAT-1895](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1895)
* Resolves [CRAYSAT-1551](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1551)

## Testing

### Tested on:

  * Drax
  * Local development environment


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

