### PR TITLE
CASMHMS-6437: Fix lost errno in heartbeat client

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -34,16 +34,16 @@ CN_ARCH=("x86_64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.0.16
+KUBERNETES_IMAGE_ID=7.1.2
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.0.16
+PIT_IMAGE_ID=7.1.2
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.0.16
+STORAGE_CEPH_IMAGE_ID=7.1.2
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.0.16
+COMPUTE_IMAGE_ID=7.1.2
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -39,8 +39,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.92.0-1.aarch64
     - craycli-0.92.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
-    - csm-node-heartbeat-2.7-1.aarch64
-    - csm-node-heartbeat-2.7-1.x86_64
+    - csm-node-heartbeat-2.8-1.aarch64
+    - csm-node-heartbeat-2.8-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.8.0-1.noarch
     - csm-ssh-keys-roles-1.7.1-1.noarch


### PR DESCRIPTION
## Summary and Scope

After getline() fails, pclose() was being called before writing out the error message for the failed getline().  This caused errno to be overwritten with zero (ie. call was a "success").

## Issues and Related PRs

* Resolves [CASMHMS-6437](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6437)

## Testing

This change is simple enough it does not really need testing but nonetheless I loaded hb_ref on a compute node on mug and restarted the service in verbose mode to ensure execution went through `get_auth_token()` without error.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable