### PR TITLE
CASMNET-2280 - Update Cilum to 1.16.5

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.5
+KUBERNETES_IMAGE_ID=7.0.7
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.5
+PIT_IMAGE_ID=7.0.7
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.5
+STORAGE_CEPH_IMAGE_ID=7.0.7
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.5
+COMPUTE_IMAGE_ID=7.0.7
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -161,7 +161,7 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/cilium/operator-generic:
       - v1.16.5
     quay.io/cilium/cilium-envoy:
-      - v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
+      - v1.30.8
 
     # Cilium Hubble images
     quay.io/cilium/hubble-relay:

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -157,17 +157,19 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Cilium images required by platform
     quay.io/cilium/cilium:
-      - v1.14.1
+      - v1.16.5
     quay.io/cilium/operator-generic:
-      - v1.14.1
+      - v1.16.5
+    quay.io/cilium/cilium-envoy:
+      - v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
 
     # Cilium Hubble images
     quay.io/cilium/hubble-relay:
-      - v1.14.1
+      - v1.16.5
     quay.io/cilium/hubble-ui:
-      - v0.12.0
+      - v0.13.1
     quay.io/cilium/hubble-ui-backend:
-      - v0.12.0
+      - v0.13.1
 
     # Cilium Tetragon images
     quay.io/cilium/tetragon:


### PR DESCRIPTION
## Summary and Scope

- Upgrade Cilium to 1.16.5
- Include Argo Workflow CLI in the NCN image

## Issues and Related PRs

* Resolves [CASMNET-2280](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2280)
* Resolves [CASMPET-7358](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7358)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Tested on the vshasta system `scanlan` with `k8s-primary-cni = "cilium"`. System deployed successfully and Cilium is running with the correct versions.
```
ncn-m001:~ # cilium status
    /¯¯\
 /¯¯\__/¯¯\    Cilium:             OK
 \__/¯¯\__/    Operator:           OK
 /¯¯\__/¯¯\    Envoy DaemonSet:    OK
 \__/¯¯\__/    Hubble Relay:       OK
    \__/       ClusterMesh:        disabled

DaemonSet              cilium             Desired: 6, Ready: 6/6, Available: 6/6
DaemonSet              cilium-envoy       Desired: 6, Ready: 6/6, Available: 6/6
Deployment             cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
Deployment             hubble-relay       Desired: 1, Ready: 1/1, Available: 1/1
Deployment             hubble-ui          Desired: 1, Ready: 1/1, Available: 1/1
Containers:            cilium             Running: 6
                       cilium-envoy       Running: 6
                       cilium-operator    Running: 1
                       hubble-relay       Running: 1
                       hubble-ui          Running: 1
Cluster Pods:          288/288 managed by Cilium
Helm chart version:    1.16.5
Image versions         cilium             artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5: 6
                       cilium-envoy       artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8: 6
                       cilium-operator    artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5: 1
                       hubble-relay       artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5: 1
                       hubble-ui          artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1: 1
                       hubble-ui          artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1: 1
```

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

