### PR TITLE
CASMHMS-6417: HMNFD: Updated image and module dependencies for security updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -70,13 +70,13 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.22.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 4.0.6
+    version: 4.1.0
     namespace: services
     timeout: 10m
     swagger:
     - name: hmnfd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.22.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.24.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
     version: 2.17.1


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Fixed pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

The tavern tests were updated to look for a returned 404 http code rather than a 405 code due to the gorilla/mux change https://github.com/gorilla/mux/pull/712 that came with updating the gorilla module.

Adopted app version 1.24.0 for CSM 1.7.0 (helm chart 4.1.0)

### Issues and Related PRs

* Resolves [CASMHMS-6417](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6417)

### Testing

Ran smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable