### PR TITLE
CASMHMS-5678: PCS: Update image and module dependencies

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,7 +107,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.1.12
+    version: 2.2.0
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Fixed a bunch of pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

Updating the hms-base module included code changes required to reference code that was moved from hms-base to the hms-xname module.

The tavern tests were updated to look for a returned 404 http code rather than a 405 code due to the gorilla/mux change https://github.com/gorilla/mux/pull/712 that came with updating the gorilla module.

Updates to hms-certs, hms-compcredentials, and hms-securestorage were not included.  A new Jira will be created to handle them seperately.  This is because updating these modules will require functional changes surrounding vault use due to the changes associated with CASMHMS-5445.

Adopted app version 2.9.0 for CSM 1.7.0 (helm chart 2.2.0)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Ran PCS smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable