### PR TITLE
CASMCMS-9203: cms-ipxe Create unique Job name.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -130,7 +130,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.15.1
+    version: 1.15.2
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
This fixes a minor bug to avoid "Job name conflict".