### PR TITLE
Updated csm-redfish-interface-emulator for vshasta

### DIFF
--- a/manifests/vshasta.yaml
+++ b/manifests/vshasta.yaml
@@ -10,5 +10,5 @@ spec:
   charts:
   - name: csm-redfish-interface-emulator
     source: csm-algol60
-    version: 0.1.0
+    version: 0.1.1
     namespace: services


### PR DESCRIPTION
## Summary and Scope

Updated csm-redfish-interface-emulator for vshasta

This version of the chart uses a app version that can be built. The previous version of the app could not be rebuilt due to issues with pip install.

CASMPET-7291

## Issues and Related PRs

* Resolves [CASMPET-7291](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7291)

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

