### PR TITLE
CASMCMS-9225: BOS scale performance improvement

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,13 +159,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.47
+    version: 2.0.48
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.47/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.48/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.11


### PR DESCRIPTION
CSM 1.4.5 backport of just the CASMCMS-9225 content from https://github.com/Cray-HPE/csm/pull/3816