### PR TITLE
CASMCMS-9255: Fix bug in BOS power operator

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.32.0
+    version: 2.32.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.32.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.32.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.24.0


### PR DESCRIPTION
CSM 1.6.1 backport: https://github.com/Cray-HPE/csm/pull/3859