### PR TITLE
CASM-5240: Update cray-externaldns version number

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Upgrade `cray-externaldns` version number to account for recent upgrade.

## Issues and Related PRs

* Resolves [CASM-5240](https://jira-pro.it.hpe.com:8443/browse/CASM-5240)
* Change to chart: https://github.com/Cray-HPE/cray-externaldns/pull/6
* New image PR: https://github.com/Cray-HPE/container-images/pull/651

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

New chart launched onto systems to ensure that images started correctly and image tested for correctness by deleting a record utilizing external-dns and then confirming that it was correctly relaunched.

## Risks and Mitigations

None


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

