### PR TITLE
CASMCMS-9217: Fix memory leak in console-node

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -166,7 +166,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.5.0
+    version: 2.6.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
Backports:

1.5: https://github.com/Cray-HPE/csm/pull/3785