### PR TITLE
CASMCMS-9266: Resolve CVEs in console-node and console-operator

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -163,12 +163,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.12.0
+    version: 1.13.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.7.0
+    version: 2.8.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
Update some dependencies to resolve CVEs in these services.

1.6.2 backport: https://github.com/Cray-HPE/csm/pull/3903