### PR TITLE
CASMCMS-9258: Only install cfs-debugger on management NCNs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.16.34
+    version: 1.16.35
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
CSM 1.5.4 backport of https://github.com/Cray-HPE/csm/pull/3876