### PR TITLE
CASMINST-7114: Fix syntax error in rgw_endpoint_check text

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.18.14-1.noarch
-    - goss-servers-1.18.14-1.noarch
+    - csm-testing-1.19.3-1.noarch
+    - goss-servers-1.19.3-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.1-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
CSM 1.7 backport of https://github.com/Cray-HPE/csm/pull/3854