### PR TITLE
CASMCMS-9201 - fix orphaned artifacts in S3.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -180,12 +180,12 @@ spec:
             tag: 2.2.3
   - name: cray-ims
     source: csm-algol60
-    version: 3.15.0
+    version: 3.15.1
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.15.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.15.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.4


### PR DESCRIPTION
## Summary and Scope

The 'soft delete' of IMS objects used the S3 'copy_from' command. This command does the copy in a single atomic operation but is limited to artifacts less than 5Gb in size. When the rootfs files got bigger than 5Gb, the copy into the 'deleted objects' location would fail, leaving them behind. Then when the 'deleted image' was deleted, these artifacts were not removed from S3.

The fix is to use the S3 'copy' command which uses a multi-part copy if the object is too larger for the single operation copy. There is an issue with S3/boto3 where the multi-part copy fails if the artifact is owned by a different user than the 'IMS' user. I had to put code in to handle the copy differently if the artifact is owned by 'STS' which is the case if 'cray artifacts create' is used to load the artifact into S3.

## Issues and Related PRs
* Resolves [CASMCMS-9201](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9201)

## Testing
### Tested on:
  * `Hela`

### Test description:

The new service was upgraded via helm chart and verified that the delete / undelete / hard delete worked as expected with all size artifacts and the 'STS' owner.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be fairly low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable