### PR TITLE
CASMCMS-9236/CASMCMS-9225: BOS bug fix and improvement

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.6
+    version: 2.30.7
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.6/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.7/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.5

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.5
+    version: 2.30.6
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.5/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.6/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.5


### PR DESCRIPTION
* CASMCMS-9236: This fixes a bug in the BOS migration code. For CSM 1.6.0 it is being handled with a workaround in docs-csm, so this is only targeted for CSM 1.6.1. No backports to prior CSM versions needed -- the bug is new in CSM 1.6.
* CASMCMS-9225: BOS scaling performance improvement. This part will be backported to other CSM releases.