### PR TITLE
CASMPET-7371: Remove PSP enablement from node-images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.9
+KUBERNETES_IMAGE_ID=7.0.10
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.9
+PIT_IMAGE_ID=7.0.10
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.9
+STORAGE_CEPH_IMAGE_ID=7.0.10
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.9
+COMPUTE_IMAGE_ID=7.0.10
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,7 +44,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.7.0-1.noarch
     - csm-ssh-keys-roles-1.7.0-1.noarch
-    - csm-testing-1.19.12-1.noarch
+    - csm-testing-1.19.13-1.noarch
     - goss-servers-1.19.12-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -45,7 +45,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-1.7.0-1.noarch
     - csm-ssh-keys-roles-1.7.0-1.noarch
     - csm-testing-1.19.13-1.noarch
-    - goss-servers-1.19.12-1.noarch
+    - goss-servers-1.19.13-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope
Remove PSP enablement from node-images since K8s does not support PSP starting in v1.25 in preparation for K8s upgrade to v1.32.

Update node-images to `7.0.10`:
 * CASMPET-7371: Remove PSP enablement from node-images

Update csm-testing to `v1.19.13`:
 * CASMPET-7397: Remove k8s_psp_enabled_check goss test from csm-testing

## Issues and Related PRs

* Resolves [CASMPET-7371](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7371)
* Resolves [CASMPET-7397](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7397)

## Testing
This has been tested on `molly` running k8s 1.32 images.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

