### PR TITLE
CASMTRIAGE-7927: Update portainer image 

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -71,7 +71,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Required by argo workflows
     docker.io/portainer/kubectl-shell:
-      - latest-v1.21.1-amd64
+      - 2.27.0
 
     # Required by argo workflows
     docker.io/alpine/git:


### PR DESCRIPTION


## Summary and Scope

Update portainer image based on CSM 1.7 Kubernetes version v1.32 and use latest cray-site-init version 1.36.8



## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7927](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7927)
* Merge after https://github.com/Cray-HPE/container-images/pull/677
* Merge with https://github.com/Cray-HPE/docs-csm/pull/5817

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

