### PR TITLE
Update `cray-sat` container image to 3.33.9

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.33.5
+      - 3.33.9
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

This will update `cray-sat` container image from 3.33.5 to 3.33.9 which includes fixes for the following issues:

- CRAYSAT-1875: Added support to new HSM Types, namely `CabinetPDU`,
  `CabinetPDUController`, `CabinetPDUPowerConnector` and `MgmtSwitch` in `sat
  status`.
- CRAYSAT-1945: Fixed the traceback error encountered during session checks in
  CFS v2 when using a smaller page size.
- CRAYSAT-1942: Drop internal default values for `rootfs_provider` and
  `rootfs_provider_passthrough` in `sat bootprep`.
- CRAYSAT-1948: Fix traceback in `sat swap blade`.

## Issues and Related PRs

* Resolves CRAYSAT-1875: https://github.com/Cray-HPE/sat/pull/302
* Resolves CRAYSAT-1945: https://github.com/Cray-HPE/sat/pull/306
* Resolves CRAYSAT-1942: https://github.com/Cray-HPE/sat/pull/304
* Resolves CRAYSAT-1948: https://github.com/Cray-HPE/sat/pull/303

## Testing

_See the linked PRs._

## Risks and Mitigations

_See the linked PRs_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

