### PR TITLE
CASMHMS-6408: PCS: Update module dependencies related to hms-certs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,13 +107,13 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.2.0
+    version: 2.2.1
     namespace: services
     timeout: 10m
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.7.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.10.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
### Summary and Scope

#### Chart Changes

Adopted app version 2.10.0 for CSM 1.7.0 (helm chart 2.2.1)

#### App Changes

Second pass on PCS to update module dependencies related to hms-certs.

The hms-certs update required changes to pass vault related override values to hms-certs.

Part of this change was updating to the latest version of hms-test.  This exposed a timing issue in the transition related tavern tests.  All of the tavern tests expect completed transitions to have a `tasks` structure.  That isn't a valid expectation though because after transitions complete, they are compressed and the compression process removes the `tasks` structure.  Transition operations aren't atomic and can be long running.  A GET on completed transitions may or may not occur before they can be compressed.  The tavern tests are rapid fire and have always issued the GET to confirm completed transitions before PCS has been able to move them through their full life cycle, including compression at the very end.  For some reason the latest hms-test with latest Alpine base images have permuted this timing and opened up a window where false positives can be generated.  The fix is simple; the tests were updated to make inclusion of the `tasks` structure optional for completed transitions.

### Issues and Related PRs

* Resolves [CASMHMS-6408](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6408)

### Testing

Ran PCS smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable