### PR TITLE
CASMPET-7522 bump cray-nls and cray-iuf chart to 5.1.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -261,11 +261,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.0.1
+    version: 5.1.0
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.0.1
+    version: 5.1.0
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

Bump cray-nls and cray-iuf chart to 5.1.0.

The `cray-nls` chart picks up the new versions of `cray-postgresql` and `cray-service`. These changes are related to the postgres upgrade in CSM 1.7.0.

The main part of the postgresql upgrade is completed by the cray-postgres-operator which has already been implemented. This is a minor change.

## Issues and Related PRs

* Resolves [CASMPET-7522](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7522)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau (vshasta)

Tested a chart upgrade and downgrade on Beau. 

## Risks and Mitigations

Minor change, low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

