### PR TITLE
CASMPET-7371: Remove function unbound_psp_check() from install.sh

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -195,6 +195,10 @@ spec:
       prometheus-node-exporter:
         rbac:
           pspEnabled: false
+      victoria-metrics-k8s-stack:
+        grafana:
+          rbac:
+            pspEnabled: false
       kube-prometheus-stack:
         prometheus:
           prometheusSpec:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -220,7 +220,7 @@ spec:
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
-    version: 0.5.0
+    version: 0.5.1
     namespace: vault
   - name: tpm-intermediate
     source: csm-algol60
@@ -260,7 +260,7 @@ spec:
     namespace: services
   - name: cray-etcd-backup
     source: csm-algol60
-    version: 0.5.5
+    version: 0.5.6
     namespace: services
   - name: cray-etcd-migration-setup
     source: csm-algol60
@@ -276,7 +276,7 @@ spec:
           create: false
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
-    version: 0.2.2
+    version: 0.2.3
     namespace: kube-system
   - name: cray-node-labels
     source: csm-algol60

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021,2023 Hewlett Packard Enterprise Development LP
+# Copyright 2021,2023, 2025 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 
@@ -35,21 +35,6 @@ function undeploy() {
     helm status "$@" || return 0
     # Remove the chart.
     helm uninstall "$@"
-}
-
-# Check for manually create unbound PSP that is not managed by helm
-function unbound_psp_check() {
-    echo "Checking for manually created cray-unbound-coredns-psp"
-    unbound_psp_exist="$(kubectl get ClusterRoleBinding -n services |grep cray-unbound-coredns-psp |wc -l)"||true
-    if [[ "$unbound_psp_exist" -eq "1" ]]; then
-        unbound_psp_helm_check="$(kubectl get ClusterRoleBinding -n services cray-unbound-coredns-psp -o yaml |grep helm |wc -l)"||true
-        if [[ "$unbound_psp_helm_check" -eq "0" ]]; then
-            echo "Found ClusterRoleBinding cray-dns-unbound-psp NOT managed by helm"
-            kubectl delete ClusterRoleBinding -n services cray-unbound-coredns-psp
-            echo "Delete ClusterRoleBinding cray-dns-unbound-psp"
-        fi
-    fi
-    echo "cray-unbound-coredns-psp check Done"
 }
 
 # CRUS is removed in CSM 1.6, and should be removed during the upgrade, if it exists
@@ -88,9 +73,6 @@ kubectl create secret generic hpe-signing-key -n services ${RPM_SIGNING_KEYS_OPT
 
 # Save previous Unbound IP
 pre_upgrade_unbound_ip="$(kubectl get -n services service cray-dns-unbound-udp-nmn -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-
-# Check for manually create unbound PSP that is not managed by helm
-unbound_psp_check
 
 deploy "${BUILDDIR}/manifests/core-services.yaml"
 


### PR DESCRIPTION
## Summary and Scope
- Added `victoria-metrics-k8s-stack` pspEnable: false block which was missed.
- Removed `unbound_psp_check()` function and call.
- Updated to cronjob `batch/v1` versions for cray-etcd-backup, cray-baremetal-etcd-backup, and spire-intermediate since these changes have not yet been merged into csm `release/1.7` and we'll need them for the next install attempt.

## Issues and Related PRs

* Resolves [CASMPET-7371](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7371)

## Testing
Will be tested on `molly` once merged and tagged.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

