### PR TITLE
CASMCMS-9270: Fix BOS internal error when trying to validate nonexistent template

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.32.1
+    version: 2.32.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.32.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.32.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.25.0


### PR DESCRIPTION
Fix a bug in the BOS server code. 

Backports:
CSM 1.6.2: https://github.com/Cray-HPE/csm/pull/3920
CSM 1.5.4: https://github.com/Cray-HPE/csm/pull/3921
CSM 1.4.5: https://github.com/Cray-HPE/csm/pull/3922
