### PR TITLE
CASMPET-7251 bump cray-keycloak chart version to 5.1.3

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -200,7 +200,7 @@ spec:
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.3
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bump cray-keycloak chart version to 5.1.3.

This incorporates this change https://github.com/Cray-HPE/keycloak-installer/pull/64 into CSM 1.6.1.

## Issues and Related PRs

* Resolves [CASMPET-7251](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7251)

## Testing

### Tested on:

  * Beau (vShasta2)

### Test description:

Tested chart upgrade and rollback.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- x ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

