### PR TITLE
CASMPET-7248: cray-istio to v3.1.0 with autoscaling/v2 for k8s upgrade

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -152,7 +152,7 @@ spec:
     namespace: cert-manager
   - name: cray-istio
     source: csm-algol60
-    version: 3.0.0
+    version: 3.1.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

In preparation for the upgrade to K8s 1.32 in CSM v1.7, the cray-istio HorizontalPodAutoscaler needs to use apiVersion autoscaling/v2, since autoscaling/v2beta2 will not be available starting in K8s 1.26+.

## Issues and Related PRs

* Resolves [CASMPET-7248](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7248)
* [cray-istio PR](https://github.com/Cray-HPE/cray-istio/pull/47) merged

## Testing
Tested on beau with helm upgrade. You can see the warnings about autoscaling/v2beta2 on rollback.

```
pit:~/studenym # helm upgrade -n istio-system cray-istio cray-istio-3.0.1-20250116183846+cbf8356.tgz
Release "cray-istio" has been upgraded. Happy Helming!
NAME: cray-istio
LAST DEPLOYED: Thu Jan 16 19:25:06 2025
NAMESPACE: istio-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
A Cray-specific Istio chart
pit:~/studenym # helm list -n istio-system
NAME               	NAMESPACE   	REVISION	UPDATED                                	STATUS  	CHART                                  	APP VERSION
cray-istio         	istio-system	2       	2025-01-16 19:25:06.489437476 +0000 UTC	deployed	cray-istio-3.0.1-20250116183846+cbf8356	1.19.10
cray-istio-deploy  	istio-system	1       	2025-01-13 14:30:55.632653297 +0000 UTC	deployed	cray-istio-deploy-2.0.1                	1.19.10
cray-istio-operator	istio-system	1       	2025-01-13 14:30:53.556527841 +0000 UTC	deployed	cray-istio-operator-2.0.0              	1.19.10
pit:~/studenym # helm history -n istio-system cray-istio
REVISION	UPDATED                 	STATUS    	CHART                                  	APP VERSION	DESCRIPTION
1       	Mon Jan 13 14:33:26 2025	superseded	cray-istio-3.0.0                       	1.19.10    	Install complete
2       	Thu Jan 16 19:25:06 2025	deployed  	cray-istio-3.0.1-20250116183846+cbf8356	1.19.10    	Upgrade complete
pit:~/studenym # helm rollback -n istio-system cray-istio 1
W0116 19:41:37.899734    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.922915    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.961895    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.974514    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:37.986042    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.030097    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.051505    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.075605    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.095884    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.107726    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.114586    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
W0116 19:41:38.120408    4522 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
Rollback was a success! Happy Helming!
pit:~/studenym #
```
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

