### PR TITLE
CASMPET-7535: Update Spire agent for TPM work

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.11
+KUBERNETES_IMAGE_ID=7.1.12
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.11
+PIT_IMAGE_ID=7.1.12
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.11
+STORAGE_CEPH_IMAGE_ID=7.1.12
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.11
+COMPUTE_IMAGE_ID=7.1.12
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -73,8 +73,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python39-requests-retry-session-0.2.4-1.noarch
     - sbps-marshal-0.0.14-1.noarch
     - smart-mon-1.0.3-1.noarch
-    - spire-agent-1.5.5-1.11.aarch64
-    - spire-agent-1.5.5-1.11.x86_64
+    - spire-agent-1.5.5-1.12.aarch64
+    - spire-agent-1.5.5-1.12.x86_64
     - tpm-provisioner-client-1.0.1-3.aarch64
     - tpm-provisioner-client-1.0.1-3.x86_64
 


### PR DESCRIPTION
## Summary and Scope

Updates the Spire agent RPM so its systemd service wont remove the working spire config when TPM is enabled.

## Issues and Related PRs

* Resolves [CASMPET-7535](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7535)

## Testing

### Tested on:

  * tyr

### Test description:

Restarted spire with the new script and it came up fine in all situations.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No known risks or issues with this change

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

