### PR TITLE
CASMPET-7369: Parameterize cray-drydock Sonar sync

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.19.0
+    version: 2.20.0
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

* Bump cray-drydock from 2.19.0 to 2.20.0 to pull in changes that allow parameterizing the sonar-sync job resources.

## Issues and Related PRs

* Resolves [CASMPET-7369](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7369).
* Fixed in cray-hpe/cray-drydock#46.

## Testing

### Tested on:

  * Local development environment

### Test description:

I templated out the chart with the defaults in values.yaml, along with some overrides. Each test produced job manifests with the appropriate resource limits set.

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

