### PR TITLE
Allow new ipxe debug options to be inserted into builds globally

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.14.2
+    version: 1.15.0
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Manifest change to allow additional build options into the ipxe image build process.

## Issues and Related PRs

* Resolves [CASMCMS-9068](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9068)

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Deployed chart and image and tested a new debug flag

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

