### PR TITLE
CASMHMS-6512: Update the etcd, service, & postgres base charts in HMS services

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -35,7 +35,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.1
+    version: 6.1.2
     namespace: services
     swagger:
     - name: sls
@@ -43,7 +43,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.9.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.5
+    version: 7.2.6
     namespace: services
     values:
       cray-service:
@@ -58,7 +58,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.38.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,7 +36,7 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.3.2
+    version: 3.3.3
     namespace: services
     timeout: 10m
     swagger:
@@ -45,7 +45,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.33.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 5.1.0
+    version: 5.1.1
     namespace: services
     swagger:
     - name: capmc
@@ -53,7 +53,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.7.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.2.3
+    version: 3.2.4
     namespace: services
     swagger:
     - name: firmware-action
@@ -61,7 +61,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.42.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.2.1
+    version: 3.2.2
     namespace: services
     timeout: 10m
     swagger:
@@ -70,7 +70,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.23.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 4.1.0
+    version: 4.1.1
     namespace: services
     timeout: 10m
     swagger:
@@ -83,7 +83,7 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 3.1.1
+    version: 3.1.2
     namespace: services
     swagger:
     - name: scsd
@@ -107,7 +107,7 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.2.3
+    version: 2.2.4
     namespace: services
     timeout: 10m
     swagger:


### PR DESCRIPTION
### Summary and Scope

Updated all HMS services to point to the latest versions of the cray-etcd-base, cray-service, and cray-postgresql base charts.

### Issues and Related PRs

* Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512) and [CASMHMS-6516](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6516)

### Testing

See individual PRs for testing details

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

