### PR TITLE
CASMCMS-9225: Fix bug in original backport of CASMCMS-9225

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,13 +159,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.48
+    version: 2.0.49
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.48/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.49/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.11


### PR DESCRIPTION
This fixes the bug found with the original backport for CASMCMS-9225. I have tested this and verified that it works.