### PR TITLE
CASMCMS-9270: Fix BOS internal error when trying to validate nonexistent template

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -132,13 +132,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.10.31
+    version: 2.10.32
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.31/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.32/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.16


### PR DESCRIPTION
CSM 1.5.4 backport of https://github.com/Cray-HPE/csm/pull/3919