### PR TITLE
CASMPET-7308: Update csm-testing RPM for 1.7

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,7 +44,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.14-1.noarch
+    - csm-testing-1.19.2-1.noarch
     - goss-servers-1.18.14-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update csm-testing RPM to the latest version to account for changes to csm-testing made to `ncn-upgrades-tests-storage` in https://github.com/Cray-HPE/csm-testing/pull/647. 

## Issues and Related PRs

* Originally related to [CASMTRIAGE-7569](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7569)
* Done as part of [CASMPET-7308](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7308)
* Related to https://github.com/Cray-HPE/docs-csm/pull/5654

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

