### PR TITLE
CASMPET-7383: disable TLS1.2 for oauth2 proxies

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -248,7 +248,7 @@ spec:
     namespace: services
   - name: cray-oauth2-proxies
     source: csm-algol60
-    version: 0.4.0
+    version: 0.4.1
     namespace: services
   - name: cray-iuf
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Disable TLS1.2 for oauth2 proxies due to some vulnerabilities found in TLS 1.2.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7383](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7383)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

After oauth2-proxies chart was upgraded, run the following script to make sure it produces PASS result:

/opt/cray/tests/install/livecd/scripts/monitoring_check.sh

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

