### PR TITLE
Use new image without extra 'v' in coredns version

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7697ff9-1738008960392
+KUBERNETES_IMAGE_ID=983e633-1738157476520
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7697ff9-1738008960392
+PIT_IMAGE_ID=983e633-1738157476520
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7697ff9-1738008960392
+STORAGE_CEPH_IMAGE_ID=983e633-1738157476520
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7697ff9-1738008960392
+COMPUTE_IMAGE_ID=983e633-1738157476520
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope

Use *_IMAGE_ID 983e633-1738157476520 that has coredns version fix.

## Issues and Related PRs

*  [CASMPET-7333](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7333)

## Testing

Will tag with `v1.7.0-k8s.1` after merge to start install on `molly` and upgrade on `orym`.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

