### PR TITLE
CASMPET-7333: Update node images and manifests with K8s 1.32.0 images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -37,13 +37,13 @@ KERNEL_VERSION='6.4.0-150600.23.17-default'
 KUBERNETES_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7697ff9-1738008960392
+PIT_IMAGE_ID=7.0.5
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7697ff9-1738008960392
+STORAGE_CEPH_IMAGE_ID=7.0.5
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7697ff9-1738008960392
+COMPUTE_IMAGE_ID=7.0.5
 
 # Public keys for RPM signature validation.
 #

--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.5
+KUBERNETES_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.5
+PIT_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.5
+STORAGE_CEPH_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.5
+COMPUTE_IMAGE_ID=7697ff9-1738008960392
 
 # Public keys for RPM signature validation.
 #

--- a/assets.sh
+++ b/assets.sh
@@ -37,13 +37,13 @@ KERNEL_VERSION='6.4.0-150600.23.17-default'
 KUBERNETES_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.5
+PIT_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.5
+STORAGE_CEPH_IMAGE_ID=7697ff9-1738008960392
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.5
+COMPUTE_IMAGE_ID=7697ff9-1738008960392
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -118,32 +118,38 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Note this is the new layout for k8s 1.22 for coredns upstream the above
     # will go away for k8s 1.23+
-    k8s.gcr.io/coredns/coredns:
-      - v1.8.4
+    # k8s.gcr.io/coredns/coredns:
+    #   - v1.8.4
     registry.k8s.io/coredns/coredns:
       - v1.8.6
+      - v1.11.3
 
     # Kube images required by platform
-    k8s.gcr.io/kube-apiserver:
-      - v1.22.13
+    # k8s.gcr.io/kube-apiserver:
+    #   - v1.22.13
     registry.k8s.io/kube-apiserver:
       - v1.24.17
-    k8s.gcr.io/kube-controller-manager:
-      - v1.22.13
+      - v1.32.0
+    # k8s.gcr.io/kube-controller-manager:
+    #   - v1.22.13
     registry.k8s.io/kube-controller-manager:
       - v1.24.17
-    k8s.gcr.io/kube-proxy:
-      - v1.22.13
+      - v1.32.0
+    # k8s.gcr.io/kube-proxy:
+    #   - v1.22.13
     registry.k8s.io/kube-proxy:
       - v1.24.17
-    k8s.gcr.io/kube-scheduler:
-      - v1.22.13
+      - v1.32.0
+    # k8s.gcr.io/kube-scheduler:
+    #   - v1.22.13
     registry.k8s.io/kube-scheduler:
       - v1.24.17
-    k8s.gcr.io/pause:
-      - 3.5
+      - v1.32.0
+    # k8s.gcr.io/pause:
+    #   - 3.5
     registry.k8s.io/pause:
       - 3.7
+      - 3.10
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
 

--- a/hack/embedded-repo.sh
+++ b/hack/embedded-repo.sh
@@ -11,9 +11,9 @@ if [ $# -ne 1 ] || ([ "${1}" != "--validate" ] && [ "${1}" != "--download" ]); t
     echo "Lists of packages and repo configurations, installed onto NCN images, "
     echo "are expected to be published along with NCN image files as:"
     echo ""
-    echo "    csm-images/stable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.packages"
-    echo "    csm-images/stable/<ncn_type>/<ncn_version>/installed.deps-<ncn_version>-<arch>.packages"
-    echo "    csm-images/stable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.repos"
+    echo "    csm-images/unstable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.packages"
+    echo "    csm-images/unstable/<ncn_type>/<ncn_version>/installed.deps-<ncn_version>-<arch>.packages"
+    echo "    csm-images/unstable/<ncn_type>/<ncn_version>/installed-<ncn_version>-<arch>.repos"
     echo ""
     echo "With --validate, validate presence of all RPM packages in repositories."
     echo "With --download, download RPMs into ${BUILDDIR}/rpm/embedded, filtering out those which are alredy in ${BUILDDIR}/rpm,"
@@ -33,7 +33,7 @@ for LIST_TYPE in installed installed.deps; do
         "pre-install-toolkit/${PIT_IMAGE_ID}/${LIST_TYPE}-${PIT_IMAGE_ID}-${NCN_ARCH}.packages" \
         "kubernetes/${KUBERNETES_IMAGE_ID}/${LIST_TYPE}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.packages" \
         "storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${LIST_TYPE}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.packages"; do
-            curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/stable/${LIST_URL}"
+            curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/unstable/${LIST_URL}"
     done
 done | tr '=' '-' | sort -u > "${TMPDIR}/ncn.rpm-list"
 
@@ -52,7 +52,7 @@ for REPOS_URL in \
     "pre-install-toolkit/${PIT_IMAGE_ID}/installed-${PIT_IMAGE_ID}-${NCN_ARCH}.repos" \
     "kubernetes/${KUBERNETES_IMAGE_ID}/installed-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.repos" \
     "storage-ceph/${STORAGE_CEPH_IMAGE_ID}/installed-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.repos"; do
-        curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/stable/${REPOS_URL}"
+        curl -Ss -f -u "${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/csm-images/unstable/${REPOS_URL}"
 done | grep -E '^baseurl=https://' \
      | sed -e 's/^baseurl=//' \
      | sed -e 's|https://[^@]*@|https://|' \

--- a/hack/resolve-globs.sh
+++ b/hack/resolve-globs.sh
@@ -28,9 +28,9 @@ source "${ROOTDIR}/assets.sh"
 source "${ROOTDIR}/common.sh"
 
 # Resolve globs in KUBERNETES_IMAGE_ID, e.g. 6.2.* > 6.2.30
-KUBERNETES_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/kubernetes/${KUBERNETES_IMAGE_ID}" "kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs")))
+KUBERNETES_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "unstable/kubernetes/${KUBERNETES_IMAGE_ID}" "kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs")))
 # Resolve globs in KERNEL_VERSION, e.g. 6.4.0-*-default > 6.4.0-150600.23.17-default
