### PR TITLE
CASMCMS-9228: CFS Configurations Need to Store Tenant Information in the CFS API

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,12 +143,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.35.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.26.0
+    version: 1.26.1
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.1/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.13.0


### PR DESCRIPTION
@jsl-hpe  did this CFS work back in January but the manifest PR piece slipped through the cracks. I have confirmed with him that this should go into CSM 1.7, so here is the manifest PR.