### PR TITLE
CASMCMS-9386: Correct error in IMS API spec

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -220,7 +220,7 @@ spec:
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.8.6/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.8.7/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.8.4


### PR DESCRIPTION
This is just to update the API docs for CSM 1.4 with the fixes from https://github.com/Cray-HPE/csm/pull/4079 that still apply in CSM 1.4