### PR TITLE
Updated platform.yaml to include the latest kyverno-policy chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -99,7 +99,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.6
+    version: 1.7.7
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION

## Summary and Scope
This new 1.7.7 kyverno-policy chart includes:
1) prepend-registry policy that prepends 'registry.local/' to all the images. 
2) exceptions to 'prepend-registry' policy. This excludes a few pods from the mutation. 
3) Contains an exception list for kyverno check-image(image verification) policy. 
4) Limit check-image policy to pods by avoiding the auto-gen kyverno rules.

## Resolves
https://jira-pro.it.hpe.com:8443/browse/CASMSEC-534

## Testing

The new chart is tested to 
1) check the mutation of the image names to prepend 'registry.local/'
2) Policy reports for signed and unsigned images
3) Tested the resources that come under exceptions
4) Tested on both fresh install and upgrade scenarios

### Tested on:

  * Starlord

### Test description:
[kyverno-policy_1_7_6_to_1_7_7_arti.txt](https://github.com/user-attachments/files/19890510/kyverno-policy_1_7_6_to_1_7_7_arti.txt)
[kyverno-policy_1_7_7_fresh_install_arti.txt](https://github.com/user-attachments/files/19890511/kyverno-policy_1_7_7_fresh_install_arti.txt)
