### PR TITLE
CASMCMS-9033 - add multi-tenant support to console services.

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -133,7 +133,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.34.6
+    version: 1.34.9
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -163,12 +163,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.14.0
+    version: 1.15.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.8.0
+    version: 2.9.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -37,8 +37,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-site-init-1.36.9-1.x86_64
     - cray-spire-dracut-2.0.3-1.noarch
     - cray-uai-util-2.2.1-1.noarch
-    - craycli-0.93.0-1.aarch64
-    - craycli-0.93.0-1.x86_64
+    - craycli-0.94.0-1.aarch64
+    - craycli-0.94.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-node-heartbeat-2.8-1.aarch64
     - csm-node-heartbeat-2.8-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Epic: CASMCMS-9033 - adding multi-tenant support to console services.

This includes changing the user access from exec'ing into the cray-console-node pods to interact directly with conman, to using the cray cli with `cray console` commands. The user that is logged into the cray cli is now checked against tenant credentials before being allowed to interact with consoles or logs.

## Issues and Related PRs
* Resolves [CASMCMS-9033](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9033)

## Testing
### Tested on:

  * `Mug`

### Test description:

The new console services were installed via helm and tested both for the new cli access as well as tenant authorization. The user is only allowed to access resources that belong to the correct tenant.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a fairly large change in the access mechanism for consoles, but if the user has root access on the management nodes, they will still be able to interact directly with conman inside the running console pods.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

