### PR TITLE
CASMSEC-505: Kyverno background policy scans are ignoring resourceFilters

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.5
+    version: 1.6.6
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Kyverno generates policy reports for all the resources in the cluster currently, including the kube-system namespace as the resource filters are by default skipped in the upstream chart.

This change sets the skipResourceFilters: false flag in the values.yaml under features.backgroundScan to enable resource filters. This reduces more than 100 kyverno baseline policy failures caused by the kube-system namespace.

## Issues and Related PRs

* Resolves [CASMSEC-505](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-505)

## Testing

### Tested on:

  * `Surtur`

### Test description:

[surtur-logs-chart-test-0601-1758.txt](https://github.com/user-attachments/files/18319477/surtur-logs-chart-test-0601-1758.txt)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

