### PR TITLE
CASMCMS-9333: Fix bug in cfs-trust

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -126,7 +126,7 @@ spec:
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.9.0
+    version: 1.9.1
     namespace: services
   - name: cms-ipxe
     source: csm-algol60

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -30,7 +30,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - canu-1.9.9-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-state-reporter-1.12.3-1.noarch
-    - cfs-trust-1.9.0-1.noarch
+    - cfs-trust-1.9.1-1.noarch
     - cray-cmstools-crayctldeploy-1.27.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.8-1.x86_64


### PR DESCRIPTION
The corresponding node-images changes for this fix are coming in with https://github.com/Cray-HPE/csm/pull/4023

No backports