### PR TITLE
CASMTRIAGE-7946-release-1.5 update csm-testing to version 1.16.83

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.5.6-1.noarch
     - csm-ssh-keys-roles-1.5.6-1.noarch
-    - csm-testing-1.16.82-1.noarch
-    - goss-servers-1.16.82-1.noarch
+    - csm-testing-1.16.83-1.noarch
+    - goss-servers-1.16.83-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.5.7-1.noarch
     - hpe-csm-virtiofsd-1.7.0-hpe1.x86_64


### PR DESCRIPTION
## Summary and Scope

Update csm-testing to version 1.16.83. This fixes a small bug in a Ceph health check script.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7946](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7946)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

