### PR TITLE
CASMCMS-9267: Resolve CVEs in cray-cmstools

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.2-1.noarch
     - cfs-trust-1.7.5-1.noarch
-    - cray-cmstools-crayctldeploy-1.25.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.26.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.6-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch


### PR DESCRIPTION
Update Golang dependency to resolve CVE.

Backports:
1.7: https://github.com/Cray-HPE/csm/pull/3909