### PR TITLE
CASMHMS-6285: cray-hms-rts fix job condition check

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.0.1
+    version: 5.1.0
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.0.1
+    version: 5.1.0
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

Update cray-hms-rts and cray-hms-rts-snmp from 5.0.1 to 5.1.0 to pull in an updated chart change that adds backwards-compatible support for a new `JobCondition` in K8s 1.30: `SuccessCriteriaMet`. This prevents pod init issues related to not properly checking for all successful job completion statuses.

## Issues and Related PRs

* Resolves [CASMHMS-6285](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6285)
* Resolved upstream by: Cray-HPE/hms-rts-charts#25

## Testing

### Tested on:

  * `molly`

### Test description:

Version `5.1.0` was installed on `molly`, and the expected workloads ran normally.

## Risks and Mitigations

Given that this is a purely additive change in a boolean OR that checks for a new successful K8s job condition, the risk should be minimal.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

