### PR TITLE
CASMPET-7328: Remove pod security policies from cray-kyverno

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -102,7 +102,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.6
+    version: 1.7.0
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

* Bump cray-kyverno from 1.6.6 to 1.7.0 to pull in changes that remove pod security policies in preparation for the move to K8s 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7328](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7328).
* Fixed by cray-hpe/cray-kyverno#38.

## Testing

To test on `molly` and `orym`, since this is a merge into our long-running feature branch.

## Risks and Mitigations

Slight risk of breakage due to the nature of the chart changes, but low overall. We shall see.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

