### PR TITLE
CASMPET-6707: Add pre-install hook to check for system-nexus-client-auth secret

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -26,7 +26,7 @@
 export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/packaging-tools:0.14.0}
 export RPM_TOOLS_IMAGE=${RPM_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/rpm-tools:1.0.0}
 export SKOPEO_IMAGE=${SKOPEO_IMAGE:-artifactory.algol60.net/csm-docker/stable/quay.io/skopeo/stable:v1}
-export CRAY_NEXUS_SETUP_IMAGE=${CRAY_NEXUS_SETUP_IMAGE:-artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0}
+export CRAY_NEXUS_SETUP_IMAGE=${CRAY_NEXUS_SETUP_IMAGE:-artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1}
 
 if [ -z "${ARTIFACTORY_USER}" ] || [ -z "${ARTIFACTORY_TOKEN}" ]; then
     echo "Missing authentication information for image download. Please set ARTIFACTORY_USER and ARTIFACTORY_TOKEN environment variables."

--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.12.2
+    version: 0.13.0
     namespace: nexus

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -85,7 +85,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.0
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
   - name: cray-kyverno
     source: csm-algol60
     version: 1.6.5


### PR DESCRIPTION
## Summary and Scope
Update nexus manifest to use `cray-nexus` version `0.13.0`.

Version 0.13.0 contains pre-install and pre-upgrade helm hooks that checks for the existence of the `system-nexus-client-auth` secret since it is needed to create the `nexus-keycloak-realm-config` secret.

Also, updating all `cray-nexus-setup` versions to 0.11.1, except what is defined in `vendor/github.hpe.com/hpe/`.

## Issues and Related PRs
* Resolves [CASMPET-6707](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6707)

## Testing
Tested both pre-install and pre-upgrade paths with and without the `system-nexus-client-auth secret`. If the secret doesn't exist, the hook will continue to wait until it is found or the helm pre-install/pre-upgrade time limit expires. If the time limit is hit, the helm install/upgrade will fail.

### Tested on:
- `beau` vShasta system

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

