### PR TITLE
CASMHMS-6477: Fixed concurrency issues in RTS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.0.1
+    version: 5.0.2
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.0.1
+    version: 5.0.2
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

There are several concurrency related changes in this PR.

A lock was added to protect the `KnownDevice` map from concurrent writes.  This was the original bug described in CASMHMS-6477.  Seperate mutexes were added for the certificate service and both the SNMP and JAWS backend helpers.  This was because there is a uniqe `KnownDevice` map for each of them.

Renamed `redisActivePipelineMux` to `RedisActivePipelineMux` and moved it into the `RedisHelper` struct so that it could be more widely accessed.  It was previously used only in the SNMP backend helper to protect the Redis active pipeline from oncurrent writes.  The same protection is required in the gcloud, JAWS, and simulator backend helpers, so they were modified to make use of it.

Adopted app version 1.24.1 for CSM 1.5.5 (helm chart 4.0.3)
Adopted app version 1.25.1 for CSM 1.6.2 (helm chart 5.0.2)
Adopted app version 1.28.0 for CSM 1.7.0 (helm chart 5.1.3)

## Issues and Related PRs

* [CASMHMS-6477](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6477)

## Testing

Tested on:

  * `gamora` (1.6)
  * `mug` (1.7)
  * `slice` (1.5)

Test description:

Tested the CSM 1.6.2 version of both cray-hms-rts and cray-hms-rts-snmp on gamora.  Confirmed no issues talking SNMP to the leaf switches (SNMP wasn't enabled on the spine switches) and no issues talking JAWS to the iPDU.  Watched logs for issues and confirmed same log output with and without my changes.  Examined the internal redis database to ensure it was identical with and without my changes.

Tested the CSM 1.7.0 version of cray-hms-rts-snmp on mug.  Confirmed no issues talking SNMP to both the leaf and spine switches (SNMP was enabled on both).  There are no iPDUs on mug.

Tested the CSM 1.5.5 version of cray-hms-rts-snmp on slice to ensure no deviant issues in the 1.5.5 version.

## Risks and Mitigations

Extending the use of `redisActivePipelineMux` into the JAWS backend helper creates a risk associated with extending the time required for initial PDU discovery.  Because the Redis active pipeline is now, correctly, gated and serialized, it will take longer to discover all of the initial PDU devices.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable