### PR TITLE
CASMHMS-5678: hmcollector: Update image and module dependencies

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -79,7 +79,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.22.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.16.9
+    version: 2.17.0
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Added musl tag in builds which is required for newer versions of kafka

Updating the hms-base module included code changes required to reference code that was moved from hms-base to the hms-xname module.

Updates to hms-certs, hms-compcredentials, and hms-securestorage were not included.  A new Jira will be created to handle them seperately.  This is because updating these modules will require functional changes surrounding vault use due to the changes associated with CASMHMS-5445.

Adopted app version 2.17.0 for CSM 1.7.0 (helm chart 2.36.0)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Updated surtur with new version.  Ensured no issues in log files.  Power cycled node to ensure state changes rippled back to SMD.

Tested on:

* `surtur`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

### High Level Diff of Changes
```
> diff -r charts/v2.16/ charts/v2.17/
diff -r charts/v2.16/cray-hms-hmcollector/Chart.yaml charts/v2.17/cray-hms-hmcollector/Chart.yaml
3c3
< version: 2.16.9
---
> version: 2.17.0
11c11
< appVersion: "2.35.0"  # update pprof image version below as well
---
> appVersion: "2.36.0"  # update pprof image version below as well
15c15
<       image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.35.0
---
>       image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.36.0
diff -r charts/v2.16/cray-hms-hmcollector/values.yaml charts/v2.17/cray-hms-hmcollector/values.yaml
3c3
<   appVersion: 2.35.0
---
>   appVersion: 2.36.0
```