### PR TITLE
CASMSEC-511: Kyverno Upgrade Needed to support N-2 Policy

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -62,11 +62,11 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.2
       - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
@@ -95,7 +95,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.6
+    version: 1.7.1
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This change is to pull latest cray-kyverno v1.7.1 which intern is based on latest upstream Kyverno version which is 1.13.2. This is needed since current cray-kyverno in CSM is based on out-of-support upstream kyverno version (1.10.7). Also, we require the latest version of Kyverno due to policyException feature which is required for PSP migration.

## Testing

Kyverno installation, uninstall, policy report logs.

### Tested on:

mercury4.hpc.amslabs.hpecorp.net

### Test description:

Attached fresh installation test logs:
[kyverno_1_7_1_test_logs_arti_chart.txt](https://github.com/user-attachments/files/18904665/kyverno_1_7_1_test_logs_arti_chart.txt)
