### PR TITLE
Casmtriage 7735

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -185,7 +185,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Images needed by IUF and possibly non-CSM products
     cray-nexus-setup:
-      - 0.11.1
+      - 0.11.2
 
     # not needed for build/install as it comes packaged as skopeo.tar
     quay.io/skopeo/stable:


### PR DESCRIPTION
## Summary and Scope

updating the version of cray-nexus-setup to 0.11.2

## Issues and Related PRs

* Resolves [CASMTRIAGE-7735](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7735)
* https://github.com/Cray-HPE/nexus-setup/pull/31
* https://github.com/Cray-HPE/docs-csm/pull/5720

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

