### PR TITLE
CASMHMS-6395: MEDS Scaling and resource usage improvements

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -35,7 +35,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.38.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
-    version: 3.1.1
+    version: 3.1.2
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.25.0 for CSM 1.7.0 (helm chart 3.1.2).

### Issues and Related PRs

* Resolves [CASMHMS-6395](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6395)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  There were no MEDS tests to run.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

