### PR TITLE
CASMPET-7443-CASMPET-7444 Fix generation of SBPS DNS records

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.28.2
+    version: 1.28.3
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope
This updates the ansible code when generating DNS records for iSCSI projection (SBPS), so that it won't include \r characters to DNS, which causes DNS to fail.  This also updates the curl commands so they will cause the script to fail if the curl commands fail.

This change is a backwards compatible bugfix

## Issues and Related PRs

* Resolves [CASMPET-7443](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7443)
* Resolves [CASPMET_7444](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7444)

## Testing

### Tested on:

  * `sutur`

### Test description:
See details in https://github.com/Cray-HPE/csm-config/pull/342

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low risk, and avoids a lengthy WAR for the customer

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable
