### PR TITLE
CASMHMS-6396: RTS - Drained/closed request/response bodies appropriately

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.1.3
+    version: 5.1.4
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.1.3
+    version: 5.1.4
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
### Summary and Scope

Updated three http handlers to drain and close any possible request bodies that might be present before returning.

Updated the internal SLS function `doRequest()` to properly drain and close response bodies for all edge cases.  Previously this was only done for the happy path.

Updated module dependencies to latest versions for security updates and to pull in fixes to several HMS modules.

Adopted app version 1.28.0 for CSM 1.7.0 (helm chart 5.1.3).

### Issues and Related PRs

* Resolves [CASMHMS-6396](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6396)

### Testing

Tested on:

* `gamora`
* `mug`

Test description:

- Tested cray-hms-rts on `gamora` to verify no issues communicating with iPDUs via JAWS.
- Tested cray-hms-rts-snmp on `mug` to verify no issues communicating with switches via SNMP.

Watched RTS logs to ensure no deviations from running without these changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable