### PR TITLE
CASMCMS-8703, CASMCMS-9181, CASMCMS-9328

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.10.0-1.noarch
     - cfs-state-reporter-1.12.3-1.noarch
     - cfs-trust-1.9.1-1.noarch
-    - cray-cmstools-crayctldeploy-1.27.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.28.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.8-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch


### PR DESCRIPTION
CASMCMS-9181: cmsdev Should record installed version of Cray CLI RPM
CASMCMS-9328: IMS: Store Artifact logs after signing key test failure
CASMCMS-8703: TESTS: Add CFS node personalization to the barebones image boot test

1.6 backport PR https://github.com/Cray-HPE/csm/pull/4038