### PR TITLE
CASMPET-7371: Add 'pspEnabled: false' to some charts.

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=c517042-1738699084146
+KUBERNETES_IMAGE_ID=3adce44-1738721016141
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=c517042-1738699084146
+PIT_IMAGE_ID=3adce44-1738721016141
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=c517042-1738699084146
+STORAGE_CEPH_IMAGE_ID=3adce44-1738721016141
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=c517042-1738699084146
+COMPUTE_IMAGE_ID=3adce44-1738721016141
 
 # Public keys for RPM signature validation.
 #

--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=d65d8c8-1738610814155
+KUBERNETES_IMAGE_ID=c517042-1738699084146
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=d65d8c8-1738610814155
+PIT_IMAGE_ID=c517042-1738699084146
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=d65d8c8-1738610814155
+STORAGE_CEPH_IMAGE_ID=c517042-1738699084146
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=d65d8c8-1738610814155
+COMPUTE_IMAGE_ID=c517042-1738699084146
 
 # Public keys for RPM signature validation.
 #

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -117,10 +117,18 @@ spec:
     source: csm-algol60
     version: 0.4.1
     namespace: kube-system
+    values:
+      sealed-secrets:
+        rbac:
+          pspEnabled: false
   - name: cray-node-problem-detector
     source: csm-algol60
     version: 1.10.0
     namespace: kube-system
+    values:
+      node-problem-detector:
+        rbac:
+          pspEnabled: false
   - name: cray-istio-operator
     source: csm-algol60
     version: 2.0.0
@@ -169,11 +177,21 @@ spec:
     source: csm-algol60
     version: 1.5.0
     namespace: services
+    values:
+      external-dns:
+        rbac:
+          pspEnabled: false
   - name: cray-sysmgmt-health
     source: csm-algol60
     version: 1.1.5
     namespace: sysmgmt-health
     values:
+      global:
+        rbac:
+          pspEnabled: false
+      prometheus-node-exporter:
+        rbac:
+          pspEnabled: false
       kube-prometheus-stack:
         prometheus:
           prometheusSpec:
@@ -245,6 +263,10 @@ spec:
     source: csm-algol60
     version: 1.2.2
     namespace: metallb-system
+    values:
+      metallb:
+        psp:
+          create: false
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
     version: 0.2.2


### PR DESCRIPTION
## Summary and Scope
Kubernetes 1.32 does not support PodSecurityPolicy (PSP).  So,
- Add 'pspEnabled: false' to some charts.
- Use image ID c517042-1738699084146 with PSP changes in assets.sh.

## Issues and Related PRs
* In Progress [CASMPET-7371](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7371)

## Testing
Will be tested on `molly` once merged and tagged.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

