### PR TITLE
CASMPET-7246: Bump cray-drydock from 2.18.4 to 2.19.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.18.4
+    version: 2.19.0
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Upgrade the Sonar sync CronJob to use the batch/v1 API, which has been available since K8s 1.21, and which is unavailable in K8s 1.25+. This is necessary for the CSM 1.7/K8s upgrade.

## Issues and Related PRs

This is the version bump that corresponds to [cray-drydock#45](https://github.com/Cray-HPE/cray-drydock/pull/45).

Resolves [CASMPET-7246](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7246).

## Testing, and Risks and Mitigations

See [cray-drydock#45](https://github.com/Cray-HPE/cray-drydock/pull/45).

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

