### PR TITLE
CASMCMS-9355/CASMCMS-9346: BOS bug fixes and improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.39.0
+    version: 2.40.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.39.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.40.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1


### PR DESCRIPTION
## Summary and Scope

This fixes the BOS bug documented in [CASMCMS-9355](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9355), and makes the back-end improvements from [CASMCMS-9346](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9346).

The changes in CASMCMS-9346 are not visible to the end user, and do not need mention in the release notes.

For the bug fix in CASMCMS-9355:
* [CASMCMS-9358](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9358) is open to document this known issue for CSM 1.3 -> CSM 1.6.
* [CASMCMS-9359](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9359) is open to update the 1.7 release notes with news of this fix.

No manifest backports (by imperial decree).

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

