### PR TITLE
CASMCMS-9282/CASMCMS-9283: Update CMS services to supported Alpine version; resolve CVE

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,15 +118,15 @@ spec:
   # CMS
   - name: cfs-ara
     source: csm-algol60
-    version: 1.3.0
+    version: 1.4.0
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.12.4
+    version: 1.13.0
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.7.5
+    version: 1.8.0
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -143,27 +143,27 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.33.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.25.0
+    version: 1.26.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.25.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.12.0
+    version: 1.13.0
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.28.0
+    version: 1.29.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
-    version: 2.3.0
+    version: 2.4.0
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.13.0
+    version: 1.14.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
@@ -173,7 +173,7 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.6.0
+    version: 2.7.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
@@ -181,33 +181,33 @@ spec:
           image:
             # The following version needs to match the above cray-csm-barebones-recipe-install
             # version. Due to included helm charts, it needs to be overridden here as well.
-            tag: 2.6.0
+            tag: 2.7.0
         catalog:
           image:
             # The following version is the cray-product-catalog version.
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.6.0
+            tag: 2.7.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.22.0
+    version: 3.23.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.22.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.23.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
-    version: 1.10.2
+    version: 1.11.0
     namespace: services
   - name: cray-tftp-pvc
     source: csm-algol60
-    version: 1.10.2
+    version: 1.11.0
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.30.0
+    version: 1.31.0
     namespace: services
     values:
       cray-import-config:
@@ -217,7 +217,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.6.0
+            tag: 2.7.0
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -241,7 +241,7 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.6.3
+    version: 1.7.0
     namespace: services
 
   - name: gitea
@@ -256,7 +256,7 @@ spec:
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
     # Also update the catalog:image:tag value in the barebones recipe section.
-    version: 2.6.0
+    version: 2.7.0
     namespace: services
 
   # Spire service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - canu-1.9.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.2-1.noarch
-    - cfs-trust-1.7.5-1.noarch
+    - cfs-trust-1.8.0-1.noarch
     - cray-cmstools-crayctldeploy-1.27.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.6-1.x86_64
@@ -42,8 +42,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.7-1.aarch64
     - csm-node-heartbeat-2.7-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
-    - csm-ssh-keys-1.6.3-1.noarch
-    - csm-ssh-keys-roles-1.6.3-1.noarch
+    - csm-ssh-keys-1.7.0-1.noarch
+    - csm-ssh-keys-roles-1.7.0-1.noarch
     - csm-testing-1.19.12-1.noarch
     - goss-servers-1.19.12-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64


### PR DESCRIPTION
Many CMS services were using no-longer-supported Alpine versions. This corrects that. It also fixes a CVE in cfs-ara