### PR TITLE
CASMHMS-6415: Updated image and module dependencies for security updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.1.0
+    version: 5.1.1
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.1.0
+    version: 5.1.1
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Fixed pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Updated local testing document to make clear requirements for setting up certs before running docker compose.

Added additional logging throughout RTS to make it easier to debug and know what RTS is doing.  These were mostly DEBUG and TRACE logs.

Fixed a race condition at startup time.  The http servers were handling requests before all of the helpers had time to run for the first time and complete initialization.  Looks like this problem has been in RTS from the very start.

The latest kubernetes http clientset now requires a context for the Get() and Delete() operations.  addXNameService() and all its callers were updated to provide this.  Additionally, the kubernetes Create() all now requires an options argument as well.

Fixed bug in runSnyk.sh that prevented jq from parsing success.

We were building our unit tests with the legacy builder which is now deprecated so switched to BuildKit.

Adopted app version 1.26.0 for CSM 1.7.0 (helm chart 5.1.1)

### Issues and Related PRs

* Resolves [CASMHMS-6415](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6415)

### Testing

The pipeline tests all pass.

I loaded the changes on both `mug` (just snmp switches) and `gamora` (has a jaws PDU).  Watched log files to ensure all logging identically matched TRS running without my changes.

On my laptop I stood up the entire simulator-like environment with:

```bash
docker-compose -f docker-compose.simulator.yaml up -d
```

As well as the jaws backend tester:

```bash
docker-compose -f docker-compose.jaws.yaml up --build
```

And ran RTS locally outside of a container:

```bash
docker-compose -f docker-compose.devel.yaml up --build 
./scripts/runRTS.sh
```

Verified all output looked sensible.

Tested on:

* `mug`
* `gamora`
* Local laptop

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable