### PR TITLE
CASMHMS-6364: upgrade cray-hms-hbtd chart from 3.1.3 to 3.2.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -61,13 +61,13 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.33.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.1.3
+    version: 3.2.0
     namespace: services
     timeout: 10m
     swagger:
     - name: hbtd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.21.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.22.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
     version: 4.0.6


### PR DESCRIPTION
## Summary and Scope

Upgrae cray-hms-hbtd from 3.1.3 to 3.2.0 to pull in changes that update the cray-service base chart, which itself adds a new `JobCondition` check introduced in K8s 1.30: `SuccessCriteriaMet`. This prevents pod init failures due to not checking for an additional job success criterion, despite jobs completing successfully. This should be backwards-compatible because the change in the `if` statement is purely additive. The docker-kubectl version bump that occurs should also not cause any issues.

Upgrade the swagger spec from 1.21.0 to 1.22.0 to correspond with the cray-hms-hbtd 3.2.0 application version.

## Issues and Related PRs

* Resolves [CASMHMS-6285](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6285)
* Resolved upstream by cray-hpe/hms-hbtd-charts#26

## Testing

### Tested on:

  * `molly`
  * `beau`

### Test description:

I manually upgraded `cray-hms-hbtd` to 3.2.0 and verified that the expected workloads were present and healthy.

## Risks and Mitigations

Risk is fairly low. The underlying base chart change only pulls in a conditional to check for an additional `JobCondition` success state, `SuccessCriteriaMet`, in addition to `Complete`. It also updates docker-kubectl to 1.24.17.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

