### PR TITLE
CASMPET-7421: Update componenet manifest for 1.7 upgrades

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -119,7 +119,7 @@ spec:
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60
-    version: 1.12.0
+    version: 1.11.1
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -115,11 +115,11 @@ spec:
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60
-    version: 0.4.1
+    version: 0.5.1
     namespace: kube-system
   - name: cray-node-problem-detector
     source: csm-algol60
-    version: 1.10.0
+    version: 1.12.0
     namespace: kube-system
   - name: cray-istio-operator
     source: csm-algol60
@@ -131,7 +131,7 @@ spec:
     namespace: istio-system
   - name: cray-certmanager
     source: csm-algol60
-    version: 0.8.1
+    version: 0.9.2
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
@@ -139,11 +139,11 @@ spec:
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.4.0
+    version: 1.5.0
     namespace: vault
   - name: cray-vault
     source: csm-algol60
-    version: 1.7.1
+    version: 1.8.0
     namespace: vault
   - name: trustedcerts-operator
     source: csm-algol60
@@ -167,7 +167,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.5.0
+    version: 1.6.0
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR updates component manifest for upgrades completed for 1.7 that have now been tested with Kubernetes v1.32 on wasp.

## Issues and Related PRs

* Resolves [CASMPET-7381](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7381)
* Resolves [CASMPET-7380](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7380)
* Resolves [CASMPET-7368](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7368)
* Resolves [CASMPET-7346](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7346)
* Resolves [CASMPET-7330](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7330)
* Resolves [CASM-5241](https://jira-pro.it.hpe.com:8443/browse/CASM-5241)
* Resolves [CASM-5240](https://jira-pro.it.hpe.com:8443/browse/CASM-5240)
* Resolves [CASMPET-7132](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7132)
* Resolves [CASMPET-7421](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7421)
* Resolves [CASMPET-7331](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7331)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `wasp` with k8s 1.32
  * Virtual Shasta: `beau` with k8s 1.24 (though, not all will still work on 1.24, we had to disable PSPs)

### Test description:

Tests run on wasp to make sure that all components are still functional with Kubernetes v1.32, previously tested with Kubernetes 1.24 on Beau (see individual issues linked above for details on testing of each individual component).

## Risks and Mitigations

This should be merged after k8s 1.32 is added to CSM 1.7, otherwise, low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

