### PR TITLE
CASMPET-7288/CASMPET-7290: csm-testing: Improvements

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.8-1.noarch
-    - goss-servers-1.18.8-1.noarch
+    - csm-testing-1.18.9-1.noarch
+    - goss-servers-1.18.9-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.6-1.noarch
-    - goss-servers-1.18.6-1.noarch
+    - csm-testing-1.18.8-1.noarch
+    - goss-servers-1.18.8-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
* CASMPET-7288: Minimize use of system Python packages in virtual environment

    From an end-user perspective, this changes nothing. It's purely to enable some things that the IUF folks need in order to add their tests to `csm-testing`.

* CASMPET-7290: Add pylint to csm-testing build pipeline

    Also invisible to the end user.

I tested the updated `csm-testing`/`goss-servers` on mug and verified that no problems were introduced.

No backports -- this is for CSM 1.6.1+ only.