### PR TITLE
CASMTRIAGE-7823 :iuf-cli version bump

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -51,7 +51,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.6.17-1.x86_64
+    - iuf-cli-1.6.18-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
     - metal-init-1.4.10-1.noarch


### PR DESCRIPTION
## Summary and Scope

Changing iuf-cli version from 1.6.17 to 1.6.18 .

## Issues and Related PRs

* Resolves [CASMTRIAGE-7823](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7823)
* https://github.com/Cray-HPE/iuf-cli/pull/189


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

