### PR TITLE
CASMPET-7329: remove cray-psp chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -105,10 +105,6 @@ spec:
     source: csm-algol60
     version: 1.0.0
     namespace: kyverno
-  - name: cray-psp
-    source: csm-algol60
-    version: 0.4.5
-    namespace: services
   - name: cray-velero
     source: csm-algol60
     version: 1.6.3-3


### PR DESCRIPTION
## Summary and Scope

Remove the `cray-psp` chart from `manifests/platform.yaml`, as pod security policies are unsupported in Kubernetes 1.25+.

## Issues and Related PRs

Resolves [CASMPET-7329](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7329).

Relates to cray-hpe/docs-csm#5739.

## Testing

To test on `molly` after merge, although `molly` is still in a bad state as we work through and fix these issues. Removing anything that attempts to create `podSecurityPolicy` resources is part of that work.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

