### PR TITLE
CASMHMS-6358: Add pprof image support for RTS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.1.0
+    version: 5.1.2
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.1.0
+    version: 5.1.2
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
### Summary and Scope

Removed RTS pprof support in the production image as its generally not advisable.  Created new pprof image to provide this support, consistent with how we enable pprof for our other HMS services.

Adopted app version 1.27.0 for CSM 1.7.0 (helm chart 5.1.2)

### Issues and Related PRs

* Resolves [CASMHMS-6358](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6358)

### Testing

Verified production image no longer contains pprof functionality.

Verified pprof image functions correctly by using a pprof client from my laptop.

Verified no apparent issues in the output logs with both the production and pprof images running.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable