### PR TITLE
CASMPET-7447: New cray-vpa-crd chart and upgrade cray-vpa chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -279,7 +279,12 @@ spec:
     source: csm-algol60
     version: 0.1.0
     namespace: kube-system
+  # cray-vpa-crd chart must be installed before cray-vpa chart
+  - name: cray-vpa-crd
+    source: csm-algol60
+    version: 1.0.0
+    namespace: services
   - name: cray-vpa
     source: csm-algol60
-    version: 0.0.2
+    version: 1.0.1
     namespace: services

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -286,5 +286,5 @@ spec:
     namespace: services
   - name: cray-vpa
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: services


### PR DESCRIPTION
## Summary and Scope
CASMPET-7447
  * Upgraded `cray-vpa` to use Fairwinds chart version 4.7.2, `vpa` version 1.3.0 for recommender, updater, and admission-controller components, and `bitnami/kubectl` version 1.32 for tests component.
  * New cray-vpa-crd chart to upgrade crds for helm upgrade path.
 
## Issues and Related PRs

* Resolves [CASMPET-7447](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7447)
* Related Approved `csm` PR: https://github.com/Cray-HPE/csm/pull/4030
* Related `cray-vpa` PRs:
cray-vpa 1.0.0 PR: https://github.com/Cray-HPE/cray-vpa/pull/7
cray-vpa 1.0.1 PR: https://github.com/Cray-HPE/cray-vpa/pull/8
cray-vpa 1.0.2 PR: https://github.com/Cray-HPE/cray-vpa/pull/9

## Testing
See `cray-vpa` PRs for testing information.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

