### PR TITLE
CRAYSAT-1941: updated the version number for cray-sat to 3.32.13

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.32.12
+      - 3.33.1
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

Update the version of cray-sat to 3.33.1. This includes the fixes for
the following Jiras:

- CRAYSAT-1941: Allow for missing rootfs_provider key in bootprep files
- CRAYSAT-1896: Add support for CFS v2 or v3 to `sat bootprep`

## Issues and Related PRs

* Resolves [CRAYSAT-1941](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1941)
* Resolves [CRAYSAT-1896](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1896)

## Testing

### Tested on:

  * Local development environment
  * rocket

### Test description:

See PRs in Cray-HPE/sat for testing details.

## Risks and Mitigations

Low risk, adequately tested.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

