### PR TITLE
CASMNET-2186 - Support Cilium upgrade with multus

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.17-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.11
+KUBERNETES_IMAGE_ID=7.1.13
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.11
+PIT_IMAGE_ID=7.1.13
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.11
+STORAGE_CEPH_IMAGE_ID=7.1.13
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.11
+COMPUTE_IMAGE_ID=7.1.13
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope

In order to support Cilium migration with Multus enabled the following needs to occur

* The `cni-exclusive` parameter must be set to false (see node-images PR)
* The `/etc/cni/net.d/10-weave.conflist` file needs to be moved to one side
* The `00-multus.conf` file needs to be updated for Cilium
* The `multus-cni-config` ConfigMap needs to be updated with the Cilium config.

This PR updates the node-images CiliumNodeConfig resource used for migration to have `cni-exclusive` set to `false`

## Issues and Related PRs

* Resolves [CASMNET-2186](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2186)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/5956

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Tested on vshasta

Verified that `cni-exclusive` is set to false in the final config.
```
ncn-m001:~ # kubectl -n kube-system get cm cilium-config -o yaml | yq4 '.data."cni-exclusive"'
false
```
Verified the `10-weave.conflist` configuration has been archived.
```
ncn-m001:~ # ls -1 /etc/cni/net.d/
00-multus.conf
05-cilium.conflist
10-weave.conflist.cilium_bak
99-loopback.conf.sample
multus.d
```

Verified that the Multus configuration put in place is for Cilium
```
ncn-m001:~ # jq . /etc/cni/net.d/00-multus.conf
{
  "name": "multus-cni-network",
  "cniVersion": "0.3.1",
  "type": "multus",
  "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig",
  "confDir": "/etc/cni/net.d",
  "clusterNetwork": "cilium",
  "systemNamespaces": [
    ""
  ]
}
```
Verified the `multus-cni-config` ConfigMap has been updated for Cilium.
```
ncn-m001:~ # kubectl -n kube-system get cm multus-cni-config  -o yaml
apiVersion: v1
data:
  00-multus.conf: |
    {
      "name": "multus-cni-network",
      "cniVersion": "0.3.1",
      "type": "multus",
      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig",
      "confDir": "/etc/cni/net.d",
      "clusterNetwork": "cilium",
      "systemNamespaces": [""]
    }
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"00-multus.conf":"{\n  \"name\": \"multus-cni-network\",\n  \"cniVersion\": \"0.3.1\",\n  \"type\": \"multus\",\n  \"kubeconfig\": \"/etc/cni/net.d/multus.d/multus.kubeconfig\",\n  \"confDir\": \"/etc/cni/net.d\",\n  \"clusterNetwork\": \"cilium\",\n  \"systemNamespaces\": [\"\"]\n}\n"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"multus","tier":"node"},"name":"multus-cni-config","namespace":"kube-system"}}
  creationTimestamp: "2025-05-13T14:36:34Z"
  labels:
    app: multus
    tier: node
  name: multus-cni-config
  namespace: kube-system
  resourceVersion: "1568607"
  uid: 59d72f41-c494-45c6-bfe0-1f8dea3219b8
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

