### PR TITLE
CASMPET-7333: Update node images and manifests with K8s 1.32.2 images

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.16
+KUBERNETES_IMAGE_ID=7.1.0
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.16
+PIT_IMAGE_ID=7.1.0
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.16
+STORAGE_CEPH_IMAGE_ID=7.1.0
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.16
+COMPUTE_IMAGE_ID=7.1.0
 
 # Public keys for RPM signature validation.
 #
@@ -55,6 +55,7 @@ COMPUTE_IMAGE_ID=7.0.16
 # opensuse-obs-backports.asc - for packages in /sles-mirror/Backports/SLE-15-SP5_x86_64 (dkms, perl-File-BaseDir)
 # suse_ptf_key.asc - for SUSE PTF kernel packages, see https://www.suse.com/support/kb/doc/?id=000018545
 # opensuse-tumbleweed.asc - k8s packages taken from https://download.opensuse.org/tumbleweed/repo/oss/repodata/
+# isv_kubernetes_key.gpg - k8s packages taken from https://build.opensuse.org/project/subprojects/isv:kubernetes (expires 2026-12-29)
 HPE_RPM_SIGNING_KEYS=(
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key-fips.asc
@@ -66,4 +67,5 @@ HPE_RPM_SIGNING_KEYS=(
     https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-backports-15-sp5.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/suse_ptf_key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-tumbleweed.asc
+    https://artifactory.algol60.net/artifactory/gpg-keys/isv_kubernetes_key.gpg
 )

--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.0
+KUBERNETES_IMAGE_ID=7.1.1
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.0
+PIT_IMAGE_ID=7.1.1
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.0
+STORAGE_CEPH_IMAGE_ID=7.1.1
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.0
+COMPUTE_IMAGE_ID=7.1.1
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -118,32 +118,26 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Note this is the new layout for k8s 1.22 for coredns upstream the above
     # will go away for k8s 1.23+
-    k8s.gcr.io/coredns/coredns:
-      - v1.8.4
     registry.k8s.io/coredns/coredns:
       - v1.8.6
+      - v1.11.3
 
     # Kube images required by platform
-    k8s.gcr.io/kube-apiserver:
-      - v1.22.13
     registry.k8s.io/kube-apiserver:
       - v1.24.17
-    k8s.gcr.io/kube-controller-manager:
-      - v1.22.13
+      - v1.32.2
     registry.k8s.io/kube-controller-manager:
       - v1.24.17
-    k8s.gcr.io/kube-proxy:
-      - v1.22.13
+      - v1.32.2
     registry.k8s.io/kube-proxy:
       - v1.24.17
-    k8s.gcr.io/kube-scheduler:
-      - v1.22.13
+      - v1.32.2
     registry.k8s.io/kube-scheduler:
       - v1.24.17
-    k8s.gcr.io/pause:
-      - 3.5
+      - v1.32.2
     registry.k8s.io/pause:
       - 3.7
+      - 3.10
     quay.io/galexrt/node-exporter-smartmon:
       - v0.1.1
 

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -51,11 +51,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.8.4 # update platform.yaml cray-precache-images with this
+    version: 0.9.0 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.8.4
+        appVersion: 0.9.0
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -99,7 +99,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.1
+    version: 1.7.4
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -51,12 +51,12 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.8.6
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.24.17
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.24.17
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.24.17
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.24.17
-      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -51,28 +51,28 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns/coredns:v1.8.4
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.22.13
-      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.22.13
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.8.6
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.24.17
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.24.17
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.24.17
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.24.17
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
       # Kyverno
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.4
       - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.9.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
@@ -95,20 +95,16 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.6.6
+    version: 1.7.2
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.6.1
+    version: 1.7.1
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60
-    version: 1.0.0
+    version: 1.1.1
     namespace: kyverno
-  - name: cray-psp
-    source: csm-algol60
-    version: 0.4.5
-    namespace: services
   - name: cray-velero
     source: csm-algol60
     version: 1.6.3-3
@@ -117,10 +113,18 @@ spec:
     source: csm-algol60
     version: 0.4.1
     namespace: kube-system
+    values:
+      sealed-secrets:
+        rbac:
+          pspEnabled: false
   - name: cray-node-problem-detector
     source: csm-algol60
     version: 1.10.0
     namespace: kube-system
+    values:
+      node-problem-detector:
+        rbac:
+          pspEnabled: false
   - name: cray-istio-operator
     source: csm-algol60
     version: 2.0.0
@@ -133,6 +137,11 @@ spec:
     source: csm-algol60
     version: 0.8.1
     namespace: cert-manager
+    values:
+      cert-manager:
+        global:
+          podSecurityPolicy:
+            enabled: false
   - name: cray-opa
     source: csm-algol60
     version: 1.34.6
@@ -169,6 +178,10 @@ spec:
     source: csm-algol60
     version: 1.5.0
     namespace: services
+    values:
+      external-dns:
+        rbac:
+          pspEnabled: false
   - name: cray-sysmgmt-health
     source: csm-algol60
     version: 1.2.1
@@ -245,6 +258,10 @@ spec:
     source: csm-algol60
     version: 1.2.2
     namespace: metallb-system
+    values:
+      metallb:
+        psp:
+          create: false
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
     version: 0.2.3

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -12,7 +12,23 @@ spec:
     source: csm-algol60
     namespace: ceph-rbd
     version: 3.6.2-1
+    values:
+      ceph-csi-rbd:
+        nodeplugin:
+          podSecurityPolicy:
+            enabled: false
+        provisioner:
+          podSecurityPolicy:
+            enabled: false
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs
     version: 3.6.3-1
+    values:
+      ceph-csi-cephfs:
+        nodeplugin:
+          podSecurityPolicy:
+            enabled: false
+        provisioner:
+          podSecurityPolicy:
+            enabled: false

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -262,7 +262,7 @@ spec:
   # Spire service
   - name: cray-spire
     source: csm-algol60
-    version: 1.6.6
+    version: 1.7.4
     namespace: spire
 
   # Tapms service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -36,8 +36,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.36.8-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
-    - craycli-0.91.0-1.aarch64
-    - craycli-0.91.0-1.x86_64
+    - craycli-0.92.0-1.aarch64
+    - craycli-0.92.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.7-1.aarch64
     - csm-node-heartbeat-2.7-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -36,8 +36,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.36.8-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
-    - craycli-0.92.0-1.aarch64
-    - craycli-0.92.0-1.x86_64
+    - craycli-0.91.0-1.aarch64
+    - craycli-0.91.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.7-1.aarch64
     - csm-node-heartbeat-2.7-1.x86_64

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021,2023 Hewlett Packard Enterprise Development LP
+# Copyright 2021,2023, 2025 Hewlett Packard Enterprise Development LP
 
 set -exo pipefail
 
@@ -35,21 +35,6 @@ function undeploy() {
     helm status "$@" || return 0
     # Remove the chart.
     helm uninstall "$@"
-}
-
-# Check for manually create unbound PSP that is not managed by helm
-function unbound_psp_check() {
-    echo "Checking for manually created cray-unbound-coredns-psp"
-    unbound_psp_exist="$(kubectl get ClusterRoleBinding -n services |grep cray-unbound-coredns-psp |wc -l)"||true
-    if [[ "$unbound_psp_exist" -eq "1" ]]; then
-        unbound_psp_helm_check="$(kubectl get ClusterRoleBinding -n services cray-unbound-coredns-psp -o yaml |grep helm |wc -l)"||true
-        if [[ "$unbound_psp_helm_check" -eq "0" ]]; then
-            echo "Found ClusterRoleBinding cray-dns-unbound-psp NOT managed by helm"
-            kubectl delete ClusterRoleBinding -n services cray-unbound-coredns-psp
-            echo "Delete ClusterRoleBinding cray-dns-unbound-psp"
-        fi
-    fi
-    echo "cray-unbound-coredns-psp check Done"
 }
 
 # CRUS is removed in CSM 1.6, and should be removed during the upgrade, if it exists
@@ -88,9 +73,6 @@ kubectl create secret generic hpe-signing-key -n services ${RPM_SIGNING_KEYS_OPT
 
 # Save previous Unbound IP
 pre_upgrade_unbound_ip="$(kubectl get -n services service cray-dns-unbound-udp-nmn -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-
-# Check for manually create unbound PSP that is not managed by helm
-unbound_psp_check
 
 deploy "${BUILDDIR}/manifests/core-services.yaml"
 


### PR DESCRIPTION
## Summary and Scope
Upgrade Kubernetes to 1.32.2.  

High-level list of changes:
* Use node-images 7.1.0 with Kubernetes version 1.32.2.  (CASMPET-7333, CASMPET-7334)
* Since K8s 1.32 doesn't support PodSecurityPolicy, disable PSP in manifest yamls if not yet disabled in charts.  As charts get updated, the `pspEnabled: false` blocks can be removed.
* Update `cray-kyverno` to 1.7.2 (running `kyverno` 1.13.4) and update `kyverno-policy` to 1.7.4. This can only run on K8s 1.32. (CASMSEC-511)
* Update `cray-spire` to 1.7.4. (CASMPET-7325, CASMTRIAGE-7898)
* Update `cray-dns-unbound` to 0.9.0. (CASMPET-7336)

## Issues and Related PRs

* Resolves [CASMPET-7333](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7333)
* Resolves [CASMPET-7334](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7334)
* Resolves [CASMPET-7361](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7361)
* Resolves [CASMPET-7359](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7359)
* Resolves [CASMPET-7329](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7329)
* Resolves [CASMPET-7328](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7328)
* Resolves [CASMPET-7325](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7325)
* Resolves [CASMPET-7336](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7336)
* Resolves [CASMSEC-511](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-511)
* Resolves [CASMCMS-8942](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8942)
* Resolves [CASMTRIAGE-7898](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7898)

* Future work required by [CASMPET-7365](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7365)

* Merge before https://github.com/Cray-HPE/csm/pull/3996

## Testing

Installed successfully on `molly` and `wasp`.

***Upgrades FAIL*** and will continue to do so until [CASMPET-7365](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7365) is complete.

## Risks and Mitigations

Currently, this only works with installs and not upgrades.  Upgrade functionality is still in the works and will come with a later PR.  ***vShasta upgrades will fail*** until then.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

