### PR TITLE
Fixed CASMCMS-9375,CASMCMS-9363

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -191,12 +191,12 @@ spec:
             tag: 2.7.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.23.0
+    version: 3.24.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.23.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.24.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.11.0


### PR DESCRIPTION
- CASMCMS-9375: During create ims stores incorrect metadata for an image
- CASMCMS-9363: IMS - deleted recipe always gets assigned arch=x86_64