### PR TITLE
CASMPET-7273: TESTS: k8s-verify-cluster: Prevent false failures from etcdbackup job pods

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.5-1.noarch
-    - goss-servers-1.18.5-1.noarch
+    - csm-testing-1.18.6-1.noarch
+    - goss-servers-1.18.6-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
Backports:
1.5: https://github.com/Cray-HPE/csm/pull/3781
1.4: https://github.com/Cray-HPE/csm/pull/3782