### PR TITLE
Downgrade cray-kyverno from 1.7.0 to 1.6.6

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -95,7 +95,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.7.0
+    version: 1.6.6
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Downgrade cray-kyverno from 1.7.0 to 1.6.6. 1.7.0 removes pod security policies, which will break on systems still running K8s 1.24, as those systems are still enforcing PSPs.

## Testing

Reverting back to a known good version.

## Risks and Mitigations

Low. 1.6.6 was a known working version, and this just restores what was there before.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

