### PR TITLE
CASMPET-7363: Remove depreciated spire chart

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -260,10 +260,6 @@ spec:
     namespace: services
 
   # Spire service
-  - name: spire
-    source: csm-algol60
-    version: 2.15.7
-    namespace: spire
   - name: cray-spire
     source: csm-algol60
     version: 1.6.6

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.19.6-1.noarch
-    - goss-servers-1.19.6-1.noarch
+    - csm-testing-1.19.8-1.noarch
+    - goss-servers-1.19.8-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -112,6 +112,9 @@ undeploy -n services cray-conman
 # Deploy remaining system management applications
 deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 
+# In 1.7 the old spire server is removed. The new cray-spire server should be around from 1.5 on
+undeploy -n spire spire
+
 # Ensure updated pre-cache images have been pulled on each NCN worker,
 # otherwise the Nexus upgrade may not be successful. This should be relatively
 # quick since the daemon-set should have run since the platform manifest was


### PR DESCRIPTION
## Summary and Scope

This removes the depreciated spire chart. The new cray-spire chart has taken over the job and has been running in place as of csm 1.5. This is expected to be removed and should cause no issues for install or upgrades.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7363](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7363)
* Resolves [CASMPET-7372](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7372)

## Testing

### Tested on:

  * Beau
  * CI/CD Pipeline

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

