### PR TITLE
CASMHMS-6299: Fix PCS/TRS resource leaks and scaling issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.0.10
+    version: 2.0.11
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

A variety of changes related to PCS/TRS scaling issues being experienced in the field.  PCS details are as follows:

- Updated hms-trs-app-api vendor code (bug fixes and enhancements)
- Passed PCS's log level through to TRS to match PCS's
- Configured TRS to use connection pools for status requests to BMCs
- Renamed PCS_STATUS_HTTP_TIMEOUT to PCS_STATUS_TIMEOUT as it is not an http timeout
- Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables which allow overriding PCS's connection pool settings in TRS
- Added PCS_BASE_TRS_TASK_TIMEOUT env variable which allows the timeout for power transitions and capping to be configured
- The above variables are configurable on PCS's helm chart
- At PCS start time, log all env variables that were set
- Added PodName global to facilitate easier debug of log messages
- Log start and end of large batched requests to BMCs
- Fixed many resource leaks associated with making http requests and using TRS
- Update required version of Go to 1.23 to avoid [ https://github.com/golang/go/issues/59017](https://github.com/golang/go/issues/59017)

PCS helm chart changes:

- Update timeoutSeconds for liveness probe from 1 to 3
- Added following env variables to make it easier to configure them:

`        - name: PCS_BASE_TRS_TASK_TIMEOUT`
`          value: "40"`
`        - name: PCS_STATUS_TIMEOUT`
`          value: "30"`
`        - name: PCS_STATUS_HTTP_RETRIES`
`          value: "3"`
`       - name: PCS_MAX_IDLE_CONNS`
`          value: "4000"`
`        - name: PCS_MAX_IDLE_CONNS_PER_HOST`
`          value: "4"`

Adopted app version 2.6.0 for CSM 1.5.3 (helm chart 2.0.11)

## Issues and Related PRs

* Resolves [CASMHMS-6299](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6299)

## Testing

Test description:

Testing was two-pronged, unit testing (in TRS) and testing on a live system.  The majority of testing was done through the TRS unit test framework.  Extensive unit tests were added for all aspects of the connection lifecycle.

These changes were also tested alongside TRS changes on both `mug` and `rocket`.  Rocket is a CSM 1.5 system and mug is a CSM 1.6 system.  Additionally, mug was running several thousand simulated BMCs on compute nodes so that the scaling aspects of these changes could be tested.  All standard PCS operations were confirmed to continue working.

While we do not have any systems internally that are able to reproduce all of the problems at customer sites, we believe this change will go a long ways towards improving most of the issues being experienced.

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N (not deployable on its own)
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N (not deployable on its own)
- Was downgrade tested? If not, why? N (not deployable on its own)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

