### PR TITLE
Bugfix for whitespace fix from helmcharts

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -128,7 +128,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.15.0
+    version: 1.15.1
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Fixes a bug that was introduced in v1.15.0 that resulted in whitespace characters from helmcharts to throw an exception in makefile rules.

## Issues and Related PRs

* Resolves [CASMCMS-9068](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9068)

## Testing

Currently deployed to mug and working.

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Chart was synced and deployed to mug to verify the new field does not crash either builders.

## Risks and Mitigations

This is a bugfix; without which we cannot boot nodes.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