-KERNEL_PATH=$(resolve_globs "csm-images" "stable/kubernetes/${KUBERNETES_IMAGE_ID}" "${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel")
+KERNEL_PATH=$(resolve_globs "csm-images" "unstable/kubernetes/${KUBERNETES_IMAGE_ID}" "${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel")
 KERNEL_VERSION=$(basename "${KERNEL_PATH}")
 KERNEL_VERSION=${KERNEL_VERSION%-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel}
 
@@ -43,31 +43,31 @@ KERNEL_VERSION=${KERNEL_VERSION%-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel}
 KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
 
 KUBERNETES_ASSETS=(
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/initrd.img-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.xz"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/kubernetes/${KUBERNETES_IMAGE_ID}/${KERNEL_VERSION}-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/kubernetes/${KUBERNETES_IMAGE_ID}/initrd.img-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.xz"
 )
 
 # Resolve globs in PIT_IMAGE_ID, e.g. 6.2.* > 6.2.30
-PIT_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/pre-install-toolkit/${PIT_IMAGE_ID}" "pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso")))
+PIT_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "unstable/pre-install-toolkit/${PIT_IMAGE_ID}" "pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso")))
 PIT_ASSETS=(
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/pre-install-toolkit/${PIT_IMAGE_ID}/pre-install-toolkit-${PIT_IMAGE_ID}-${NCN_ARCH}.iso"
 )
 
 # Resolve globs in STORAGE_CEPH_IMAGE_ID, e.g. 6.2.* > 6.2.30
-STORAGE_CEPH_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}" "storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs")))
+STORAGE_CEPH_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}" "storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs")))
 STORAGE_CEPH_ASSETS=(
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
-    "https://artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/initrd.img-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.xz"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/storage-ceph-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.squashfs"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/${KERNEL_VERSION}-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.kernel"
+    "https://artifactory.algol60.net/artifactory/csm-images/unstable/storage-ceph/${STORAGE_CEPH_IMAGE_ID}/initrd.img-${STORAGE_CEPH_IMAGE_ID}-${NCN_ARCH}.xz"
 )
 
 for arch in "${CN_ARCH[@]}"; do
     # Resolve globs in COMPUTE_IMAGE_ID, e.g. 6.2.* > 6.2.30
-    COMPUTE_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "stable/compute/${COMPUTE_IMAGE_ID}" "compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs")))
+    COMPUTE_IMAGE_ID=$(basename $(dirname $(resolve_globs "csm-images" "unstable/compute/${COMPUTE_IMAGE_ID}" "compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs")))
     eval "COMPUTE_${arch}_ASSETS"=\( \
-        "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \
-        "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/${KERNEL_VERSION}-${COMPUTE_IMAGE_ID}-${arch}.kernel" \
-        "https://artifactory.algol60.net/artifactory/csm-images/stable/compute/${COMPUTE_IMAGE_ID}/initrd.img-${COMPUTE_IMAGE_ID}-${arch}.xz" \
+        "https://artifactory.algol60.net/artifactory/csm-images/unstable/compute/${COMPUTE_IMAGE_ID}/compute-${COMPUTE_IMAGE_ID}-${arch}.squashfs" \
+        "https://artifactory.algol60.net/artifactory/csm-images/unstable/compute/${COMPUTE_IMAGE_ID}/${KERNEL_VERSION}-${COMPUTE_IMAGE_ID}-${arch}.kernel" \
+        "https://artifactory.algol60.net/artifactory/csm-images/unstable/compute/${COMPUTE_IMAGE_ID}/initrd.img-${COMPUTE_IMAGE_ID}-${arch}.xz" \
     \)
 done

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -51,12 +51,19 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.8.6
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.24.17
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.24.17
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.24.17
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.24.17
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
+      # Kubernetes 1.32
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless


### PR DESCRIPTION
## Summary and Scope

Created K8s 1.32 node images - unstable - and want to get them into the feature branch to see if they work on install. 

## Issues and Related PRs

* Resolves [CASMPET-7333](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7333)
* Only merge to `feature/kubernetes-upgrade` at this point

## Testing
Once merged to `feature/kubernetes-upgrade` branch, will create tag to trigger an install on `molly` vShasta system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

