### PR TITLE
CASMPET-6561: Upgrade kube-state-metrics to 2.15.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -184,7 +184,7 @@ spec:
           pspEnabled: false
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.1
+    version: 1.2.4
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
Upgrade `kube-state-metrics` image used in `cray-sysmgmt-health` manifest to fix CVEs and for compatibility with K8s 1.32.

## Issues and Related PRs

* Resolves [CASMPET-6561](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6561)

## Testing
Tested on `molly` running K8s 1.32.2.

```
ncn-m001:~/studenym # helm upgrade -n sysmgmt-health cray-sysmgmt-health cray-sysmgmt-health-1.2.4-20250321190703+6e8066b.tgz
Release "cray-sysmgmt-health" has been upgraded. Happy Helming!
NAME: cray-sysmgmt-health
LAST DEPLOYED: Fri Mar 21 19:13:29 2025
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 5
pit:~ # kubectl get pods -n sysmgmt-health | grep cray-sysmgmt
cray-sysmgmt-health-canu-test-6945887cb8-bvrtn                   2/2     Running     0             6d22h
cray-sysmgmt-health-grafana-665777dc5d-kzzvw                     2/2     Running     0             6d22h
cray-sysmgmt-health-grok-exporter-f5cd5494d-6wld2                1/1     Running     0             6d22h
cray-sysmgmt-health-grok-exporter-f5cd5494d-94tqf                1/1     Running     0             6d22h
cray-sysmgmt-health-grok-exporter-f5cd5494d-ftqx6                1/1     Running     0             6d22h
cray-sysmgmt-health-kube-state-metrics-88695fd6f-pdv9h           1/1     Running     0             3d23h
cray-sysmgmt-health-logstash-exporter-7b475899cc-hx6dg           1/1     Running     0             2d22h
cray-sysmgmt-health-node-exporter-smartmon-4qdbt                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-9vbmv                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-k8vzr                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-mmq6s                 1/1     Running     0             6d20h
cray-sysmgmt-health-node-exporter-smartmon-p42k2                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-rbrbg                 1/1     Running     0             6d22h
cray-sysmgmt-health-patch-service-monitors-5-5kbxf               0/1     Completed   0             2d22h
cray-sysmgmt-health-prometheus-node-exporter-5gjt2               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-ck7wt               1/1     Running     0             6d20h
cray-sysmgmt-health-prometheus-node-exporter-ldr2g               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-pw96d               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-qr98w               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-wbqpx               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-snmp-exporter-7985b57977-gqzz4    1/1     Running     0             6d22h
cray-sysmgmt-health-redfish-cron-29046240-kh5gw                  0/1     Completed   0             17h
cray-sysmgmt-health-redfish-cron-29046600-d9ffq                  0/1     Completed   0             11h
cray-sysmgmt-health-redfish-cron-29046960-xvckw                  0/1     Completed   0             5h56m
cray-sysmgmt-health-redfish-exporter-7477b757c6-lgw9g            1/1     Running     0             6d22h
cray-sysmgmt-health-victoria-metrics-operator-6cc697fb8d-dk9gb   1/1     Running     0             6d22h
pit:~ # helm history -n sysmgmt-health cray-sysmgmt-health
REVISION	UPDATED                 	STATUS    	CHART                                           	APP VERSION	DESCRIPTION
1       	Mon Mar 17 19:04:40 2025	superseded	cray-sysmgmt-health-1.2.1                       	0.24.5     	Install complete
2       	Thu Mar 20 18:36:54 2025	superseded	cray-sysmgmt-health-1.2.3                       	0.24.5     	Upgrade complete
3       	Thu Mar 20 18:39:48 2025	superseded	cray-sysmgmt-health-1.2.1                       	0.24.5     	Rollback to 1
4       	Thu Mar 20 18:50:24 2025	superseded	cray-sysmgmt-health-1.2.2                       	0.24.5     	Upgrade complete
5       	Fri Mar 21 19:13:29 2025	deployed  	cray-sysmgmt-health-1.2.4-20250321190703+6e8066b	0.24.5     	Upgrade complete
pit:~ #
```

Was able to attach to service ...

![image](https://github.com/user-attachments/assets/d5358e0a-ea3a-4942-ae1f-6c16c71d193e)

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

