### PR TITLE
CASMNET-2240/CASMNET-2273 - Add CMN to mgmt ACL and apply that ACL to the CSM VRF

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-2.30.8-1.noarch
     - cani-0.4.0-1.x86_64
-    - canu-1.9.4-1.x86_64
+    - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.0-1.noarch
     - cfs-trust-1.7.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

Both changes apply to systems with network switch configuration generated using CANU 1.8.0 or later (CSM 1.5 and above).

* Apply the `mgmt` access control list to the CSM VRF to prevent unauthorized access to management switches from river nodes over the NMN
* Add the CMN to the `mgmt` access control list to permit SSH, HTTPS, and SMNP over the CMN and resolve a CSM validation test failure

## Issues and Related PRs

* Resolves [CASMNET-2240](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2240) and [CASMNET-2273](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2273)

## Testing

### Tested on:

  * `hela`
  * Local development environment

### Test description:

Generated configuration for `hela` and applied it to the switches. All CSM validation checks pass and SSH over the NMN is no longer possible.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

