### PR TITLE
CASMHMS-6499, CASMTRIAGE-8079: Add curl to smd/pcs and fix false positive SMD ct test

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.4
+    version: 7.2.5
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.37.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.38.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,13 +107,13 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.2.2
+    version: 2.2.3
     namespace: services
     timeout: 10m
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.11.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.12.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
## Summary and Scope

Added 'curl' command to SMD and PCS container images.  Removed all future potential for false positive failures in the SMD CT tests associated with ethernet device naming.

SMD: Adopted app version 2.38.0 for CSM 1.7.0 (helm chart 7.2.5).
PCS: Adopted app version 2.12.0 for CSM 1.7.0 (helm chart 2.2.3).

## Issues and Related PRs

* Resolves [CASMHMS-6499](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6499)
* Resolves [CASMTRIAGE-8079](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8079)

## Testing

Tested on:

  * Local development environment
  * mug

Test description:

Loaded image into Docker Desktop on laptop and verified 'curl' command was present.  No further testing necessary.

Loaded onto mug and ran CT tests to verify tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

