### PR TITLE
CASMPET-7631: Use etcd 3.5.16 in node images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=983e633-1738157476520
+KUBERNETES_IMAGE_ID=187f243-1738182776328
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=983e633-1738157476520
+PIT_IMAGE_ID=187f243-1738182776328
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=983e633-1738157476520
+STORAGE_CEPH_IMAGE_ID=187f243-1738182776328
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=983e633-1738157476520
+COMPUTE_IMAGE_ID=187f243-1738182776328
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope

Use images with etcd 3.5.16.

## Issues and Related PRs

* Resolves [CASMPET-7631](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7361)

## Testing
Testing will happen once `feature/kubernetes-upgrade` branch is tagged.  New CSM  will be installed on `molly` and we should get past the etcd error seen in the last install.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

