### PR TITLE
CASMNET-2194/CASMNET-2199 - Enable Hubble UI access

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -283,3 +283,7 @@ spec:
     source: csm-algol60
     version: 0.0.2
     namespace: services
+  - name: cray-hubble
+    source: csm-algol60
+    version: 0.0.1
+    namespace: kube-system

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -70,7 +70,6 @@ spec:
       - '{{ kubernetes.services[''cray-sysmgmt-health''][''victoria-metrics-k8s-stack''].grafana.externalAuthority }}'
       - '{{ kubernetes.services.gitea.externalHostname }}'
       - '{{ kubernetes.services[''cray-nls''].externalHostname }}'
-      - '{{ kubernetes.services[''cray-hubble''].externalHostname }}'
       - sma-grafana.cmn.{{ network.dns.external }}
       - sma-kibana.cmn.{{network.dns.external}}
       - sma-dashboards.cmn.{{network.dns.external}}
@@ -921,5 +920,3 @@ spec:
             - '{{ kubernetes.sealed_secrets.powerdns | toYaml }}'
       cray-nls:
         externalHostname: "cmn.{{ network.dns.external }}"
-      cray-hubble:
-        externalHostname: hubble.cmn.{{ network.dns.external }}

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -70,6 +70,7 @@ spec:
       - '{{ kubernetes.services[''cray-sysmgmt-health''][''victoria-metrics-k8s-stack''].grafana.externalAuthority }}'
       - '{{ kubernetes.services.gitea.externalHostname }}'
       - '{{ kubernetes.services[''cray-nls''].externalHostname }}'
+      - '{{ kubernetes.services[''cray-hubble''].externalHostname }}'
       - sma-grafana.cmn.{{ network.dns.external }}
       - sma-kibana.cmn.{{network.dns.external}}
       - sma-dashboards.cmn.{{network.dns.external}}
@@ -920,3 +921,5 @@ spec:
             - '{{ kubernetes.sealed_secrets.powerdns | toYaml }}'
       cray-nls:
         externalHostname: "cmn.{{ network.dns.external }}"
+      cray-hubble:
+        externalHostname: hubble.cmn.{{ network.dns.external }}


### PR DESCRIPTION
## Summary and Scope

* Add the Cilium Hubble UI to `proxiedWebAppExternalHostnames` in order to allow authenticated access to the UI.
* Add new `cray-hubble` Helm chart to create the Istio VirtualService resource.

Note that the VirtualService creation cannot happen when Cilium is installed because Istio isn't installed yet when that occurs.

## Issues and Related PRs

* Resolves [CASMNET-2194](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2194)
* Resolves [CASMNET-2199](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2199)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/5883

## Testing

### Tested on:

  * `starlord`

### Test description:

Reinstalled cray-keycloak, cray-keycloak-users-localize, cray-oauth2-proxies, and the new cray-hubble chart.

The virtual service was created successfully

```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  annotations:
    meta.helm.sh/release-name: cray-hubble
    meta.helm.sh/release-namespace: kube-system
  creationTimestamp: "2025-04-09T09:26:24Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: cray-hubble
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cray-hubble
    app.kubernetes.io/version: 0.0.1
    helm.sh/chart: cray-hubble-0.0.1
  name: cray-hubble
  namespace: kube-system
  resourceVersion: "22893284"
  uid: 781117bd-396d-4873-90ca-be1d304dbf22
spec:
  gateways:
  - services/services-gateway
  - services/customer-admin-gateway
  hosts:
  - hubble.cmn.starlord.hpc.amslabs.hpecorp.net
  http:
  - match:
    - authority:
        exact: hubble.cmn.starlord.hpc.amslabs.hpecorp.net
    route:
    - destination:
        host: hubble-ui
        port:
          number: 80
      headers:
        request:
          remove:
          - Authorization
```

Login to the UI via hubble.cmn.starlord.hpc.amslabs.hpecorp.net is possible

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

