### PR TITLE
CASM-5264:  cray-nexus-setup image version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -187,7 +187,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Images needed by IUF and possibly non-CSM products
     cray-nexus-setup:
-      - 0.11.2
+      - 0.12.0
 
     # not needed for build/install as it comes packaged as skopeo.tar
     quay.io/skopeo/stable:


### PR DESCRIPTION
## Summary and Scope

Updating the cray-nexus-setup image to 0.12.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-5264](https://jira-pro.it.hpe.com:8443/browse/CASM-5264)
* https://github.com/Cray-HPE/nexus-setup/pull/32

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

