### PR TITLE
CRAYSAT-1949: update cray-sat to 3.35.0

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.34.8
+      - 3.35.1
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

This will update cray-sat container image from 3.34.8 to 3.35.1 which includes fixes for the following issues:

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CRAYSAT-1987: Resolve dependabot alerts for jinja2
* Resolves https://github.com/Cray-HPE/sat/pull/332
* Resolves CRAYSAT-1949: Add ability to specify skip or overwrite of existing items in bootprep file.
* Documentation changes required in https://github.com/Cray-HPE/docs-csm/pull/5860

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Rocket
  * Gamora
  * Drax
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? yes

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ no


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

