### PR TITLE
CASMHMS-6416: SHCD: Updated image and module dependencies for security updates

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -36,7 +36,7 @@ artifactory.algol60.net/csm-docker/stable:
     # XXX Are these HMS images missing from a chart or are they used to
     # XXX facilitate install/upgrade?
     hms-shcd-parser:
-      - 1.9.0
+      - 1.11.0
 
     cf-gitea-update:
       - 1.1.0


### PR DESCRIPTION
### Summary and Scope

- Updated image and module dependencies for security updates
- Updated Go to v1.24
- Updated README to point to artifactory rather than old DTR

Adopted app version 1.11.0 for CSM 1.7.0 (no helm chart)

### Issues and Related PRs

* Resolves [CASMHMS-6416](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6416)

### Testing

With my changes applied, ran with `configs/sls_test_shcd-gamora.xlsx` to generate an `hmn_connections.json` output file.  Compared that to the `hmn_connections.json` output file generated by the latest v1.10.0 version of hms-shcd-parser in Artifactory.  Confirmed both output files were identical.

Tested on:

* Local laptop

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N (none exist)
Were continuous integration tests run? Y/N   If not, Why? N (none exist)
Was an Upgrade tested?                 Y/N   If not, Why? N (not upgradeable)
Was a Downgrade tested?                Y/N   If not, Why? Y (not downgradeable)

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated