### PR TITLE
CASMHMS-6282: Update Alpine base image to resolve CVE

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,7 +53,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.10
+    version: 3.1.11
     namespace: services
     swagger:
     - name: firmware-action


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.18 to 3.19 to resolve reported CVE's.  Decided not to use the latest Alpine image 3.21 as I didn't want to inject any more risk than necessary into CSM 1.6.1 just before the end of the release cycle.

Detailed changes include:

- Update Alpine base image to resolve CVE
- New Alpine base image implemented PEP 668 which required switching to a virtual python environment in our dockerfiles
- Broke up RUN directive in dockerfiles for easier reading
- Remove obsolete version field from docker-compose files

Adopted app version 1.36.0 for CSM 1.6.1 (helm chart 3.1.11)

### Issues and Related PRs

* Resolves [CASMHMS-6282](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6282)

### Testing

Tested on:

* `mug`

Test Description: 

Deployed on mug.  Ran functional tests and confirmed no failures.  Performed various FAS operations and confirmed no issues.  Watched FAS logs to ensure no errors reported.

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable