### PR TITLE
CASMCMS-9258: Only install cfs-debugger on management NCNs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.28.0
+    version: 1.28.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
CSM 1.6.2 backport of https://github.com/Cray-HPE/csm/pull/3876