### PR TITLE
CASMHMS-6413: HTA: Updated alpine image dependency for security updates in…

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -46,7 +46,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Utility to help make changes for adding river cabinets
     hardware-topology-assistant:
-    - 0.3.1
+    - 0.4.0
 
     iuf:
     - v0.1.13


### PR DESCRIPTION
### Summary and Scope

Updated alpine image dependency to the latest version for hardware-topology-assistant.

Added capability to build image locally via the Makefile (not included in default directive though).

Adopted app version 0.4.0 for CSM 1.7.0.  There is no helm chart.

### Issues and Related PRs

* Resolves [CASMHMS-6413](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6413)

### Testing

The pipeline unit tests all pass.

No further testing was done as this is a very minimal change and there is no easy way to test hardware-topology-assistant.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

