### PR TITLE
CASMCMS-9379: Test v2 API and default version API

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.10.2-1.noarch
     - cfs-state-reporter-1.12.3-1.noarch
     - cfs-trust-1.9.1-1.noarch
-    - cray-cmstools-crayctldeploy-1.29.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.30.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.9-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch


### PR DESCRIPTION
Changes include

- CASMCMS-9379: TESTS: IMS: cmsdev: Test v2 API and default version API
- CASMCMS-8135: IMS: cmsdev failed during post-install health check
- CASMCMS-9384: cmsdev should warn if docs-csm RPM is not installed