### PR TITLE
CASMAUTO-92:  updating csm-testing and goss-servers

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.7.1-1.noarch
     - csm-ssh-keys-roles-1.7.1-1.noarch
-    - csm-testing-1.19.13-1.noarch
-    - goss-servers-1.19.13-1.noarch
+    - csm-testing-1.19.15-1.noarch
+    - goss-servers-1.19.15-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

 updating csm-testing and goss-servers version to 1.19.15 for CSM 1.7

Tested on #tyr

## Issues and Related PRs

* Resolves [CASMAUTO-92](https://jira-pro.it.hpe.com:8443/browse/CASMAUTO-92)
* https://github.com/Cray-HPE/csm-testing/pull/666

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

