### PR TITLE
CASMTRIAGE-8192: Update Spire Chart to fix TTLs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -262,7 +262,7 @@ spec:
   # Spire service
   - name: cray-spire
     source: csm-algol60
-    version: 1.7.4
+    version: 1.7.6
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

There is a bug where when xname validation is enabled some workloads that need extra long TTLs are changed to have standard TTL. This is incorrect and needed to be addressed.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8192](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8192)

## Testing


### Tested on:

  * lemondrop

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No risks this is correcting xname validation workloads to what they are in non xname validation workloads.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

