### PR TITLE
CASMSEC-555 Enable  and move image verification policy after nexus

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -104,6 +104,9 @@ deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
 
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
+
+# Deploy Kyverno image verification policy
+deploy "${BUILDDIR}/manifests/kyverno-policy.yaml"
 
 # Deploy Vshasta specific services
 function is_vshasta_node {

--- a/manifests/kyverno-policy.yaml
+++ b/manifests/kyverno-policy.yaml
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: nexus
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: image-verification-policy
+    source: csm-algol60
+    version: 1.0.0
+    namespace: kyverno

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -101,7 +101,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.6
+    version: 1.7.10
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2021,2023, 2025 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 set -exo pipefail
 
@@ -117,6 +138,9 @@ fi
 
 # Deploy Nexus
 deploy "${BUILDDIR}/manifests/nexus.yaml"
+
+# Deploy Kyverno image verification policy
+deploy "${BUILDDIR}/manifests/kyverno-policy.yaml"
 
 # Deploy Vshasta specific services
 function is_vshasta_node {


### PR DESCRIPTION
## Summary and Scope

During fresh install, images are pulled onto Kubernetes nodes from PIT Nexus, because in-cloud Nexus is not yet available at this time. This is achieved by mirroring configuration in `/etc/containerd/config.toml`. This mirroring configuration is not honored by Kyverno, therefore we can not enable image signature validation at this time. Image signature validation can only be enabled after in-cloud Nexus is up and it starts providing images and their respective signatures.

To achieve that:
1. Image signature verification had been moved from `kyverno-policy` chart to a dedicated chart `iimage-verification-policy`
2. New chart `image-verification-policy` is getting deployed last during fresh install sequence, after `cray-nexus` chart is deployed and in-cloud Nexus is up.

Notes:
1.  I turned on checkmark "Release Noted in docs-csm" updated - I assume there will be a dedicated afford to update release notes with image signature verification feature.
2. image signature verification is enabled after nexus install, for both fresh install and upgrade. If you want to enable image signature verification prior to upgrading other charts, you need to add kyverno upgrade and policies installation to prerequisites.sh.

## Issues and Related PRs

* Resolves CASMSEC-555

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Temporary build was generated and successfully installed onto vShasta environment, post-install tests run:
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/1734/display/redirect

## Risks and Mitigations

Issues are anticipated after image verification policy enablement, this is why it is being done early in development cycle. There's coordinated effort by security team to provide image signatures for CSM and all products deployed on top of it.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

