### PR TITLE
CASMNET-2300 - Update network firmware versions for CSM 1.7

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.1-1.noarch
     - cani-0.4.0-1.x86_64
-    - canu-1.9.7-1.x86_64
+    - canu-1.9.9-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.3-1.noarch
     - cfs-trust-1.9.0-1.noarch


### PR DESCRIPTION
## Summary and Scope

Update management network AOS-CX version to 10.13.1080

## Issues and Related PRs

* Resolves [CASMNET-2300](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2300)

## Testing

### Tested on:

  * `surtur`

### Test description:

```
ncn-m001:~ # canu report network firmware --csm 1.7 --ips $(awk '/sw-/{ printf "%s%s", sep, $1; sep="," }' /etc/hosts) --password $PASSWORD
------------------------------------------------------------------
    STATUS  IP              HOSTNAME            FIRMWARE
------------------------------------------------------------------
 🛶 Pass    10.254.0.2      sw-spine-001        GL.10.13.1080
 🛶 Pass    10.254.0.3      sw-spine-002        GL.10.13.1080
 🛶 Pass    10.254.0.4      sw-leaf-bmc-001     FL.10.13.1080

Summary
------------------------------------------------------------------
🛶 Pass - 3 switches
GL.10.13.1080 - 2 switches
FL.10.13.1080 - 1 switches
```

```
ncn-m001:~ # canu test --csm 1.7 --password $PASSWORD | grep Software
|  0 | sw-spine-001    | Software Version                             | PASS     |                                                                                            |
| 23 | sw-spine-002    | Software Version                             | PASS     |                                                                                            |
| 46 | sw-leaf-bmc-001 | Software Version                             | PASS     |                                                                                            |
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

