### PR TITLE
CASMCMS-9217: Fix memory leak in console-node

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -166,7 +166,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.3.2
+    version: 2.3.3
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
CSM 1.5 backport of https://github.com/Cray-HPE/csm/pull/3784