### PR TITLE
CASMCMS-9241, CASMCMS-9247: cfs-debugger fixes

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -29,7 +29,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cani-0.3.0-1.x86_64
     - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.6.1-1.noarch
-    - cfs-debugger-1.5.0-1.noarch
+    - cfs-debugger-1.5.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
     - cfs-state-reporter-1.11.1-1.noarch
     - cfs-trust-1.6.9-1.noarch


### PR DESCRIPTION
CSM 1.5: backport of https://github.com/Cray-HPE/csm/pull/3842

Inlcudes fix for fatal cfs-debugger issue
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9247