### PR TITLE
CASMTRIAGE-7663: Update cfs-state-reporter RPM requirements to avoid error

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cani-0.4.0-1.x86_64
     - canu-1.9.4-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
-    - cfs-state-reporter-1.12.0-1.noarch
+    - cfs-state-reporter-1.12.1-1.noarch
     - cfs-trust-1.7.4-1.noarch
     - cray-cmstools-crayctldeploy-1.25.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
@@ -60,11 +60,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.7.0-1.noarch
     - python3-liveness-1.4.3-1.noarch
-    - python3-requests-retry-session-0.1.5-1.noarch
-    - python310-requests-retry-session-0.1.5-1.noarch
-    - python311-requests-retry-session-0.1.5-1.noarch
-    - python312-requests-retry-session-0.1.5-1.noarch
-    - python39-requests-retry-session-0.1.5-1.noarch
+    - python3-requests-retry-session-0.1.8-1.noarch
+    - python310-requests-retry-session-0.1.8-1.noarch
+    - python311-requests-retry-session-0.1.8-1.noarch
+    - python312-requests-retry-session-0.1.8-1.noarch
+    - python39-requests-retry-session-0.1.8-1.noarch
     - sbps-marshal-0.0.13-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64


### PR DESCRIPTION
This fixes a problem with cfs-state-reporter breaking in CSM 1.6.1.

No backports needed.