### PR TITLE
CASMHMS-6310: Fix FAS resource leaks and scaling issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,7 +53,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.8
+    version: 3.1.10
     namespace: services
     swagger:
     - name: firmware-action


### PR DESCRIPTION
### Summary and Scope

Various changes including:

- Resolved various scaling/resource issues
- Update to latest TRS
- Update to Go 1.23 as result of updating to latest TRS
- Updated python to alpine:3.18 in all Dockerfiles to avoid pipenv install issue

Adopted app version 1.35.0 for CSM 1.5.3 (helm chart 3.0.10)
Adopted app version 1.35.0 for CSM 1.6.1 (helm chart 3.1.10)

### Issues and Related PRs

* Resolves [CASMHMS-6310](https://github.com/Cray-HPE/hms-trs-app-api/tree/CASMHMS-6310)

### Testing

Tested Description:

All integration and unit tests pass in the build pipeline.

Deployed on mug (CSM 1.6) and rocket (CSM 1.5) and verified all ```/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t fas``` tests succeeded.

Mike performed manual testing on mug.

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable