### PR TITLE
CASMTRIAGE-7469 - update csm-config for new base image.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -205,7 +205,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.27.4
+    version: 1.28.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

The barebones compute image created from the node-images repo underwent several changes. This PR reflects changes in the ansible plays that configure that image based on the new version.

We no longer need to use the SUSE zypper repos to configure the IMS remote build image.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7469](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7469)

## Testing
### Tested on:
  * `Wasp`

### Test description:

I modified the ansible code on wasp to match the changes here, then ran manually ran through the procedure to create and use the IMS remote build functionality. I also ran the barebones boot test to insure the current image and ansible plays work for that.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change that should only impact the use of the barebones compute image which is only used for CSM testing.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
