### PR TITLE
CASMHMS-6482: FAS: Update module dependencies to pull in resource fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,12 +53,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.7.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.2.1
+    version: 3.2.2
     namespace: services
     swagger:
     - name: firmware-action
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.39.0/api/docs/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.41.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
     version: 3.2.1


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, hms-hmetcd, and hms-trs-app-api modules.

Several sections of FAS code were removed and/or replaced due to the most recent changes to hms-base.

Additionally upgraded Go from v1.23 to v1.24.  There were a number of code changes that were required to support differences in these two version of Go.

Fixed a jq parsing issue when running local Snyk scans.

Adopted app version 1.41.0 for CSM 1.7.0 (helm chart 3.2.2).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of FAS.  Watched log files to ensure nothing obvious was wrong.  Ran the standard FAS smoke and functional tests which all passed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

