### PR TITLE
CASMNET-2197 - Add cilium images to the precache image list

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -86,6 +86,13 @@ spec:
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
+      # Cilium
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
     version: 1.6.6


### PR DESCRIPTION
## Summary and Scope

Add Cilium images to cray-precache-images.

## Issues and Related PRs

* Resolves [CASMNET-2197](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2197)

Only merge after these two PRs have been merged

* https://github.com/Cray-HPE/node-images/pull/1201
* https://github.com/Cray-HPE/csm/pull/3865

## Testing

### Tested on:

  * `wasp`
  * vShasta `scanlan`

### Test description:

Ensured required images were present in Nexus on target system.

Redeployed cray-precache-images with new values
```
ncn-m001:~ # helm -n nexus get values cray-precache-images
USER-SUPPLIED VALUES:
cacheImages:
- artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
- artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
- artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
- artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
- artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
- artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
- artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
- artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
- artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
- artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
- artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
- artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
- artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
- artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
- artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
- artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.68.1-1
- artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
cacheRefreshSeconds: "120"
global:
  chart:
    name: cray-precache-images
    version: 0.6.0
```
Verified Cilium images were synced to node
```
ncn-m001:~ # kubectl -n nexus logs cray-precache-images-dwtf9 | grep -A1 cilium
Caching image: artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
  Image is up to date for sha256:6b040117a97d65b31cf3df26301f80005214b9ab2d28afe435b8249f28e79155
Caching image: artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
  Image is up to date for sha256:dabaa35c8374a17524a04a39774f213ba5981cfd9048d0ff263a06f6a457da2e
Caching image: artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
  Image is up to date for sha256:5cf238db2a79dd8d1a2076e2a4b241133309d548362241bf91effa08f0f5b2d7
Caching image: artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
  Image is up to date for sha256:7139f50a676d2936261ccfbd607f985e8e42181e4f4238c5a2e5ebf04c80b712
Caching image: artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
  Image is up to date for sha256:12daf69c12ef91b3d583014a81174e297e40a1ae1d43fa4adb46b31aebd79b0b
Caching image: artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
  Image is up to date for sha256:0f78824e40d7357e7ab236d0a304dbad836b1a0d86b574d930b36c8403748c3e
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

