### PR TITLE
Update to use cray-kyverno 1.7.1; Revert back to k8s 1.32.0

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=2d9b343-1740167257976
+KUBERNETES_IMAGE_ID=e125509-1739570604342
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=2d9b343-1740167257976
+PIT_IMAGE_ID=e125509-1739570604342
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=2d9b343-1740167257976
+STORAGE_CEPH_IMAGE_ID=e125509-1739570604342
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=2d9b343-1740167257976
+COMPUTE_IMAGE_ID=e125509-1739570604342
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -122,29 +122,29 @@ artifactory.algol60.net/csm-docker/stable:
     #   - v1.8.4
     registry.k8s.io/coredns/coredns:
       - v1.8.6
-      - v1.11.4
+      - v1.11.3
 
     # Kube images required by platform
     # k8s.gcr.io/kube-apiserver:
     #   - v1.22.13
     registry.k8s.io/kube-apiserver:
       - v1.24.17
-      - v1.32.2
+      - v1.32.0
     # k8s.gcr.io/kube-controller-manager:
     #   - v1.22.13
     registry.k8s.io/kube-controller-manager:
       - v1.24.17
-      - v1.32.2
+      - v1.32.0
     # k8s.gcr.io/kube-proxy:
     #   - v1.22.13
     registry.k8s.io/kube-proxy:
       - v1.24.17
-      - v1.32.2
+      - v1.32.0
     # k8s.gcr.io/kube-scheduler:
     #   - v1.22.13
     registry.k8s.io/kube-scheduler:
       - v1.24.17
-      - v1.32.2
+      - v1.32.0
     # k8s.gcr.io/pause:
     #   - 3.5
     registry.k8s.io/pause:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -58,11 +58,11 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.24.17
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
       # Kubernetes 1.32
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.4
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.2
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.2
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.2
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.0
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.0
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
@@ -102,7 +102,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

- Revert back to using K8s 1.32.0 images
- Use cray-kyverno 1.7.1

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

