### PR TITLE
CASMTRIAGE-8133 - monitoring_check.sh does not look for VictoriaMetrics services

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -45,8 +45,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-identity-1.0.22-1.noarch
     - csm-ssh-keys-1.8.0-1.noarch
     - csm-ssh-keys-roles-1.7.1-1.noarch
-    - csm-testing-1.19.20-1.noarch
-    - goss-servers-1.19.20-1.noarch
+    - csm-testing-1.19.21-1.noarch
+    - goss-servers-1.19.21-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The `monitoring_check.sh` check was not updated to look for the Istio `VirtualService` definitions associated with the new VictoriaMetrics services so failed to identify that these services were misconfigured on an in-house system.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8133](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8133)
* Related PR: https://github.com/Cray-HPE/csm-testing/pull/703

## Testing

### Tested on:

  * `tyr`

### Test description:

Ran fixed test script and confirmed it now fails for the misconfigured vmagent service.
```
ncn-m001:~ # ./monitoring_check.sh
curl: (6) Could not resolve host: vmagent.local
Monitoring url https://vmagent.local/ in namespace sysmgmt-health failed to redirect for auth.
curl: (6) Could not resolve host: vmagent.local
Monitoring url https://vmagent.local/ in namespace sysmgmt-health failed to respond with OK.
FAIL
```
Fixed problem with vmagent virtual services and verified test now passes
```
ncn-m001:~ # ./monitoring_check.sh
PASS
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

