### PR TITLE
CASMCMS-9292/CASMCMS-9293: Update cfs-trust, cfs-state-reporter, and dependencies to address scale issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -124,7 +124,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.6.9
+    version: 1.6.10
     namespace: services
   - name: cms-ipxe
     source: csm-algol60

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.5.1-1.noarch
     - cray-node-exporter-1.5.0.1-1.noarch
     - cfs-state-reporter-1.11.1-1.noarch
-    - cfs-trust-1.6.9-1.noarch
+    - cfs-trust-1.6.10-1.noarch
     - cray-cmstools-crayctldeploy-1.16.5-1.x86_64
     - cray-site-init-1.32.6-1.x86_64
     - cray-uai-util-2.2.1-1.noarch
@@ -60,12 +60,17 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.3.0-3.38.0_1.x86_64
     - metal-observability-1.0.9-1.x86_64
     - platform-utils-1.6.10-1.noarch
-    - python3-liveness-1.4.3-1.noarch
-    - python3-requests-retry-session-0.1.5-1.noarch
-    - python310-requests-retry-session-0.1.5-1.noarch
-    - python311-requests-retry-session-0.1.5-1.noarch
-    - python312-requests-retry-session-0.1.5-1.noarch
-    - python39-requests-retry-session-0.1.5-1.noarch
+    - python3-liveness-1.4.4-1.noarch
+    - python3-requests-retry-session-0.1.8-1.noarch
+    - python310-requests-retry-session-0.1.8-1.noarch
+    - python311-requests-retry-session-0.1.8-1.noarch
+    - python312-requests-retry-session-0.1.8-1.noarch
+    - python39-requests-retry-session-0.1.8-1.noarch
+    - python3-requests-retry-session-0.2.4-1.noarch
+    - python310-requests-retry-session-0.2.4-1.noarch
+    - python311-requests-retry-session-0.2.4-1.noarch
+    - python312-requests-retry-session-0.2.4-1.noarch
+    - python39-requests-retry-session-0.2.4-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
CSM 1.5.4 backport of https://github.com/Cray-HPE/csm/pull/3964

Unlike the CSM 1.7 PR, this backport PR has no dependencies on other PRs, and is ready to merge.