### PR TITLE
CASMPET-7499 Ignore ClusterPolicy while retrieving images from charts

### DIFF
--- a/build/images/extract.sh
+++ b/build/images/extract.sh
@@ -99,10 +99,11 @@ function extract-images() {
     ## Second: attempt to extract images from fully templated manifests (avoiding CRDs)
 
     # cray-service chart refers to postgresql.connectionPooler image as .dockerImage
-    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition") | .. | (.image?, .dockerImage?) | select(type == "!!str")' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
+    # CRS's and ClusterPolicy objects may have image: definitions which are not really images
+    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition" and .kind? != "ClusterPolicy") | .. | (.image?, .dockerImage?) | select(type == "!!str")' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
 
     ## Third: support "{image: {repository: aaa, tag: bbb}}" construct from cray-sysmgmt-health chart
-    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition") | .. | select(.image?|type == "!!map") | (.image.repository + ":" + .image.tag)' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
+    printf "%s\n" "$CHART_TEMPLATE" | yq e -N 'select(.kind? != "CustomResourceDefinition" and .kind? != "ClusterPolicy") | .. | select(.image?|type == "!!map") | (.image.repository + ":" + .image.tag)' | tee "${cacheflags[@]}" >> "$IMAGE_LIST_FILE"
 
     images="$(cat "$IMAGE_LIST_FILE" | sort -u | xargs)"
 


### PR DESCRIPTION
## Summary and Scope

Image retrieval logic in `extract.sh` may fail, if `image:` field occurs in Kyverno ClusterPolicy object (where it indicates image processing rule rather then image). Need to add oexemption for this case.

## Issues and Related PRs

* Resolves CASMPET-7499

## Testing
### Tested on:

  * Local development environment
  * Jenkins

### Test description:

Build does not fail anymore.

## Risks and Mitigations

Low - build only.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable
