### PR TITLE
CASMCMS-9386: Correct errors in IMS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -196,7 +196,7 @@ spec:
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.22.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.22.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.10.2


### PR DESCRIPTION
This is just to update the API docs for CSM 1.6 with the fixes from https://github.com/Cray-HPE/csm/pull/4079