### PR TITLE
CASMPET-7293: Changing iuf image version iuf:v0.1.13

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -49,7 +49,7 @@ artifactory.algol60.net/csm-docker/stable:
     - 0.3.1
 
     iuf:
-    - v0.1.12
+    - v0.1.13
 
     # Rebuilt third-party images below
 


### PR DESCRIPTION
## Summary and Scope

changing iuf-containers image version to v0.1.13

## Issues and Related PRs

* [CASMPET-7293](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7293)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

