### PR TITLE
CASMTRIAGE-7607: Add docker-kubectl:1.24.17 to nexus cray-precache-images list

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -86,6 +86,7 @@ spec:
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
   - name: cray-kyverno
     source: csm-algol60
     version: 1.6.5

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -47,6 +47,8 @@ spec:
     values:
       cacheRefreshSeconds: "120"
       cacheImages:
+      # Common Images
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       # Kubernetes
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
@@ -76,7 +78,6 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
-      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
@@ -86,7 +87,6 @@ spec:
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
-      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
   - name: cray-kyverno
     source: csm-algol60
     version: 1.6.5


### PR DESCRIPTION
## Summary and Scope
Add `docker-kubectl:1.24.17` image used in a pre-install and pre-upgrade hook to the `cray-precache-images` `cacheImages` list for `cray-nexus`.

``` 
      # cray-nexus
      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
```

## Issues and Related PRs

* Resolves [CASMTRIAGE-7607](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7607)

## Testing
Will be tested during vShasta 1.5.3 to 1.6.1 upgrade run.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

