### PR TITLE
BOS: Resolve type annotation linter complaints

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.40.0
+    version: 2.41.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.40.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.41.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.41.0
+    version: 2.42.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.41.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.42.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1


### PR DESCRIPTION
## Summary and Scope

Resolves `mypy` linter complaints in BOS, with no functional changes to the service. No release notes PR needed. No backports.

Tickets:
* CASMCMS-9382
* CASMCMS-9390
* CASMCMS-9391
* CASMCMS-9392
* CASMCMS-9393
* CASMCMS-9394
* CASMCMS-9395
* CASMCMS-9402
* CASMCMS-9403
* CASMCMS-9405
* CASMCMS-9406

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

