### PR TITLE
CASMCMS-9166 - IMS - fix arch value in image delete/undelete.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -189,12 +189,12 @@ spec:
             tag: 2.6.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.20.0
+    version: 3.21.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.20.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.21.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.10.2


### PR DESCRIPTION
## Summary and Scope

The primary change is to fix a bug in IMS where an image loses the 'arch' value when it is soft deleted. The following 'undelete' operation would then change the 'arch' value to x86_64 even if the original image was aarch64. This change preserves the correct arch value through the delete/undelete operation.

This also picks up new versions of the ims-utils and ims-sshd images for small fixes.
CASMCMS-9226 - CAST relating to mis-spelling in log output.
CASMCMS-9037 - Removing openssh elements that are not required to prevent future CVE issues.

## Issues and Related PRs
* Resolves [CASMCMS-9166](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9166)
* Resolves [CASMCMS-9226](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9226)
* Resolves [CASMCMS-9037](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9037)

## Testing
### Tested on:
  * `Mug`

### Test description:

I used Helm to install the test version on Mug and insured that delete/undelete now retains the correct 'arch' value throughout.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

