### PR TITLE
CASMPET-7373: Use apiVersion 'batch/v1' in cray-spire spire-intermediate cronjob.yaml

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -195,7 +195,7 @@ spec:
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
-    version: 0.5.0
+    version: 0.5.1
     namespace: vault
   - name: tpm-intermediate
     source: csm-algol60


### PR DESCRIPTION

## Summary and Scope

CronJob apiVersion `batch/v1` has been around since k8s 1.21. CronJob apiVersion `batch/v1beta1` is deprecated in K8s 1.25+. Use `batch/v1` in the `spire-intermediate` cronjob.yaml template in prep for K8s upgrade to 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7373](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7373)

## Testing

See `cray-spire` PR for testing information:
https://github.com/Cray-HPE/cray-spire/pull/101

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

