### PR TITLE
CASMNET-2187 - Add metrics settings to cilium helm chart values

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.15
+KUBERNETES_IMAGE_ID=7.0.16
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.15
+PIT_IMAGE_ID=7.0.16
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.15
+STORAGE_CEPH_IMAGE_ID=7.0.16
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.15
+COMPUTE_IMAGE_ID=7.0.16
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope

Add parameters that enable Cilium and Hubble metrics to the Helm chart values files.

## Issues and Related PRs

* Resolves [CASMNET-2187](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2187)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * `wasp`
  * Virtual Shasta

### Test description:

#### Baremetal install test

Before change:

Metrics are not enabled
```
ncn-m001:~ # curl -s http://10.252.1.5:9962/metrics
ncn-m001:~ # curl -s http://10.252.1.5:9965/metrics
ncn-m001:~ #
```

Reinstall chart with new values:

```
ncn-m001:~/cspiller/metrics # . /srv/cray/resources/common/vars.sh
COREDNS_VERSION=v1.11.3
ncn-m001:~/cspiller/metrics # export PODS_CIDR=$(craysys metadata get kubernetes-pods-cidr)
ncn-m001:~/cspiller/metrics # export WEAVE_MTU=$(craysys metadata get kubernetes-weave-mtu)
ncn-m001:~/cspiller/metrics # export K8S_VIP=$(craysys metadata get k8s-virtual-ip)
ncn-m001:~/cspiller/metrics # export CILIUM_OPERATOR_REPLICAS=$(craysys metadata get cilium-operator-replicas 2>/dev/null || echo "1")
ncn-m001:~/cspiller/metrics # export K8S_CNI=$(craysys metadata get k8s-primary-cni 2>/dev/null || echo "weave")
ncn-m001:~/cspiller/metrics # export CILIUM_KUBE_PROXY_REPLACEMENT=$(craysys metadata get cilium-kube-proxy-replacement 2>/dev/null || echo "disabled")
ncn-m001:~/cspiller/metrics # vi /srv/cray/scripts/common/apply-networking-manifests.sh
ncn-m001:~/cspiller/metrics # envsubst < cilium-cli-helm-values.yaml > cilium-helm-values.yaml
ncn-m001:~/cspiller/metrics # helm upgrade -f cilium-helm-values.yaml cilium /srv/cray/resources/common/cilium-v1.16.5/ --namespace kube-system --set kubeProxyReplacement=false
Release "cilium" has been upgraded. Happy Helming!
NAME: cilium
LAST DEPLOYED: Thu Mar 13 10:34:51 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
You have successfully installed Cilium with Hubble Relay and Hubble UI.

Your release version is 1.16.5.

For any further help, visit https://docs.cilium.io/en/v1.16/gettinghelp
```

Verify metrics are now enabled:

```
ncn-m001:~/cspiller/metrics # curl -s http://10.252.1.5:9962/metrics | grep drop_count_total
# HELP cilium_drop_count_total Total dropped packets, tagged by drop reason and ingress/egress direction
# TYPE cilium_drop_count_total counter
cilium_drop_count_total{direction="EGRESS",reason="Unsupported L3 protocol"} 2925
cilium_drop_count_total{direction="INGRESS",reason="CT: Map insertion failed"} 8
cilium_drop_count_total{direction="INGRESS",reason="Stale or unroutable IP"} 88

ncn-m001:~/cspiller/metrics # curl -s http://10.252.1.5:9965/metrics | grep tcp_flags_total
# HELP hubble_tcp_flags_total TCP flag occurrences
# TYPE hubble_tcp_flags_total counter
hubble_tcp_flags_total{family="IPv4",flag="FIN"} 731
hubble_tcp_flags_total{family="IPv4",flag="RST"} 64
hubble_tcp_flags_total{family="IPv4",flag="SYN"} 391
hubble_tcp_flags_total{family="IPv4",flag="SYN-ACK"} 359
```

#### vshasta live migration test

Performed live migration from Weave to Cilium on a vshasta environment, verified Cilium Helm chart was installed with expected metrics values etc.

```
ncn-m001:~ # helm -n kube-system get values cilium | yq4 .hubble.metrics
enableOpenMetrics: true
enabled:
  - dns
  - drop
  - tcp
  - flow
  - port-distribution
  - icmp
  - httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

