### PR TITLE
CASMPET-7375: Use apiVersion 'batch/v1' in cray-baremetal-etcd-backup cronjob.yaml

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -247,7 +247,7 @@ spec:
     namespace: metallb-system
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
-    version: 0.2.2
+    version: 0.2.3
     namespace: kube-system
   - name: cray-node-labels
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

CronJob apiVersion `batch/v1` has been around since k8s 1.21. CronJob apiVersion `batch/v1beta1` is deprecated in K8s 1.25+. Use `batch/v1` in prep for K8s upgrade to 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7375](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7375)

## Testing

See `cray-baremetal-etcd-backup` PR for testing information:
https://github.com/Cray-HPE/cray-baremetal-etcd-backup/pull/5

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

