### PR TITLE
CASMPET-7104: Fix kyverno running pods test

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,7 +44,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.6-1.noarch
+    - csm-testing-1.18.7-1.noarch
     - goss-servers-1.18.6-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch


### PR DESCRIPTION
## Summary and Scope
Fixed the `k8s_kyverno_pods_running.sh` goss test in csm-testing for CSM 1.6

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7104
https://github.com/Cray-HPE/csm-testing/pull/636

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

