### PR TITLE
CASMPET-7333: Update kubeadm config to use kubeadm.k8s.io/v1beta4

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=60de6ae-1738276494695
+KUBERNETES_IMAGE_ID=ba2349f-1738371226862
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=60de6ae-1738276494695
+PIT_IMAGE_ID=ba2349f-1738371226862
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=60de6ae-1738276494695
+STORAGE_CEPH_IMAGE_ID=ba2349f-1738371226862
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=60de6ae-1738276494695
+COMPUTE_IMAGE_ID=ba2349f-1738371226862
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION

## Summary and Scope
Update kubeadm config in node images to use kubeadm.k8s.io/v1beta4 in InitConfiguration and ClusterConfiguration.

## Issues and Related PRs

* Continues work on [CASMPET-7333](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7333)

## Testing
This change addresses the error found during install of `molly`.
```
W0131 15:30:50.097417   13594 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

