### PR TITLE
CASMPET-7504: Add kubectl 1.32.2 to precache images

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -93,6 +93,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
+      # cray-metallb
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
   - name: cray-kyverno
     source: csm-algol60
     version: 1.7.2

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -77,6 +77,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
       - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
@@ -93,8 +94,6 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
-      # cray-metallb
-      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
   - name: cray-kyverno
     source: csm-algol60
     version: 1.7.2


### PR DESCRIPTION
## Summary and Scope

During cray-metallb chart upgrades, the `cray-metallb-generate-crds` job failed with `ImagePullBackOff`. This occurred because the job required the `docker-kubectl:1.32.2` image from Artifactory, but the MetalLB upgrade process itself temporarily disabled the external LoadBalancer IPs needed to reach Artifactory, creating a dependency loop.

This change adds `kubectl:1.32.2` to the list of pre-cached images to avoid the reliance on external network access during the upgrade, resolving the failure.

## Issues and Related PRs

* Resolves [CASMPET-7504](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7504)

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

