### PR TITLE
CASMCMS-9245: Update RPMs to avoid requisite failure

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.8
+    version: 2.30.9
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.8/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.9/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.5

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,7 +126,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.7.4
+    version: 1.7.5
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.9
+    version: 2.30.10
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.9/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.10/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.5

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.30.8-1.noarch
+    - bos-reporter-2.30.9-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,12 +25,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.30.9-1.noarch
+    - bos-reporter-2.30.10-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
-    - cfs-state-reporter-1.12.1-1.noarch
-    - cfs-trust-1.7.4-1.noarch
+    - cfs-state-reporter-1.12.2-1.noarch
+    - cfs-trust-1.7.5-1.noarch
     - cray-cmstools-crayctldeploy-1.25.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.6-1.x86_64
@@ -65,6 +65,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python311-requests-retry-session-0.1.8-1.noarch
     - python312-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.1.8-1.noarch
+    - python3-requests-retry-session-0.2.3-1.noarch
+    - python310-requests-retry-session-0.2.3-1.noarch
+    - python311-requests-retry-session-0.2.3-1.noarch
+    - python312-requests-retry-session-0.2.3-1.noarch
+    - python39-requests-retry-session-0.2.3-1.noarch
     - sbps-marshal-0.0.13-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64


### PR DESCRIPTION
This updates the bos-reporter, cfs-trust, and cfs-state-reporter RPM requirements to ensure they doesn't pull in a version of the requests_retry_session RPM that will cause problems, or try to pull in a version which will cause install failures.

No backports needed