### PR TITLE
CASMCMS-9353/CASMCMS-9357: BOS logging fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -159,13 +159,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.0.51
+    version: 2.0.52
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.51/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.52/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.12


### PR DESCRIPTION
CSM 1.4 backport of the two BOS logging fixes from https://github.com/Cray-HPE/csm/pull/4052