### PR TITLE
CASMMON-508 VM upgrade 0.42.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -167,7 +167,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.7
+    version: 1.2.10
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
Victoriametrics upgrade from 0.25.0 to 0.42.0
upgrade node exporter

## Issues and Related PRs

_https://jira-pro.it.hpe.com:8443/browse/CASMMON-481
https://jira-pro.it.hpe.com:8443/browse/CASMMON-482


https://github.com/Cray-HPE/cray-sysmgmt-health/pull/196

## Testing

_List the environments in which these changes were tested._

### Tested on: wasp


![image](https://github.com/user-attachments/assets/a64e6b09-d724-410c-970c-615b572aa8ea)

![image](https://github.com/user-attachments/assets/6bbc5932-f990-460b-bbcc-91e98ca26041)
