### PR TITLE
CASMTRIAGE-8151: Fix FAS false positive test failure

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,12 +53,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.7.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.2.2
+    version: 3.2.3
     namespace: services
     swagger:
     - name: firmware-action
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.41.0/api/docs/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.42.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
     version: 3.2.1


### PR DESCRIPTION
### Summary and Scope

Fixed false positive test failure.

Adopted app version 1.42.0 for CSM 1.7.0 (helm chart 3.2.3).

### Issues and Related PRs

* Resolves [CASMTRIAGE-8151](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8151)

### Testing

Tested on:

* `tyr`

Test description:

Reran CT tests and observed the false positive no longer occurs.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

