### PR TITLE
CASMMON-469 delete SMA postgres VMscrapeserive for SMA

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -164,7 +164,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.1.5
+    version: 1.1.6
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
CASMMON-469 delete SMa postgres VMscrapeserive for SMA

tested in drax

ncn-m001:/mnt/developer/ram/smh # kubectl get vmservicescrapes.operator.victoriametrics.com -n sysmgmt-health |grep sma
ncn-m001:/mnt/developer/ram/smh #

kubectl get svc -n sysmgmt-health |grep sma
ncn-m001:/mnt/developer/ram/smh #

kubectl logs -n sysmgmt-health vmagent-vms-1-657bf795fb-zl96s vmagent |grep suppressScrapeErrorsDelay
2025-01-31T05:07:11.175Z info VictoriaMetrics/lib/logger/flag.go:20 -promscrape.suppressScrapeErrorsDelay="10m0s"