### PR TITLE
CASMHMS-5678: Update module dependencies related to vault and hms-certs

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.0
+    version: 7.2.1
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.23.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.34.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.0.2


### PR DESCRIPTION
### Summary and Scope

Updated module dependencies for security updates.

The hms-certs update required changes to pass vault related override values to hms-certs.

Adopted app version 2.34.0 for CSM 1.7.0 (helm chart 7.2.1)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Ran smoke and integration tests.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable