### PR TITLE
CASMCMS-9242: Add BOS v2 options to change API read timeouts

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.30
+    version: 2.10.31
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.30/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.31/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.15

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.10.28-1.noarch
+    - bos-reporter-2.10.31-1.noarch
     - cani-0.3.0-1.x86_64
     - canu-1.8.0-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch
@@ -36,8 +36,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-cmstools-crayctldeploy-1.16.5-1.x86_64
     - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
-    - craycli-0.82.18-1.aarch64
-    - craycli-0.82.18-1.x86_64
+    - craycli-0.82.19-1.aarch64
+    - craycli-0.82.19-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.6-1.aarch64
     - csm-node-heartbeat-2.6-1.x86_64


### PR DESCRIPTION
CSM 1.5.3 backport of https://github.com/Cray-HPE/csm/pull/3828