### PR TITLE
CASMCMS-9258: Only install cfs-debugger on management NCNs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.28.0
+    version: 1.29.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
This modifies csm-config so that the cfs-debugger RPM is only installed/updated on management NCNs.

Backports:
1.6.2: https://github.com/Cray-HPE/csm/pull/3877
1.5.4: https://github.com/Cray-HPE/csm/pull/3878
1.5.3: https://github.com/Cray-HPE/csm/pull/3879