### PR TITLE
CASMPET-7037: remove old multus image

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -37,7 +37,7 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=6.2.33
+KUBERNETES_IMAGE_ID=6.2.34
 
 # Resolve globs in KUBERNETES_IMAGE_ID, e.g. 6.2.* > 6.2.30
 KUBERNETES_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/kubernetes/${KUBERNETES_IMAGE_ID}" "kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs")))
@@ -52,7 +52,7 @@ KUBERNETES_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=6.2.33
+PIT_IMAGE_ID=6.2.34
 # Resolve globs in PIT_IMAGE_ID, e.g. 6.2.* > 6.2.30
 PIT_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/pre-install-toolkit/${PIT_IMAGE_ID}" "pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso")))
 PIT_ASSETS=(
@@ -60,7 +60,7 @@ PIT_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=6.2.33
+STORAGE_CEPH_IMAGE_ID=6.2.34
 # Resolve globs in STORAGE_CEPH_IMAGE_ID, e.g. 6.2.* > 6.2.30
 STORAGE_CEPH_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}" "storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs")))
 STORAGE_CEPH_ASSETS=(
@@ -70,7 +70,7 @@ STORAGE_CEPH_ASSETS=(
 )
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=6.2.33
+COMPUTE_IMAGE_ID=6.2.34
 for arch in "${CN_ARCH[@]}"; do
     # Resolve globs in COMPUTE_IMAGE_ID, e.g. 6.2.* > 6.2.30
     COMPUTE_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/compute/${COMPUTE_IMAGE_ID}" "compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs")))

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -116,7 +116,6 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Multus required by platform
     ghcr.io/k8snetworkplumbingwg/multus-cni:
-      - v3.9.1
       - v3.9.3
 
     # Note this is the new layout for k8s 1.22 for coredns upstream the above


### PR DESCRIPTION
## Summary and Scope

Since we switched multus image from v3.9.1 to v3.9.3, we don't need the old multus image v3.9.1 anymore in CSM 1.6. This PR removes multus image v3.9.1 for CSM 1.6 and onward.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7037](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7037)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

