### PR TITLE
CASMPET-7011: Remove old referenced image from cray-spire

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -262,7 +262,7 @@ spec:
   # Spire service
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.6
+    version: 1.7.1
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This removes a old image from the dependent images on the Cray-Spire chart. No code change and no chart change.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7011](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7011)

## Testing

No change so no way to test.

## Risks and Mitigations

No change so no risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

