### PR TITLE
CASMHMS-6324: Added support for pprof builds

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,7 +12,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.0.1
+    version: 6.0.2
     namespace: services
     swagger:
     - name: sls
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.6.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.19
+    version: 7.1.20
     namespace: services
     values:
       cray-service:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.2.5
+    version: 3.2.6
     namespace: services
     timeout: 10m
     swagger:
@@ -53,7 +53,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.12
+    version: 3.1.13
     namespace: services
     swagger:
     - name: firmware-action
@@ -61,7 +61,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.33.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: services
     timeout: 10m
     swagger:
@@ -70,7 +70,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.21.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 4.0.5
+    version: 4.0.6
     namespace: services
     timeout: 10m
     swagger:
@@ -79,7 +79,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.22.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.16.8
+    version: 2.16.9
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
@@ -105,7 +105,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.1.10
+    version: 2.1.12
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed services with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) were successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable