### PR TITLE
CASMCMS-9330: Fix BOS logging bug

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.35.0
+    version: 2.35.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.34.2/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.35.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.0


### PR DESCRIPTION
Fix a minor BOS logging bug.

CSM 1.6.2 backport PR: https://github.com/Cray-HPE/csm/pull/4015