### PR TITLE
CASMCMS-9254: Update bos-reporter RPM

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.4
+KUBERNETES_IMAGE_ID=7.0.5
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.4
+PIT_IMAGE_ID=7.0.5
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.4
+STORAGE_CEPH_IMAGE_ID=7.0.5
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.4
+COMPUTE_IMAGE_ID=7.0.5
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-3.2.0-1.noarch
+    - bos-reporter-3.3.0-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
@@ -59,25 +59,15 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.6.0-3.68.1_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.7.0-1.noarch
-    - python3-bos-reporter-3.2.0-1.aarch64
-    - python3-bos-reporter-3.2.0-1.x86_64
     - python3-liveness-1.4.3-1.noarch
     - python3-requests-retry-session-0.1.8-1.noarch
     - python3-requests-retry-session-0.2.3-1.noarch
-    - python310-bos-reporter-3.2.0-1.aarch64
-    - python310-bos-reporter-3.2.0-1.x86_64
     - python310-requests-retry-session-0.1.8-1.noarch
     - python310-requests-retry-session-0.2.3-1.noarch
-    - python311-bos-reporter-3.2.0-1.aarch64
-    - python311-bos-reporter-3.2.0-1.x86_64
     - python311-requests-retry-session-0.1.8-1.noarch
     - python311-requests-retry-session-0.2.3-1.noarch
-    - python312-bos-reporter-3.2.0-1.aarch64
-    - python312-bos-reporter-3.2.0-1.x86_64
     - python312-requests-retry-session-0.1.8-1.noarch
     - python312-requests-retry-session-0.2.3-1.noarch
-    - python39-bos-reporter-3.2.0-1.aarch64
-    - python39-bos-reporter-3.2.0-1.x86_64
     - python39-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.2.3-1.noarch
     - sbps-marshal-0.0.13-1.noarch

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,5 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
+    - python3-bos-reporter-3.3.0-1.aarch64
+    - python3-bos-reporter-3.3.0-1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -27,3 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
     - cfs-debugger-1.9.3-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
+    - python39-bos-reporter-3.3.0-1.aarch64
+    - python39-bos-reporter-3.3.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -27,3 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
     - cfs-debugger-1.9.3-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
+    - python310-bos-reporter-3.3.0-1.aarch64
+    - python310-bos-reporter-3.3.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -27,3 +27,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
     - cfs-debugger-1.9.3-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
+    - python311-bos-reporter-3.3.0-1.aarch64
+    - python311-bos-reporter-3.3.0-1.x86_64

--- a/rpm/cray/csm/sle-15sp6/index.yaml
+++ b/rpm/cray/csm/sle-15sp6/index.yaml
@@ -27,3 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp6/:
     - cfs-debugger-1.9.3-1.x86_64
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
+    - python311-bos-reporter-3.3.0-1.aarch64
+    - python311-bos-reporter-3.3.0-1.x86_64
+    - python312-bos-reporter-3.3.0-1.aarch64
+    - python312-bos-reporter-3.3.0-1.x86_64


### PR DESCRIPTION
This updates the bos-reporter RPM version (and updates to images that contain this RPM version). No backports.