### PR TITLE
CASMCMS-9270: Fix BOS internal error when trying to validate nonexistent template

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,13 +159,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.50
+    version: 2.0.51
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.50/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.51/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.12


### PR DESCRIPTION
CSM 1.4.5 backport of https://github.com/Cray-HPE/csm/pull/3919