### PR TITLE
CASMTRIAGE-7901: Update cray-spire for sbps-marshal workload

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -266,7 +266,7 @@ spec:
     namespace: spire
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.6
+    version: 1.6.8
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This fixes a bug in the indentation of a workload in workloads.yaml. This bug prevented systems with xname validation enabled from getting tokens for workloads

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7901](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7901)

## Testing

### Tested on:

  * lemondrop

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

no risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

