### PR TITLE
CASMCMS-9241, CASMCMS-9248: cfs-debugger fixes.

### DIFF
--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - cfs-debugger-1.9.1-1.x86_64
+    - cfs-debugger-1.9.2-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
-    - cfs-debugger-1.9.1-1.x86_64
+    - cfs-debugger-1.9.2-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
-    - cfs-debugger-1.9.1-1.x86_64
+    - cfs-debugger-1.9.2-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64

--- a/rpm/cray/csm/sle-15sp6/index.yaml
+++ b/rpm/cray/csm/sle-15sp6/index.yaml
@@ -23,6 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp6/:
   rpms:
-    - cfs-debugger-1.9.1-1.x86_64
+    - cfs-debugger-1.9.2-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64


### PR DESCRIPTION
This fixes a minor service status parsing bug.

Backport PRs:
1.7: https://github.com/Cray-HPE/csm/pull/3843
1.5: https://github.com/Cray-HPE/csm/pull/3844
1.4: https://github.com/Cray-HPE/csm/pull/3845