### PR TITLE
CASMPET-6937: Update spire-agent log level

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -262,7 +262,7 @@ spec:
   # Spire service
   - name: cray-spire
     source: csm-algol60
-    version: 1.7.4
+    version: 1.7.5
     namespace: spire
 
   # Tapms service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-cmstools-crayctldeploy-1.27.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.8-1.x86_64
-    - cray-spire-dracut-2.0.3-1.noarch
+    - cray-spire-dracut-2.0.4-1.noarch
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.92.0-1.aarch64
     - craycli-0.92.0-1.x86_64
@@ -72,8 +72,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python39-requests-retry-session-0.2.4-1.noarch
     - sbps-marshal-0.0.14-1.noarch
     - smart-mon-1.0.3-1.noarch
-    - spire-agent-1.5.5-1.10.aarch64
-    - spire-agent-1.5.5-1.10.x86_64
+    - spire-agent-1.5.5-1.11.aarch64
+    - spire-agent-1.5.5-1.11.x86_64
     - tpm-provisioner-client-1.0.1-3.aarch64
     - tpm-provisioner-client-1.0.1-3.x86_64
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMPET-6937](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6937)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This changes the log level on spire-agent to WARN. This was chosen because of the amount of logs that the spire-agent gives can cause slowdowns on larger systems. On all internal systems the log messages for info are not needed and provide no helpful data. 

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
           Tested on tyr by changing the loglevel on the config file and restarting the service to ensure it started up.
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
There is no risk as this can be changed on the fly for systems if we need more logging for some reason, however it has never been useful logging to begin with.