### PR TITLE
CASMHMS-6414: HBTD: Updated image and module dependencies for security updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -61,13 +61,13 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.39.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.2.0
+    version: 3.2.1
     namespace: services
     timeout: 10m
     swagger:
     - name: hbtd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.22.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.23.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
     version: 4.0.6


### PR DESCRIPTION
### Summary and Scope

#### App Changes

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

#### Chart Changes

Adopted app version 1.23.0 for CSM 1.7.0 (helm chart 3.2.1)

### Issues and Related PRs

* Resolves [CASMHMS-6414](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6414)

### Testing

Ran smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable