### PR TITLE
CASMTRIAGE-8027: Fixed false positive ComponentEndpoints test failure in SMD

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.2
+    version: 7.2.3
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.35.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.36.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.1


### PR DESCRIPTION
## Summary and Scope

Test was matching ethernet NICs with:

```
DC[0-9A-Za-z]+|\
DE[0-9A-Za-z]+|\
```

But a new NIC was installed on creek that started with DA, so the test failed.  Rather than add:

```
DA[0-9A-Za-z]+|\
```

This PR replaces the prior patterns with:

```
D[0-9A-Za-z]+|\
```

So that we don't have to continually revisit this for this NIC family.

Adopted app version 2.36.0 for CSM 1.7.0 (helm chart 7.2.3)

## Issues and Related PRs

* Resolves [CASMTRIAGE-8027](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8027)

## Testing

Tested on:

  * `mug`

Test description:

Ran this on mug but unfortenately it doesn't exercise these changes as we don't have this ethernet NIC on any system other than creek.  It's such a simple change though, it's not necessary.  Deploying on mug and running the CT tests at least verifies no regressions there.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable