### PR TITLE
CASMSEC-518: Optimize cray-kyverno-policies-upstream chart to include single podsecurity-subrule-baseline policy

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -103,7 +103,7 @@ spec:
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60
-    version: 1.0.0
+    version: 1.1.1
     namespace: kyverno
   - name: cray-psp
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Overrided the values.yaml to skip deploying the upstream discrete baseline policies and manually provide a podsecurity-subrule-baseline ClusterPolicy to have easier PolicyExceptions, and centralized management of policies. More information at [Adoption Notes](https://rndwiki-pro.its.hpecorp.net/pages/viewpage.action?pageId=437162218#MigrationofPodSecurityPolicies(PSP)toKyverno(PodSecurityStandards(PSS))-AdoptionNotes).

## Issues and Related PRs

* Resolves [CASMSEC-518](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-518)
* Merge after #3982 

## Testing

[casmsec-518-wasp-testing-2802.txt](https://github.com/user-attachments/files/19242739/casmsec-518-wasp-testing-2802.txt)

### Tested on:

  * `wasp`

### Test description:

- Upgrade, Install, Uninstall, Rollback tested

## Risks and Mitigations

* Not backwards compatible to csm/1.6 as kubeVersion set to >=1.25

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

