### PR TITLE
CASMHMS-6409: hmcollector: Update module dependencies related to hms-certs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -79,7 +79,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.22.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.17.0
+    version: 2.17.1
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Second pass on hmcollector to update module dependencies related to hms-certs.

The hms-certs update required changes to pass vault related override values to hms-certs.

Adopted app version 2.17.1 for CSM 1.7.0 (helm chart 2.37.0)

### Issues and Related PRs

* Resolves [CASMHMS-6409](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6409)

### Testing

Updated mug with new version.  Ensured no issues in log files.  Power cycled node to ensure state changes rippled back to SMD.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable