### PR TITLE
CASMCMS-9386: Correct error in IMS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -185,7 +185,7 @@ spec:
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.15.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.15.2/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.4


### PR DESCRIPTION
This is just to update the API docs for CSM 1.5 with the fixes from https://github.com/Cray-HPE/csm/pull/4079 that still apply in CSM 1.5