### PR TITLE
CASMPET-7380: disable podSecurityPolicy for cray-certmanager

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=043aedd-1738962127807
+KUBERNETES_IMAGE_ID=ea64a13-1739212351078
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=043aedd-1738962127807
+PIT_IMAGE_ID=ea64a13-1739212351078
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=043aedd-1738962127807
+STORAGE_CEPH_IMAGE_ID=ea64a13-1739212351078
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=043aedd-1738962127807
+COMPUTE_IMAGE_ID=ea64a13-1739212351078
 
 # Public keys for RPM signature validation.
 #

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -144,6 +144,11 @@ spec:
     source: csm-algol60
     version: 0.8.1
     namespace: cert-manager
+    values:
+      cert-manager:
+        global:
+          podSecurityPolicy:
+            enabled: false
   - name: cray-opa
     source: csm-algol60
     version: 1.34.6


### PR DESCRIPTION
## Summary and Scope

- Disable `podSecurityPolicy` for cert-manager
- Use latest node-images ea64a13-1739212351078

## Issues and Related PRs

* Resolves [CASMPET-7380](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7380)

## Testing
Will be tested on `molly` with new install once merged and tagged.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

