### PR TITLE
Update index to use new csm-testing

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,7 +44,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.9-1.noarch
+    - csm-testing-1.18.10-1.noarch
     - goss-servers-1.18.9-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Upgrade CSM-testing RPM to use new RPM generated from https://github.com/Cray-HPE/csm-testing/pull/647, which is a PR updating the storage tests to also test unused drives.

## Issues and Related PRs

* Related to https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7569
* Related to https://github.com/Cray-HPE/csm-testing/pull/647

## Risks and Mitigations

Testing will now need to use the IUF feature branch to ensure that the correct tests are being run.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

