### PR TITLE
CASMPET-7335 update cray-postgres-operator chart version to 1.10.1

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -187,7 +187,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.8.5
+    version: 1.10.1
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Bump cray-postgres-operator chart version to 1.10.1.

This is for the postgres-upgrade in CSM 1.7.

## Issues and Related PRs

* Resolves [CASMPET-7335](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7335)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau

### Test description:

I have tested the chart upgrade on Beau.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

