### PR TITLE
CASMCMS-9353/CASMCMS-9357: BOS logging fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.30.13
+    version: 2.30.14
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.13/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.14/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.6


### PR DESCRIPTION
CSM 1.6 backport of the two BOS logging fixes from https://github.com/Cray-HPE/csm/pull/4052