### PR TITLE
CASMINST-6734: Update cray-nls version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -259,11 +259,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 4.1.3
+    version: 5.0.1
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 4.1.3
+    version: 5.0.1
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

CASMINST-6734: SW_ADMIN_PASSWORD variable is not required to be set for tests anymore

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards incompatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6734](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6734)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/5743
* Merge after https://github.com/Cray-HPE/cray-nls/pull/226
* Merge after https://github.com/Cray-HPE/cray-nls-charts/pull/75

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

