### PR TITLE
four csm-testing adjustments 

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.6.3-1.noarch
     - csm-ssh-keys-roles-1.6.3-1.noarch
-    - csm-testing-1.19.8-1.noarch
-    - goss-servers-1.19.8-1.noarch
+    - csm-testing-1.19.12-1.noarch
+    - goss-servers-1.19.12-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
CASMINST-7173: add retry logic to Kubernetes Postgres Check that All Clusters are in a Running State test
CASMINST-7172: add retry logic to Postgresql SyncFailed status check test
CASMINST-7168: adjust velero backup test to pass is a newer success exists after a failure
CASMINST-7167/CAST-32609: adjust k8s nodes ready test to ignore SchedulingDisabled
