### PR TITLE
CASMHMS-6399: SLS Scaling and resource usage improvements

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -12,12 +12,12 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.0
+    version: 6.1.1
     namespace: services
     swagger:
     - name: sls
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.9.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
     version: 7.2.5


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base module.

Made calls to explicitly drain and close all http request and response bodies.  There were some potential edge cases where memory leaks might have occurred.

Additionally upgraded Go from v1.23 to v1.24.

Adopted app version 2.9.0 for CSM 1.7.0 (helm chart 6.1.1).

### Issues and Related PRs

* Resolves [CASMHMS-6399](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6399)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Ran the standard smoke and functional tests which all passed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

