### PR TITLE
CASMNET-2271 - Update cray-dns-unbound in CSM 1.5.3

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -55,11 +55,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.7.26 # update platform.yaml cray-precache-images with this
+    version: 0.7.28 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.7.26
+        appVersion: 0.7.28
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,7 +69,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.27
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.26
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.28
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.3.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.3
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

Update the version the `cray-dns-unbound` chart to fix a deployment problem seen on vex.

This issue was already fixed in [CASMNET-2223](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2223) and `cray-dns-unbound` 0.7.28 however it appears CSM 1.5 never received this version.

## Issues and Related PRs

* Resolves [CASMNET-2271](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2271)

## Testing

### Tested on:

* Previously tested as this code is already in CSM 1.6. will also get tested as part of the next CSM 1.5.3 build.

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

