### PR TITLE
CASMHMS-6361: Added support for pprof builds in MEDS

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -35,7 +35,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.35.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
-    version: 3.1.0
+    version: 3.1.1
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Added pprof image support to MEDS.

Also completed a minor update of the go module dependencies and upgraded it from Go 1.23 to 1.24.

Adopted app version 1.24.0 for CSM 1.7.0 (helm chart 3.1.1)

### Issues and Related PRs

* Resolves [CASMHMS-6361](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6361)

### Testing

Verified production image no longer contains pprof functionality.

Verified pprof image functions correctly by using a pprof client from my laptop.

Verified no apparent issues in the output logs with both the production and pprof images running.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable