### PR TITLE
CASMPET-7501: Update cray-spire-dracut for TPM ARM support

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -35,7 +35,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-cmstools-crayctldeploy-1.30.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.9-1.x86_64
-    - cray-spire-dracut-2.0.3-1.noarch
+    - cray-spire-dracut-2.1.0-1.noarch
     - cray-uai-util-2.2.1-1.noarch
     - craycli-0.93.0-1.aarch64
     - craycli-0.93.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Updates the cray-spire-dracut module to allow TPM to be enabled on ARM based compute modules.

## Issues and Related PRs

* Resolves [CASMPET-7501](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7501)

## Testing

### Tested on:

  * tyr

### Test description:

Restarted spire with the new script and it came up fine in all situations.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No known risks or issues with this change

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

