### PR TITLE
Use livecd-gcp-infrastructure upgrade feature branch

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -84,6 +84,7 @@ pipeline {
                     env.CSM_VSHASTA = "molly"
                     env.CSM_VSHASTA_UPGRADE = "orym"
                     env.DOCS_CSM_VERSION = csmUtils.findDocsCsmByBranch("feature/kubernetes-upgrade")
+                    env.LGI_BRANCH = "feature/kubernetes-upgrade"
                     if ( isIntegrationBuild() ) {
                         println "Build on integration branch detected. Evaluating latest docs-csm package built from ${env.DOCS_CSM_BRANCH} ..."
                         env.DOCS_CSM_VERSION = csmUtils.findDocsCsmByBranch(env.DOCS_CSM_BRANCH)
@@ -373,7 +374,9 @@ pipeline {
                         // Override docs-csm version, in case if dev version was picked by integration build
                         string(name: "DOCS_CSM_VERSION", value: env.DOCS_CSM_VERSION),
                         // Where to report results
-                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY)
+                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY),
+                        // Which livecd-gcp-infrastructure branch to use
+                        string(name: "LGI_BRANCH", value: env.LGI_BRANCH)
                     ])
                     // Upgrade last previous release to current build on vex
                     build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
@@ -388,7 +391,9 @@ pipeline {
                         // Override docs-csm version, in case if dev version was picked by integration build
                         string(name: "DOCS_CSM_VERSION_UPGRADE", value: env.DOCS_CSM_VERSION),
                         // Where to report
-                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY)
+                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY),
+                        // Which livecd-gcp-infrastructure branch to use
+                        string(name: "LGI_BRANCH", value: env.LGI_BRANCH)
                     ])
                 }
                 // if ( isPublishedRelease() ) {


### PR DESCRIPTION
## Summary and Scope

We pushed a feature branch, `feature/kubernetes-upgrade`, to `livecd-gcp-infrastructure`, to fix functionality in `handoff.sh` that was causing K8s 1.32 vShasta instances to not start correctly. This changeset updates the Jenkinsfile to use that feature branch for future vShasta deployments for molly and orym as part of K8s 1.32/CSM 1.7 upgrade testing.

## Issues and Related PRs

TBD.

## Testing

N/A.

## Risks and Mitigations

This change is limited to breakage on an existing feature branch that is used for regularly testing breaking changes related to K8s 1.32/CSM 1.7 upgrades. Overall risk is minimal.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable