### PR TITLE
CASMCMS-9241, CASMCMS-9248: cfs-debugger fixes

### DIFF
--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - bos-reporter-2.0.50-1.x86_64
     - canu-1.7.1-2.x86_64
     - cf-ca-cert-config-framework-2.5.0-1.x86_64
-    - cfs-debugger-1.3.1-1.x86_64
+    - cfs-debugger-1.3.2-1.x86_64
     - cfs-state-reporter-1.9.1-1.x86_64
     - cfs-trust-1.6.3-1.x86_64
     - cray-cmstools-crayctldeploy-1.10.11-1.x86_64


### PR DESCRIPTION
CSM 1.4: backport of https://github.com/Cray-HPE/csm/pull/3842

Inlcudes fix for fatal cfs-debugger issue
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9248