### PR TITLE
CASMCMS-9225: BOS scale performance improvement

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.28
+    version: 2.10.29
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.28/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.29/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.15


### PR DESCRIPTION
CSM 1.5.3 backport of just the CASMCMS-9225 content from https://github.com/Cray-HPE/csm/pull/3816