### PR TITLE
CASMPET-7332: Disable PSP in cray-externaldns by default

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -113,18 +113,10 @@ spec:
     source: csm-algol60
     version: 0.5.1
     namespace: kube-system
-    values:
-      sealed-secrets:
-        rbac:
-          pspEnabled: false
   - name: cray-node-problem-detector
     source: csm-algol60
     version: 1.11.1
     namespace: kube-system
-    values:
-      node-problem-detector:
-        rbac:
-          pspEnabled: false
   - name: cray-istio-operator
     source: csm-algol60
     version: 2.0.0
@@ -137,11 +129,6 @@ spec:
     source: csm-algol60
     version: 0.9.2
     namespace: cert-manager
-    values:
-      cert-manager:
-        global:
-          podSecurityPolicy:
-            enabled: false
   - name: cray-opa
     source: csm-algol60
     version: 1.34.6
@@ -176,12 +163,8 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.6.0
+    version: 1.6.1
     namespace: services
-    values:
-      external-dns:
-        rbac:
-          pspEnabled: false
   - name: cray-sysmgmt-health
     source: csm-algol60
     version: 1.2.1


### PR DESCRIPTION
## Summary and Scope

Now that K8s 1.32 is in `release/1.7`, use `cray-externaldns` version 1.6.1 with PSP disabled by default.
  
No longer need to disable PSP in `manifests/platform.yaml` for `sealed-secrets`, `cray-node-problem-selector`, `cray-certmanager`, and `cray-externaldns` since PSP is disabled by default in their own charts.

## Issues and Related PRs

* Resolves [CASMPET-7332](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7332)

## Testing
On molly running K8s 1.32.2:
```
pit:~/studenym # helm upgrade -n services cray-externaldns cray-externaldns-1.6.1-20250313130232+f07f4d4.tgz
Release "cray-externaldns" has been upgraded. Happy Helming!
NAME: cray-externaldns
LAST DEPLOYED: Thu Mar 13 16:12:23 2025
NAMESPACE: services
STATUS: deployed
REVISION: 5
TEST SUITE: None
NOTES:
Happy Helming
pit:~/studenym #
pit:~/studenym # kubectl get pods -n services | grep external
cray-externaldns-external-dns-7cbc88795d-w5qvr                    1/1     Running            0                 2m13s
pit:~/studenym # kubectl get pods -n services cray-externaldns-external-dns-7cbc88795d-w5qvr -o yaml | grep image
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns@sha256:d909ec61396b69b83025bde15e76daf9724db8f30d21e7597959c84fce862160
pit:~/studenym #
```

## Risks and Mitigations
No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

