### PR TITLE
BOS changes for CSM 1.7

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.10
+    version: 2.32.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.10/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.32.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.5

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-2.30.10-1.noarch
+    - bos-reporter-3.2.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
@@ -59,16 +59,26 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.6.0-3.68.1_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.7.0-1.noarch
+    - python3-bos-reporter-3.2.0-1.aarch64
+    - python3-bos-reporter-3.2.0-1.x86_64
     - python3-liveness-1.4.3-1.noarch
     - python3-requests-retry-session-0.1.8-1.noarch
-    - python310-requests-retry-session-0.1.8-1.noarch
-    - python311-requests-retry-session-0.1.8-1.noarch
-    - python312-requests-retry-session-0.1.8-1.noarch
-    - python39-requests-retry-session-0.1.8-1.noarch
     - python3-requests-retry-session-0.2.3-1.noarch
+    - python310-bos-reporter-3.2.0-1.aarch64
+    - python310-bos-reporter-3.2.0-1.x86_64
+    - python310-requests-retry-session-0.1.8-1.noarch
     - python310-requests-retry-session-0.2.3-1.noarch
+    - python311-bos-reporter-3.2.0-1.aarch64
+    - python311-bos-reporter-3.2.0-1.x86_64
+    - python311-requests-retry-session-0.1.8-1.noarch
     - python311-requests-retry-session-0.2.3-1.noarch
+    - python312-bos-reporter-3.2.0-1.aarch64
+    - python312-bos-reporter-3.2.0-1.x86_64
+    - python312-requests-retry-session-0.1.8-1.noarch
     - python312-requests-retry-session-0.2.3-1.noarch
+    - python39-bos-reporter-3.2.0-1.aarch64
+    - python39-bos-reporter-3.2.0-1.x86_64
+    - python39-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.2.3-1.noarch
     - sbps-marshal-0.0.13-1.noarch
     - smart-mon-1.0.3-1.noarch


### PR DESCRIPTION
Pulls in fixes/changes for the following:

* CASMCMS-9149: Update autoscaling apiVersion to support updated Kubernetes in CSM 1.7
* CASMCMS-9242: Add BOS options: bss_read_timeout, ims_read_timeout, hsm_read_timeout, pcs_read_timeout
* CASMCMS-9237: Added paging for component listing; add context managers around requests
* CASMCMS-9180: Move bos-reporter into its own repository
* CASMCMS-9251: Build bos-reporter RPM for aarch64 and x86_64