### PR TITLE
CASMHMS-6482: PCS: Update modules to pull in fixes to resource issues in HMS modules

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,13 +107,13 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.2.1
+    version: 2.2.2
     namespace: services
     timeout: 10m
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.10.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.11.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, hms-hmetcd, and hms-trs-app-api modules.

Replaced a fair amount of redundant code with reference to new code built into the new hms-base module.

Additionally upgraded Go from v1.23 to v1.24.  There were a few code changes that were required to support differences in these two version of Go.

Fixed a jq parsing issue when running local Snyk scans.

Adopted app version 2.11.0 for CSM 1.7.0 (helm chart 2.2.2).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of PCS.  Watched log files to ensure nothing obvious was wrong.  Ran the standard PCS smoke and functional tests which all passed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

