### PR TITLE
CASMPET-7374: Use apiVersion 'batch/v1' in cray-etcd-backup cronjob.yaml

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -235,7 +235,7 @@ spec:
     namespace: services
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.5.5
+    version: 0.5.6
     namespace: services
   - name: cray-etcd-migration-setup
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
CronJob apiVersion `batch/v1` has been around since k8s 1.21. CronJob apiVersion `batch/v1beta1` is deprecated in K8s 1.25+. Use `batch/v1` in prep for K8s upgrade to 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7374](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7374)

## Testing

See cray-etcd-backup PR: https://github.com/Cray-HPE/cray-etcd/pull/42

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

