### PR TITLE
CASMCMS-9270: Fix BOS internal error when trying to validate nonexistent template

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.11
+    version: 2.30.12
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.11/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.12/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.6


### PR DESCRIPTION
CSM 1.6.2 backport of https://github.com/Cray-HPE/csm/pull/3919