### PR TITLE
CASMCMS-9335: cfs session patch fails to update Job ID causing session to remain in pending state

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.29.0
+    version: 1.30.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
CASMCMS-9335: cfs session patch fails to update Job ID causing session to remain in pending state