### PR TITLE
CASMTRIAGE-7715 - fix console log file permissions and CVE updates.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -168,7 +168,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.7.0
+    version: 2.8.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

Something has been changing the directory permissions as well as log file permissions. This looks at directories as well, and tweaks the checking logic.

This also picks up some CVE vulnerability updates.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7715](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7715)
* Resolves [CASMCMS-9266](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9266)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the test image, then would manually change the file permissions of the log files and directories. Watching the pod log files and file/directory permissions I verified that they were set back to correctly giving read/write access.

There were a few times the node pod crashed when a file was unexpectedly read-only, but it would restart and the permissions were corrected and the restarted pod worked as expected. This should be acceptable.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a safe fix - it only tries to correct a bad situation.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable