### PR TITLE
Update kyverno precache images to 1.13.2

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -69,11 +69,11 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.2
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.2
       - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,7 +44,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.7.0-1.noarch
     - csm-ssh-keys-roles-1.7.0-1.noarch
-    - csm-testing-1.19.12-1.noarch
+    - csm-testing-1.19.13-1.noarch
     - goss-servers-1.19.12-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch


### PR DESCRIPTION
## Summary and Scope

When I updated `feature/kubernetes-upgrade` branch to use cray-kyverno 1.7.1, I forgot to update the precache images to 1.13.2.

## Issues and Related PRs

## Testing
A failed test on `molly` install made me check the precache images where I noticed that we wanted 1.13.2 rather than 1.10.7.
```
Caching image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
  E0224 23:20:32.317597   14014 remote_image.go:238] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7\": failed to resolve reference \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7\": failed to do request: Head \"http://pit.nmn:5000/v2/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre/manifests/v1.10.7?ns=artifactory.algol60.net\": dial tcp 10.252.1.13:5000: connect: connection refused" image="artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7"
time="2025-02-24T23:20:32Z" level=fatal msg="pulling image: rpc error: code = Unknown desc = failed to pull and unpack image \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7\": failed to resolve reference \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7\": failed to do request: Head \"http://pit.nmn:5000/v2/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre/manifests/v1.10.7?ns=artifactory.algol60.net\": dial tcp 10.252.1.13:5000: connect: connection refused"
<snip>
Caching image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
  E0224 23:20:32.542729   14038 remote_image.go:238] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7\": failed to resolve reference \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7\": failed to do request: Head \"http://pit.nmn:5000/v2/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller/manifests/v1.10.7?ns=artifactory.algol60.net\": dial tcp 10.252.1.13:5000: connect: connection refused" image="artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7"
time="2025-02-24T23:20:32Z" level=fatal msg="pulling image: rpc error: code = Unknown desc = failed to pull and unpack image \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7\": failed to resolve reference \"artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7\": failed to do request: Head \"http://pit.nmn:5000/v2/artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller/manifests/v1.10.7?ns=artifactory.algol60.net\": dial tcp 10.252.1.13:5000: connect: connection refused"
```
## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

