### PR TITLE
CASMCMS-9263: Improve performance of CFS component queries

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,12 +143,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.32.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.24.0
+    version: 1.25.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.24.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.25.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
When it is queried for components, the CFS code has a number of inefficiencies. These are not a problem except on large scale systems, where they can lead to timeouts, disrupting CFS batcher from being able to get the information it needs to create jobs to configure nodes.

The same problem existed in BOS, and was fixed. This makes similar changes for CFS.

Backports:
1.6.2: https://github.com/Cray-HPE/csm/pull/3894
1.5.4: https://github.com/Cray-HPE/csm/pull/3895
1.4.5: https://github.com/Cray-HPE/csm/pull/3896