### PR TITLE
Temporarily disable automated tag deployments on orym

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -365,9 +365,9 @@ pipeline {
                 archiveArtifacts(artifacts: 'dist/csm-*-chartmap.csv', allowEmptyArchive: true)
                 archiveArtifacts(artifacts: 'dist/csm-*-versions.yaml', allowEmptyArchive: true)
                 if ( isPublishedRelease() || (isIntegrationBuild() && COMPILE_BUILD)) {
-                    // Fresh install current build on yasha
+                    // Fresh install current build on molly
                     build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
-                        // Test fresh installs on yasha
+                        // Test fresh installs on molly
                         string(name: "ENVIRONMENT", value: env.CSM_VSHASTA),
                         // Install version which was just built
                         string(name: "CSM_RELEASE", value: env.RELEASE_VERSION),
@@ -378,23 +378,24 @@ pipeline {
                         // Which livecd-gcp-infrastructure branch to use
                         string(name: "LGI_BRANCH", value: env.LGI_BRANCH)
                     ])
-                    // Upgrade last previous release to current build on vex
-                    build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
-                        // Test upgrades on vex
-                        string(name: "ENVIRONMENT", value: env.CSM_VSHASTA_UPGRADE),
-                        // Automatically evaluate last previous release e.g. 1.4.3
-                        string(name: "CSM_RELEASE", value: ""),
-                        // Upgrade to what had been just built
-                        string(name: "CSM_RELEASE_UPGRADE", value: env.RELEASE_VERSION),
-                        // Upgrade after fresh install
-                        booleanParam(name: "UPGRADE", value: true),
-                        // Override docs-csm version, in case if dev version was picked by integration build
-                        string(name: "DOCS_CSM_VERSION_UPGRADE", value: env.DOCS_CSM_VERSION),
-                        // Where to report
-                        string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY),
-                        // Which livecd-gcp-infrastructure branch to use
-                        string(name: "LGI_BRANCH", value: env.LGI_BRANCH)
-                    ])
+					// Temporarily disable orym builds for manual upgrade testing.
+                    // Upgrade last previous release to current build on orym
+                    // build(job: "Cray-HPE/csm-vshasta-deploy/main", wait: false, parameters: [
+                    //     // Test upgrades on orym
+                    //     string(name: "ENVIRONMENT", value: env.CSM_VSHASTA_UPGRADE),
+                    //     // Automatically evaluate last previous release e.g. 1.4.3
+                    //     string(name: "CSM_RELEASE", value: ""),
+                    //     // Upgrade to what had been just built
+                    //     string(name: "CSM_RELEASE_UPGRADE", value: env.RELEASE_VERSION),
+                    //     // Upgrade after fresh install
+                    //     booleanParam(name: "UPGRADE", value: true),
+                    //     // Override docs-csm version, in case if dev version was picked by integration build
+                    //     string(name: "DOCS_CSM_VERSION_UPGRADE", value: env.DOCS_CSM_VERSION),
+                    //     // Where to report
+                    //     string(name: "SLACK_REPORT_CHANNEL", value: env.SLACK_CHANNEL_NOTIFY),
+                    //     // Which livecd-gcp-infrastructure branch to use
+                    //     string(name: "LGI_BRANCH", value: env.LGI_BRANCH)
+                    // ])
                 }
                 // if ( isPublishedRelease() ) {
                 //     build(job: "Cray-HPE/csm-release-internal-upload/main", wait: false, parameters: [


### PR DESCRIPTION
## Summary and Scope

Update the Jenkins config to temporarily disable automated deployments to `orym` so we can install 1.6.1 and then manually test upgrades ourselves.

## Risks and Mitigations

Low, this is an upgrade-specific feature branch.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

