### PR TITLE
CASMPET-7328: Remove pod security policies from cray-kyverno

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -95,7 +95,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.6
+    version: 1.7.0
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

* Bump cray-kyverno from 1.6.6 to 1.7.0 to pull in changes that remove pod security policies in preparation for the move to K8s 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7328](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7328).
* Fixed by cray-hpe/cray-kyverno#38.

## Testing

### Tested on:

  * `molly` (K8s 1.32)

### Test description:

I pulled the 1.7.0 `cray-kyverno` Helm chart and ran a manual upgrade on `molly`. The Helm upgrade completed successfully; all of the expected workloads were running, and matched what's running on beau, which has an existing 1.6.6 `cray-kyverno` deployment.

## Risks and Mitigations

Risk is fairly low, since the bulk of the chart changes involve removing pod security policy resources, along with RBAC resources that facilitate using PSPs. There was one modification to a role that involved removing PSP permissions but keeping the existing role, but the expected workloads were all healthy, so we can assume that that modification didn't break anything.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

