### PR TITLE
BOS fixes and improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.34.1
+    version: 2.34.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.34.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.34.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.25.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.33.0
+    version: 2.34.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.33.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.34.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.25.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.34.0
+    version: 2.34.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.34.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.34.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.25.0


### PR DESCRIPTION
This covers a lot of minor BOS improvements, as well as a few critical fixes:

* CASMCMS-9284 (fixes the critical problem reported in CASMTRIAGE-7853)
* CASMCMS-9285
* CASMCMS-9287
* CASMCMS-9288
* CASMCMS-9289
* CASMCMS-9290

No backports.