### PR TITLE
CASMSEC-505: Update platform.yaml to enable resourceFilters in cray-kyverno

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -88,7 +88,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.5
+    version: 1.6.6
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The latest version of cray-kyverno which is v1.6.6 has the change for supporting resourceFilters. Hence we are submitting platform.yaml change to include latest cray-kyverno version that is v1.6.6.

## Testing

Redeploy the cray-Kyverno chart and checked for zero policy failures in kube-system as well as kyverno namespaces.
Checked for baseline policy violations and they were reduced by more than 100 as expected.

### Tested on:

Surtur

### Test description:

[surtur-logs-chart-test-0601-1758.txt](https://github.com/user-attachments/files/18320215/surtur-logs-chart-test-0601-1758.txt)
