### PR TITLE
CASMCMS-9225: Fix bug in original backport of CASMCMS-9225

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.29
+    version: 2.10.30
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.29/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.30/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.15


### PR DESCRIPTION
This fixes the bug found with the original backport for CASMCMS-9225. I have tested this and verified that it works.