### PR TITLE
CASMPET-7447: New cray-vpa-crd chart and upgrade cray-vpa chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -279,7 +279,12 @@ spec:
     source: csm-algol60
     version: 0.1.0
     namespace: kube-system
+  # cray-vpa-crd chart must be installed before cray-vpa chart
+  - name: cray-vpa-crd
+    source: csm-algol60
+    version: 1.0.0
+    namespace: services
   - name: cray-vpa
     source: csm-algol60
-    version: 0.0.2
+    version: 1.0.0
     namespace: services


### PR DESCRIPTION
## Summary and Scope

CASMPET-7447
* Upgraded `cray-vpa` to use Fairwinds chart version 4.7.2 and `vpa` version 1.3.0 for `recommender`, `updater`, and `admission-controller` components.
* New `cray-vpa-crd` chart to upgrade crds for `helm upgrade` path.

## Issues and Related PRs

* Resolves [CASMPET-7447](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7447)

## Testing
Installed on `wasp` running K8s 1.32.2
```
ncn-m001:~/studenym # helm history -n services cray-vpa-crd
REVISION	UPDATED                 	STATUS	CHART             	APP VERSION	DESCRIPTION
1       	Mon Mar 31 18:04:29 2025	failed	cray-vpa-crd-1.0.0	           	Release "cray-vpa-crd" failed: context canceled
ncn-m001:~/studenym # helm upgrade -n services cray-vpa-crd cray-vpa-crd-1.0.0.tgz
Release "cray-vpa-crd" has been upgraded. Happy Helming!
NAME: cray-vpa-crd
LAST DEPLOYED: Mon Mar 31 18:11:42 2025
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
ncn-m001:~/studenym # helm history -n services cray-vpa-crd
REVISION	UPDATED                 	STATUS    	CHART             	APP VERSION	DESCRIPTION
1       	Mon Mar 31 18:04:29 2025	superseded	cray-vpa-crd-1.0.0	           	Release "cray-vpa-crd" failed: context canceled
2       	Mon Mar 31 18:11:42 2025	deployed  	cray-vpa-crd-1.0.0	           	Upgrade complete
ncn-m001:~/studenym # helm history -n services cray-vpa
REVISION	UPDATED                 	STATUS    	CHART         	APP VERSION	DESCRIPTION
1       	Wed Mar 26 18:10:17 2025	superseded	cray-vpa-0.0.2	1.4.0      	Install complete
2       	Wed Mar 26 19:12:16 2025	deployed  	cray-vpa-0.0.2	1.4.0      	Upgrade complete
ncn-m001:~/studenym # helm upgrade -n services cray-vpa cray-vpa-1.0.0.tgz
Release "cray-vpa" has been upgraded. Happy Helming!
NAME: cray-vpa
LAST DEPLOYED: Mon Mar 31 18:14:47 2025
NAMESPACE: services
STATUS: deployed
REVISION: 3
ncn-m001:~/studenym # helm history -n services cray-vpa
REVISION	UPDATED                 	STATUS    	CHART         	APP VERSION	DESCRIPTION
1       	Wed Mar 26 18:10:17 2025	superseded	cray-vpa-0.0.2	1.4.0      	Install complete
2       	Wed Mar 26 19:12:16 2025	superseded	cray-vpa-0.0.2	1.4.0      	Upgrade complete
3       	Mon Mar 31 18:14:47 2025	deployed  	cray-vpa-1.0.0	4.7.2      	Upgrade complete
ncn-m001:~/studenym #

ncn-m001:~ # kubectl get pods -n services | grep cray-vpa
cray-vpa-recommender-658574c8f6-5wgn7                             2/2     Running     0                105s
cray-vpa-updater-c445c7c85-qsfwc                                  2/2     Running     0                105s
ncn-m001:~ #
ncn-m001:~ # kubectl logs -n services cray-vpa-recommender-658574c8f6-5wgn7 --since=10m
I0331 18:14:54.317095       1 flags.go:57] FLAG: --add-dir-header="false"
I0331 18:14:54.317308       1 flags.go:57] FLAG: --address=":8942"
I0331 18:14:54.317314       1 flags.go:57] FLAG: --alsologtostderr="false"
I0331 18:14:54.317320       1 flags.go:57] FLAG: --checkpoints-gc-interval="10m0s"
I0331 18:14:54.317325       1 flags.go:57] FLAG: --checkpoints-timeout="1m0s"
<snip>
I0331 18:14:54.317728       1 main.go:127] "Vertical Pod Autoscaler Recommender" version="1.3.0" recommenderName="default"
I0331 18:14:54.318177       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0331 18:14:54.318193       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0331 18:14:54.318204       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0331 18:14:54.318215       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0331 18:14:54.319262       1 reflector.go:313] Starting reflector *v1.StatefulSet (10m0s) from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:54.319284       1 reflector.go:349] Listing and watching *v1.StatefulSet from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:54.339805       1 reflector.go:376] Caches populated for *v1.StatefulSet from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:54.419796       1 controller_fetcher.go:147] "Initial sync completed" kind="StatefulSet"
<snip>
I0331 18:14:55.023400       1 reflector.go:313] Starting reflector *v1.Pod (1h0m0s) from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:55.023433       1 reflector.go:349] Listing and watching *v1.Pod from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:55.620586       1 reflector.go:376] Caches populated for *v1.Pod from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:55.623752       1 main.go:239] "Using Metrics Server"
I0331 18:14:55.624107       1 reflector.go:313] Starting reflector *v1.VerticalPodAutoscaler (1h0m0s) from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:55.624123       1 reflector.go:349] Listing and watching *v1.VerticalPodAutoscaler from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:55.657337       1 reflector.go:376] Caches populated for *v1.VerticalPodAutoscaler from pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251
I0331 18:14:55.724899       1 api.go:97] "Initial VPA synced successfully"
I0331 18:14:55.725183       1 fetcher.go:102] "Initial sync completed" kind="Job"
I0331 18:14:55.725202       1 fetcher.go:102] "Initial sync completed" kind="CronJob"
I0331 18:14:55.725215       1 fetcher.go:102] "Initial sync completed" kind="DaemonSet"
I0331 18:14:55.725230       1 fetcher.go:102] "Initial sync completed" kind="Deployment"
I0331 18:14:55.725246       1 fetcher.go:102] "Initial sync completed" kind="ReplicaSet"
I0331 18:14:55.725259       1 fetcher.go:102] "Initial sync completed" kind="StatefulSet"
<snip>
I0331 18:14:55.725593       1 recommender.go:205] "New Recommender created" recommender={}
I0331 18:14:55.725621       1 cluster_feeder.go:251] "Initializing VPA from checkpoints"
I0331 18:14:55.725636       1 cluster_feeder.go:338] "Start selecting the vpaCRDs."
I0331 18:14:55.725656       1 cluster_feeder.go:379] "Fetching VPAs" count=0
I0331 18:15:55.726727       1 recommender.go:148] "Recommender Run"
I0331 18:15:55.726782       1 cluster_feeder.go:338] "Start selecting the vpaCRDs."
I0331 18:15:55.726809       1 cluster_feeder.go:379] "Fetching VPAs" count=0
I0331 18:15:55.751271       1 metrics_client.go:74] "podMetrics retrieved for all namespaces" podMetrics=347
I0331 18:15:55.755444       1 cluster_feeder.go:467] "ClusterSpec fed with ContainerUsageSamples" sampleCount=1254 containerCount=627 droppedSampleCount=0
I0331 18:15:55.755473       1 recommender.go:158] "ClusterState is tracking" pods=436 vpas=0
I0331 18:15:55.755880       1 cluster.go:365] "Garbage collection of AggregateCollectionStates triggered"
I0331 18:15:55.756391       1 cluster.go:372] "Removing empty and not contributive AggregateCollectionState" key={}
<snip>
```


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

