### PR TITLE
CASMINST-7333 - cray vnid jobs create fails

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.10
+KUBERNETES_IMAGE_ID=7.1.11
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.10
+PIT_IMAGE_ID=7.1.11
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.10
+STORAGE_CEPH_IMAGE_ID=7.1.11
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.10
+COMPUTE_IMAGE_ID=7.1.11
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -37,8 +37,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.36.9-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
-    - craycli-0.92.0-1.aarch64
-    - craycli-0.92.0-1.x86_64
+    - craycli-0.93.0-1.aarch64
+    - craycli-0.93.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.8-1.aarch64
     - csm-node-heartbeat-2.8-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Some of the VNID REST API parameters have changed, so some of the cray vnid commands were failing. Update to the latest OpenAPI spec for vnid to fix the issue.

## Issues and Related PRs

* Resolves [USS-4742](https://jira-pro.it.hpe.com:8443/browse/USS-4742)[CASMINST-7333](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7333)

## Testing

### Tested on:

  * lemondrop

### Test description:

Tested using automated CT tests.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

