### PR TITLE
CASMHMS-6386: Improve responsiveness of BSS /meta-data requests

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,13 +36,13 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.3.1
+    version: 3.3.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.29.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.33.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 5.0.0


### PR DESCRIPTION
### Summary and Scope

Summary

Customer reported hung BSS commands when booting 5000+ compute nodes.  A number of issues related to performance at boot time were identified and resolved:

- The HSM cache was previously being invalidated and rebuilt for any `/meta-data`, `/user-data`, and `/phone-home` request.  This obviously caused BSS to perform excess work for each request.  This issue is now resolved.
- When a `meta-data` request arrives, BSS looks at the IP address in the request for the client making the request.  It uses this IP address to look up client specific metadata for the requesting client in the cache.  When a compute node boots, BSS receives two of these `meta-data` requests, one using the actual client's IP address and one from `cfs_state_reporter` which is proxied through weave and thus the requesting IP address appears as a weave IP address (a request through `api-gw-service-nmn.local` causes this).  A weave IP address will never be in the HSM cache and so it will always result in a cache miss and a forced invalidation and rebuild of the cache.  If the incoming `/meta-data` request contains a query for Global data, a query into the cache is not necessary because client specific metadata is not being requested.  `cfs_state_reporter` only requires Global metada.  To resolve this issue, the `/meta-data` handler was optimized to look for Global queries and immediately return the Global metadata without making any queries into the cache to gather additional client specific metadata that the requesting client is not requesting.
- BSS previously pulled Global metadata out of etcd for every `/meta-data` request that came in.  Profiling with `pprof` during high volume bursts of parallel `/meta-data` requests shows that half of BSS's time is spend in the garbage collector dealing with the buffers associated with this.  Additionally, etcd failures were observed due to the overwhelming demand being placed on it.  These bursts led to stalled, timed out, and failed BSS requests.  To fix the issue a short-lived cache was implemented for Global metadata.  By default, the cache lives for one second before being refreshed and results in no more than 1 etcd lookup per second.  This is configurable in the deployment with `BSS_GLOBAL_DATA_TIMEOUT`.  The down side is that BSS might return stale Global metadata if it was updated within the last second of an incoming read request.  After discussion with other engineers this was deemed a low probability and low risk window of opportunity.  Global data is rarely updated, and when it is updated it generally happens when compute nodes are not booting (eg. rebuilding master nodes).
- Debug logging was previously enabled by default.  It was extremely verbose voluminous and likely contributed to the slowed responses from BSS.  Debug logging is now disabled by default.

Additional changes made include:

- Converted existing cache invalidation timeout from minutes to seconds for consistency with similar configuration knobs in other HMS services
- Made the cache invalidation timeout configurable via `BSS_CACHE_EVICTION_TIMEOUT` in BSS's deployment/helm chart
- When BSS starts, it now logs its configuration.  This will assist in future debug in the field
- Because debug logging is now disabled by default, added a single log to each API handler to ensure we still know what's happening in BSS
- Updated and added various log messages for clarity
- Fixed bug in `/meta-data` handler where response header was being written after the response was already sent.  This can cause undefined behavior

Issues discovered but not addressed by this fix:

- Queries and subqueries now function correctly down the optimized Global metadata path.  However, subqueries for other metadata do not work and result in mapLookup() returning failure.  I will open a new Jira for this issue.
- We suspect that BSS has resource leaks similar to what we've discovered in other HMS services like PCS, FAS, hmcollector, and SMD.  However, `pprof` reported no such issues in the `/meta-data` handler.  As this customer issue is focused on `/meta-data` handling, no other parts of BSS were analyzed for resource leaks.

Adopted app version 1.26.1 for CSM 1.5.4 (helm chart 3.1.6)
Adopted app version 1.30.1 for CSM 1.6.2 (helm chart 3.2.7)
Adopted app version 1.33.0 for CSM 1.7.0 (helm chart 3.3.2)

### Issues and Related PRs

* Resolves [CASMHMS-6386](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6386)

### Testing

Testing performed:

* Performed half a million serialized /meta-data requests with no issues
* Performed 100,000 parallel /meta-data requests (50k simulated node boot) with no BSS issues encountered
* Smoke and CT tests run by `run_hms_ct_tests.sh -t bss` all passed
* Changes to `cfs_state_reporter` were successfully tested alongside these BSS changes

Additionally verified expected behavior for the following queries from compute nodes:

* `curl -s http://10.92.100.81:8888/meta-data`
* `curl -s http://10.92.100.81:8888/meta-data?key=Global`
* `curl -s http://10.92.100.81:8888/meta-data?key=Global.cfs_public_key`
* `curl -s http://api-gw-service-nmn.local:8888/meta-data`
* `curl -s http://api-gw-service-nmn.local:8888/meta-data?key=Global`
* `curl -s http://api-gw-service-nmn.local:8888/meta-data?key=Global.cfs_public_key`

Tested on:

* `mug` for the 1.6 and 1.7 changes
* `slice` for the 1.5 changes

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable