### PR TITLE
CASMCMS-9219: Fix bug causing CFS server CLBO

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -141,12 +141,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.28/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.18.14
+    version: 1.18.15
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.14/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.18.15/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.9.3


### PR DESCRIPTION
This fixes a bug that causes the CFS server to get stuck in CLBO.

No backports needed to other releases -- this problem is unique to CSM 1.5.