### PR TITLE
CASMHMS-6418: SCSD: Updated image and module dependencies for security updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -83,12 +83,12 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 3.0.2
+    version: 3.1.0
     namespace: services
     swagger:
     - name: scsd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.20.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.21.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Fixed pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Latest images/modules require building with the `musl` tag.

Fixed a bunch of calls to ```Errorf(emsg)``` which are now required to be ```Errorf("%s", emsg)``` with Go v1.24 and later.

Updating the hms-base module required changes to reference code that was moved from hms-base to the hms-xname module.

Fixed bug in runSnyk.sh that prevented jq from parsing success.

We were building our unit tests with the legacy builder which is now deprecated so switched to BuildKit.

The github.com/Cray-HPE/hms-trs-app-api module was NOT updated as part of this effort.  It currently sits at v1.6.2 and would be a substantial effort to upgrade it to the latest v3.0.4.  [CASMHMS-6446](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6446) was opened to track this added effort so that we can quickly get the other security updates completed.

Adopted app version 1.21.0 for CSM 1.7.0 (helm chart 3.1.0)

### Issues and Related PRs

* Resolves [CASMHMS-6418](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6418)

### Testing

Ran smoke tests on mug.  We don't have any integration tests for SCSD.  I did hit various endpoints with GET and confirmed identical output with the version of SCSD previously running on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable