### PR TITLE
CASMHMS-6482: SMD: Updated module and image dependencies to latest versions

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.3
+    version: 7.2.4
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.36.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.37.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.1


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, and hms-go-http-lib modules.  Several sections of SMD code were removed and/or replaced due to the most recent changes to hms-base.

Additionally upgraded Go from v1.23 to v1.24.  There were a number of SMD code changes that were required to support differences in these two version of Go.

Adopted app version 2.37.0 for CSM 1.7.0 (helm chart 7.2.4).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of SMD.  Watched log files to ensure nothing obvious was wrong.  Ran the standard SMD smoke and functional tests which all passed.  Ran xtdiscover against several BMCs to ensure no issues with that functionality.

Watched logs to ensure no deviations from running without these changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

