### PR TITLE
CASMNET-2212 - Switch to install Cilium by default (not weave) in cloud-init

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -33,7 +33,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-trust-1.8.0-1.noarch
     - cray-cmstools-crayctldeploy-1.27.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cray-site-init-1.36.6-1.x86_64
+    - cray-site-init-1.36.7-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.90.0-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Set default CNI to Cilium for CSM 1.7

## Issues and Related PRs

* Resolves [CASMNET-2212](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2212)

## Testing

### Tested on:

  * `wasp`
  * Local development environment

### Test description:

Verified generated basecamp data has `k8s-primary-cni` set to `cilium`

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

