### PR TITLE
CASMHMS-6359: Added support for pprof builds in SCSD

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -83,12 +83,12 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: services
     swagger:
     - name: scsd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.21.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.22.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp


### PR DESCRIPTION
### Summary and Scope

Added pprof image support to SCSD.

Also completed a minor update of the go module dependencies.

Adopted app version 1.22.0 for CSM 1.7.0 (helm chart 3.1.1)

### Issues and Related PRs

* Resolves [CASMHMS-6359](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6359)

### Testing

Ran CT tests on mug with both the pprof and non-pprof images.  Also used pprof client from my laptop to comfirm pprof functionality on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable