### PR TITLE
CASMCMS-9262: Update RPM lists in csm-config

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.29.0
+    version: 1.30.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
The list of RPMs installed/updated when CFS runs needed some small updates to ensure we were updating the appropriate RPMs, but only those, and not pulling in others.

Backports:
CSM 1.6.2: https://github.com/Cray-HPE/csm/pull/3899
CSM 1.5.4: https://github.com/Cray-HPE/csm/pull/3900