### PR TITLE
CAST-35972: Update csm-ssh-keys to pull in key injection regex fix (1.7)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -241,7 +241,7 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.7.0
+    version: 1.8.0
     namespace: services
 
   - name: gitea

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -42,7 +42,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.7-1.aarch64
     - csm-node-heartbeat-2.7-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
-    - csm-ssh-keys-1.7.1-1.noarch
+    - csm-ssh-keys-1.8.0-1.noarch
     - csm-ssh-keys-roles-1.7.1-1.noarch
     - csm-testing-1.19.13-1.noarch
     - goss-servers-1.19.13-1.noarch


### PR DESCRIPTION
## Summary and Scope
Pulls in a fix to prevent the csm ssh keys from getting added to the same file multiple times

## Issues and Related PRs

* Resolves CAST-35972

## Testing

### Tested on:

  * Mug

### Test description:

Verified that the same line was no longer getting added multiple times

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

