### PR TITLE
CASMHMS-6295: Resolved some scaling/resource issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -79,7 +79,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.19.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.16.7
+    version: 2.16.8
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Resolved some scaling/resource issues relating to:

- Draining/closing HTTP response/request bodies
- Explicitly calling cancel on any created contexts
- Explicitly closing any created communication channels

Additionally, for consistency with similar changes to other HSM services, updated to use Go 1.23.

Adopted app version 2.34.0 for both CSM 1.5.3 and CSM 1.6.1 (helm chart 2.16.8)

### Issues and Related PRs

* Resolves [CASMHMS-6299](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6299)

## Testing

Test description:

All integration and unit tests pass in the build pipeline.

Deployed on rocket and:

- Confirmed correct functionality with no regressions
- Enabled logging in ingress deployment for x9000c1s2b0 to verify telemetry still streaming for it to kafka
- Power cycled x9000c1s2b0n0 and confirmed power on/off events still received and logged
- Verified in all hmcollector logs no sign of errors during all testing
- Unfortunately, no system CT tests exist for hmcollector

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable