### PR TITLE
CASMCMS-9386/CASMCMS-9396/CASMCMS-9389/CASMCMS-9387: IMS bug fixes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -191,12 +191,12 @@ spec:
             tag: 2.7.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.24.0
+    version: 3.24.1
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.24.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.24.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.11.0

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -191,12 +191,12 @@ spec:
             tag: 2.7.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.24.1
+    version: 3.24.2
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.24.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.24.2/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.11.0


### PR DESCRIPTION
## Summary and Scope

### CASMCMS-9386

This updates the IMS API spec to correct several errors in it.

No release notes update required.

There are several backport PRs. These are just to update the auto-generated API docs:

CSM 1.6: https://github.com/Cray-HPE/csm/pull/4080
CSM 1.5: https://github.com/Cray-HPE/csm/pull/4081
CSM 1.4: https://github.com/Cray-HPE/csm/pull/4082

### CASMCMS-9396/CASMCMS-9389/CASMCMS-9387

These fix bugs in the IMS service itself. There are no backports for these. There is a ticket open for these to update the 1.7 release notes (CASMCMS-9400) and to document these as known issues in prior CSM releases (CASMCMS-9401).

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

