### PR TITLE
Manifest PR for CASMTRIAGE-7910 fix

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -70,7 +70,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python312-requests-retry-session-0.2.4-1.noarch
     - python39-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.2.4-1.noarch
-    - sbps-marshal-0.0.13-1.noarch
+    - sbps-marshal-0.0.14-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.10.aarch64
     - spire-agent-1.5.5-1.10.x86_64


### PR DESCRIPTION
## Summary and Scope

Manifest PR to pull fix for CASMTRIAGE-7910 where "sbps-marshal-0.0.14-1.noarch.rpm" should be installed. 

## Issues and Related PRs
CASMTRIAGE-7910
https://github.com/Cray-HPE/sbps-marshal/pull/21

* Resolves [issue id](issue link): CASMTRIAGE-7910
* Change will also be needed in `<insert branch name here>`: 'release/1.6'
* Future work required by [issue id](issue link): N/A
* Documentation changes required in [issue id](issue link): N/A
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
Fix tested on Lemondrop where fix for CASMTRIAGE-7901 was applied

### Tested on:
Fix tested on Lemondrop where fix for CASMTRIAGE-7901 was applied

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: N/A
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: N/A

## Risks and Mitigations
None
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [NA ] Copyrights updated
- [X ] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [NA ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

