### PR TITLE
CASMCMS-9353/CASMCMS-9356/CASMCMS-9357: BOS fixes/improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.38.0
+    version: 2.38.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.38.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.38.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.38.1
+    version: 2.39.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.38.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.39.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1


### PR DESCRIPTION
CASMCMS-9356: Fixes a BOS logging bug that can show up when the chart is initially deployed. No backports needed.
CASMCMS-9353/CASMCMS-9357: Improve BOS logging and fix logging issue that can lead to OOM problems. Backports for these two forthcoming.
