### PR TITLE
CASMPET-7460: Modify upgrade.sh to deploy k8s version specific manifests

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -1,0 +1,101 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# List of charts that can successfully be deployed on K8s 1.24.
+# This file is based on the core-services.yaml from CSM 1.7.0-alpha.16.
+#
+# Most of these charts can also be deployed on K8s 1.32.
+# The charts that can only be deployed on K8s 1.24 are noted.
+# Charts that can only be deployed on K8s 1.32 are contained in
+# the post-upgrade-deploy-v1.32.yaml manifest and will be deployed
+# after upgrade to K8s 1.32.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: core-services
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+
+  # HMS
+  - name: cray-hms-sls
+    source: csm-algol60
+    version: 6.1.1
+    namespace: services
+    swagger:
+    - name: sls
+      version: v2
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
+  - name: cray-hms-smd
+    source: csm-algol60
+    version: 7.2.5
+    namespace: services
+    values:
+      cray-service:
+        sqlCluster:
+          resources:
+            requests:
+              cpu: "4"
+              memory: 8Gi
+    swagger:
+    - name: smd
+      version: v2
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.36.0/api/swagger_v2.yaml
+  - name: cray-hms-meds
+    source: csm-algol60
+    version: 3.1.2
+    namespace: services
+  - name: cray-hms-discovery
+    source: csm-algol60
+    version: 3.1.1
+    namespace: services
+
+  # Cray DHCP Kea
+  - name: cray-dhcp-kea
+    source: csm-algol60
+    version: 0.11.6   # DO NOT UPDATE cray-dhcp-kea version that works with K8s 1.24
+    namespace: services
+
+  # Cray DNS unbound (resolver)
+  - name: cray-dns-unbound
+    source: csm-algol60
+    version: 0.8.4   # DO NOT UPDATE cray-dns-unbound version that works with K8s 1.24
+    namespace: services
+    values:
+      global:
+        appVersion: 0.8.4
+
+  # Cray DNS powerdns
+  - name: cray-dns-powerdns
+    source: csm-algol60
+    version: 0.4.2 # update platform.yaml cray-precache-images with this
+    namespace: services
+
+  - name: cray-powerdns-manager
+    source: csm-algol60
+    version: 0.8.4 # update platform.yaml cray-precache-images with this
+    namespace: services

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -1,0 +1,296 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# List of charts that can successfully be deployed on K8s 1.24.
+# This file is based on the platform.yaml from csm v1.7.0-alpha.9.
+#
+# Most of these charts can also be deployed on K8s 1.32.
+# The charts that can only be deployed on K8s 1.24 are noted.
+# Charts that can only be deployed on K8s 1.32 are contained in
+# the post-upgrade-deploy-v1.32.yaml manifest and will be deployed
+# after upgrade to K8s 1.32.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: platform
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: cray-metrics-server
+    source: csm-algol60
+    version: 0.5.0
+    namespace: kube-system
+  - name: cray-drydock
+    source: csm-algol60
+    version: 2.20.1
+    namespace: loftsman
+  - name: cray-precache-images
+    source: csm-algol60
+    version: 0.6.0
+    namespace: nexus
+    timeout: 20m0s
+    values:
+      cacheRefreshSeconds: "120"
+      cacheImages:
+      # Kubernetes
+      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
+      - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.2
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
+      # Istio
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
+      # Kyverno for K8s 1.24
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
+      # Kyverno for K8s 1.32
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.4
+      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.32.3
+      # OPA
+      - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
+      # DNS for K8s 1.24
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
+      # DNS for K8s 1.32
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.12.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.9.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
+      # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
+      - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+      - artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
+      # cray-nexus
+      - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
+      # Cilium
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
+  - name: cray-velero
+    source: csm-algol60
+    version: 1.6.3-3
+    namespace: velero
+  - name: sealed-secrets
+    source: csm-algol60
+    version: 0.5.1
+    namespace: kube-system
+  - name: cray-node-problem-detector
+    source: csm-algol60
+    version: 1.11.1
+    namespace: kube-system
+  - name: cray-istio-operator
+    source: csm-algol60
+    version: 2.0.0
+    namespace: istio-system
+  - name: cray-istio-deploy
+    source: csm-algol60
+    version: 2.0.1   # Update cray-precache-images above on proxyv2 tag change.
+    namespace: istio-system
+  - name: cray-certmanager
+    source: csm-algol60
+    version: 0.9.2
+    namespace: cert-manager
+  - name: cray-opa
+    source: csm-algol60
+    version: 1.34.6
+    namespace: opa
+  - name: cray-vault-operator
+    source: csm-algol60
+    version: 1.5.0
+    namespace: vault
+  - name: cray-vault
+    source: csm-algol60
+    version: 1.8.0
+    namespace: vault
+  - name: trustedcerts-operator
+    source: csm-algol60
+    version: 0.9.0
+    namespace: pki-operator
+  - name: cray-s3
+    source: csm-algol60
+    version: 1.1.0
+    namespace: ceph-rgw
+  - name: cray-certmanager-issuers
+    source: csm-algol60
+    version: 0.7.2
+    namespace: cert-manager
+  - name: cray-istio
+    source: csm-algol60
+    version: 3.1.0
+    namespace: istio-system
+  - name: cray-kiali
+    source: csm-algol60
+    version: 0.6.1
+    namespace: operators
+  - name: cray-externaldns
+    source: csm-algol60
+    version: 1.6.1
+    namespace: services
+  - name: cray-sysmgmt-health
+    source: csm-algol60
+    version: 1.2.7   # DO NOT UPDATE cray-sysmgmt-health version that works with helm v3.13.3
+    namespace: sysmgmt-health
+    values:
+      kube-prometheus-stack:
+        prometheus:
+          prometheusSpec:
+            resources:
+              limits:
+                cpu: '6'
+                memory: 30Gi
+              requests:
+                cpu: '2'
+                memory: 15Gi
+            retention: 48h
+  - name: cray-postgres-operator
+    source: csm-algol60
+    version: 1.10.1
+    namespace: services
+  - name: cray-kafka-operator
+    source: csm-algol60
+    version: 1.2.1
+    namespace: operators
+  - name: spire-intermediate
+    source: csm-algol60
+    version: 0.5.1
+    namespace: vault
+  - name: tpm-intermediate
+    source: csm-algol60
+    version: 1.0.0
+    namespace: vault
+  - name: tpm-provisioner
+    source: csm-algol60
+    version: 1.0.0
+    namespace: spire
+  - name: cray-keycloak
+    source: csm-algol60
+    version: 5.1.4
+    namespace: services
+  - name: cray-keycloak-users-localize
+    source: csm-algol60
+    version: 1.11.5
+    namespace: services
+  - name: cray-node-discovery
+    source: csm-algol60
+    version: 1.2.5
+    namespace: services
+  - name: cray-shared-kafka
+    source: csm-algol60
+    version: 1.1.1
+    namespace: services
+  - name: cray-sts
+    source: csm-algol60
+    version: 0.8.3
+    namespace: services
+    swagger:
+    - name: sts
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.8.1/api/openapi.yaml
+  - name: cray-etcd-defrag
+    source: csm-algol60
+    version: 0.4.1
+    namespace: services
+  - name: cray-etcd-backup
+    source: csm-algol60
+    version: 0.5.6
+    namespace: services
+  - name: cray-etcd-migration-setup
+    source: csm-algol60
+    version: 1.0.2
+    namespace: services
+  - name: cray-metallb
+    source: csm-algol60
+    version: 1.2.2   # DO NOT UPDATE cray-metallb version that works with K8s 1.24
+    namespace: metallb-system
+    values:
+      metallb:
+        psp:
+          create: false
+  - name: cray-baremetal-etcd-backup
+    source: csm-algol60
+    version: 0.2.3
+    namespace: kube-system
+  - name: cray-node-labels
+    source: csm-algol60
+    version: 0.5.0
+    namespace: services
+  - name: cray-oauth2-proxies
+    source: csm-algol60
+    version: 0.5.0
+    namespace: services
+  - name: cray-iuf
+    source: csm-algol60
+    version: 5.1.0
+    namespace: argo
+  - name: cray-nls
+    source: csm-algol60
+    version: 5.1.0
+    namespace: argo
+    swagger:
+    - name: nls
+      title: "NCN Lifecycle Service"
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.10/docs/NLS_swagger.yaml
+  - name: cray-hnc-manager
+    source: csm-algol60
+    version: 0.1.1
+    namespace: hnc-system
+    timeout: 10m0s
+  - name: cray-k8s-encryption
+    source: csm-algol60
+    version: 0.1.0
+    namespace: kube-system
+  - name: cray-vpa-crd
+    source: csm-algol60
+    version: 1.0.0
+    namespace: services
+  - name: cray-vpa
+    source: csm-algol60
+    version: 1.0.2
+    namespace: services

--- a/manifests/post-upgrade-02-platform-v1.25.yaml
+++ b/manifests/post-upgrade-02-platform-v1.25.yaml
@@ -38,7 +38,7 @@ spec:
   charts:
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.10
+    version: 1.2.7
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:

--- a/manifests/post-upgrade-02-platform-v1.25.yaml
+++ b/manifests/post-upgrade-02-platform-v1.25.yaml
@@ -36,22 +36,6 @@ spec:
       type: repo
       location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
   charts:
-  - name: cray-sysmgmt-health
-    source: csm-algol60
-    version: 1.2.7
-    namespace: sysmgmt-health
-    values:
-      kube-prometheus-stack:
-        prometheus:
-          prometheusSpec:
-            resources:
-              limits:
-                cpu: '6'
-                memory: 30Gi
-              requests:
-                cpu: '2'
-                memory: 15Gi
-            retention: 48h
   - name: cray-metallb
     source: csm-algol60
     version: 2.0.0

--- a/manifests/post-upgrade-02-platform-v1.25.yaml
+++ b/manifests/post-upgrade-02-platform-v1.25.yaml
@@ -1,0 +1,62 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This post-upgrade-02-platform-v1.32.yaml manifest is intended to be deployed
+# after the control plane upgrade to K8s 1.32 at the end of the docs-csm
+# upgrade_control_plane.sh script.
+# The charts listed here can only be deployed on K8s 1.32.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: platform
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: cray-sysmgmt-health
+    source: csm-algol60
+    version: 1.2.10
+    namespace: sysmgmt-health
+    values:
+      kube-prometheus-stack:
+        prometheus:
+          prometheusSpec:
+            resources:
+              limits:
+                cpu: '6'
+                memory: 30Gi
+              requests:
+                cpu: '2'
+                memory: 15Gi
+            retention: 48h
+  - name: cray-metallb
+    source: csm-algol60
+    version: 2.0.0
+    namespace: metallb-system
+  - name: cray-hubble
+    source: csm-algol60
+    version: 0.0.1
+    namespace: kube-system

--- a/manifests/post-upgrade-02-platform-v1.25.yaml
+++ b/manifests/post-upgrade-02-platform-v1.25.yaml
@@ -21,10 +21,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This post-upgrade-02-platform-v1.32.yaml manifest is intended to be deployed
-# after the control plane upgrade to K8s 1.32 at the end of the docs-csm
+# This post-upgrade-02-platform-v1.25.yaml manifest is intended to be deployed
+# after the control plane upgrade to K8s 1.25 at the end of the docs-csm
 # upgrade_control_plane.sh script.
-# The charts listed here can only be deployed on K8s 1.32.
+# The charts listed here can be deployed on K8s >=1.25.
 #
 apiVersion: manifests/v1beta1
 metadata:

--- a/manifests/post-upgrade-02-platform-v1.32.yaml
+++ b/manifests/post-upgrade-02-platform-v1.32.yaml
@@ -1,0 +1,50 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This post-upgrade-02-platform-v1.32.yaml manifest is intended to be deployed
+# after the control plane upgrade to K8s 1.32 at the end of the docs-csm
+# upgrade_control_plane.sh script.
+# The charts listed here can only be deployed on K8s 1.32.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: platform
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: cray-kyverno
+    source: csm-algol60
+    version: 1.7.3
+    namespace: kyverno
+  - name: kyverno-policy
+    source: csm-algol60
+    version: 1.7.10
+    namespace: kyverno
+  - name: cray-kyverno-policies-upstream
+    source: csm-algol60
+    version: 1.1.1
+    namespace: kyverno

--- a/manifests/post-upgrade-04-core-services-v1.25.yaml
+++ b/manifests/post-upgrade-04-core-services-v1.25.yaml
@@ -1,0 +1,97 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This post-upgrade-04-core-services-v1.25.yaml manifest is intended to be
+# deployed after the control plane upgrade to K8s 1.25 at the end of the
+# docs-csm upgrade_control_plane.sh script.
+# The charts listed here can only be deployed on K8s >= 1.25.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: core-services
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+
+  # HMS
+  - name: cray-hms-sls
+    source: csm-algol60
+    version: 6.1.1
+    namespace: services
+    swagger:
+    - name: sls
+      version: v2
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.9.0/api/openapi.yaml
+  - name: cray-hms-smd
+    source: csm-algol60
+    version: 7.2.5
+    namespace: services
+    values:
+      cray-service:
+        sqlCluster:
+          resources:
+            requests:
+              cpu: "4"
+              memory: 8Gi
+    swagger:
+    - name: smd
+      version: v2
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.38.0/api/swagger_v2.yaml
+  - name: cray-hms-meds
+    source: csm-algol60
+    version: 3.1.2
+    namespace: services
+  - name: cray-hms-discovery
+    source: csm-algol60
+    version: 3.1.1
+    namespace: services
+
+  # Cray DHCP Kea
+  - name: cray-dhcp-kea
+    source: csm-algol60
+    version: 0.12.0 # update platform.yaml cray-precache-images with this
+    namespace: services
+
+  # Cray DNS unbound (resolver)
+  - name: cray-dns-unbound
+    source: csm-algol60
+    version: 0.9.0 # update platform.yaml cray-precache-images with this
+    namespace: services
+    values:
+      global:
+        appVersion: 0.9.0
+
+  # Cray DNS powerdns
+  - name: cray-dns-powerdns
+    source: csm-algol60
+    version: 0.4.2 # update platform.yaml cray-precache-images with this
+    namespace: services
+
+  - name: cray-powerdns-manager
+    source: csm-algol60
+    version: 0.8.4 # update platform.yaml cray-precache-images with this
+    namespace: services

--- a/manifests/post-upgrade-09-kyverno-policy-v1.32.yaml
+++ b/manifests/post-upgrade-09-kyverno-policy-v1.32.yaml
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: kyverno-policy
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+  - name: image-verification-policy
+    source: csm-algol60
+    version: 1.0.0
+    namespace: kyverno

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -101,9 +101,6 @@ if [ "${K8SVER}" = "v1.24" ]; then
     undeploy -n kyverno cray-kyverno
 fi
 
-## cray-psp is removed in CSM 1.7 with upgrade to K8s >= 1.25, undeploy if it exists
-# undeploy -n services cray-psp
-
 # Select manifests are we deploying
 core_services_yaml=$(select_manifest_file core-services)
 keycloak_gatekeeper_yaml=$(select_manifest_file keycloak-gatekeeper)

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -42,6 +42,9 @@ find "${ROOTDIR}/manifests" -name "*.yaml" | while read manifest; do
     manifestgen -i "$manifest" -c "${BUILDDIR}/customizations.yaml" -o "${BUILDDIR}/manifests/$(basename "$manifest")"
 done
 
+# What version of K8s is currently running?
+K8SVER=$(kubectl version -o json | jq -r '.serverVersion.gitVersion' | grep -o "v1.[^.]*")
+
 function deploy() {
     # XXX Loftsman may not be able to connect to $NEXUS_URL due to certificate
     # XXX trust issues, so use --charts-path instead of --charts-repo.
@@ -55,7 +58,19 @@ function undeploy() {
     # If the chart is missing (rc==1) just return success.
     helm status "$@" || return 0
     # Remove the chart.
-    helm uninstall "$@"
+    helm uninstall "$@" --keep-history
+}
+
+# Select which manifest file to deploy depending on K8SVER running.
+# If a manifest doesn't exist for the K8SVER, use default manifest (ie platform.yaml).
+function select_manifest_file() {
+    manifest="$1"
+    # If we're not running K8SVER v1.32, then return ${manifest}-${K8SVER}.yaml.
+    if [ "${K8SVER}" != "v1.32" ] && [ -f ${BUILDDIR}/manifests/${manifest}-${K8SVER}.yaml ]; then
+      echo "${manifest}-${K8SVER}.yaml"
+    else
+      echo "${manifest}.yaml"
+    fi
 }
 
 # CRUS is removed in CSM 1.6, and should be removed during the upgrade, if it exists
@@ -73,12 +88,37 @@ echo "These charts will later be deployed in the services namespace."
 undeploy -n operators cray-etcd-backup
 undeploy -n operators cray-etcd-defrag
 
+#
+# Need to undeploy kyverno at K8s 1.24 before upgrading to K8s 1.32
+# Will be deployed at K8s 1.32 in post-upgrade-02-platform-v1.32.yaml
+#
+if [ "${K8SVER}" = "v1.24" ]; then
+    echo "Removing cray-kyverno-policies-upstream chart ..."
+    undeploy -n kyverno cray-kyverno-policies-upstream
+    echo "Removing kyverno-policy chart ..."
+    undeploy -n kyverno kyverno-policy
+    echo "Removing cray-kyverno chart ..."
+    undeploy -n kyverno cray-kyverno
+fi
+
+## cray-psp is removed in CSM 1.7 with upgrade to K8s >= 1.25, undeploy if it exists
+# undeploy -n services cray-psp
+
+# Select manifests are we deploying
+core_services_yaml=$(select_manifest_file core-services)
+keycloak_gatekeeper_yaml=$(select_manifest_file keycloak-gatekeeper)
+nexus_yaml=$(select_manifest_file nexus)
+platform_yaml=$(select_manifest_file platform)
+storage_yaml=$(select_manifest_file storage)
+sysmgmt_yaml=$(select_manifest_file sysmgmt)
+
 # Deploy services critical for Nexus to run
-echo "Deploying new ceph csi provisioners"
-deploy "${BUILDDIR}/manifests/storage.yaml"
-echo "Deployment of new ceph csi provisioners is complete.  PVC movement will resume when all ceph csi pods are finished starting"
-deploy "${BUILDDIR}/manifests/platform.yaml"
-deploy "${BUILDDIR}/manifests/keycloak-gatekeeper.yaml"
+echo "Deploying new ceph csi provisioners..."
+deploy "${BUILDDIR}/manifests/${storage_yaml}"
+echo "Deployment of new ceph csi provisioners is complete."
+echo "PVC movement will resume when all ceph csi pods are finished starting."
+deploy "${BUILDDIR}/manifests/${platform_yaml}"
+deploy "${BUILDDIR}/manifests/${keycloak_gatekeeper_yaml}"
 
 # TODO How to upgrade metallb?
 # Deploy metal-lb configuration
@@ -95,7 +135,7 @@ kubectl create secret generic hpe-signing-key -n services ${RPM_SIGNING_KEYS_OPT
 # Save previous Unbound IP
 pre_upgrade_unbound_ip="$(kubectl get -n services service cray-dns-unbound-udp-nmn -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
 
-deploy "${BUILDDIR}/manifests/core-services.yaml"
+deploy "${BUILDDIR}/manifests/${core_services_yaml}"
 
 # Wait for Unbound to come up
 "${ROOTDIR}/lib/wait-for-unbound.sh"
@@ -113,9 +153,13 @@ fi
 undeploy -n services cray-conman
 
 # Deploy remaining system management applications
-deploy "${BUILDDIR}/manifests/sysmgmt.yaml"
+deploy "${BUILDDIR}/manifests/${sysmgmt_yaml}"
 
-# In 1.7 the old spire server is removed. The new cray-spire server should be around from 1.5 on
+# In 1.7 the old spire server is removed. The new cray-spire server should be around from 1.5 on.
+# We first need to change the serviceAccountName in cray-spire daemonset request-ncn-join-token in
+# case it is using the cray-spire-request-ncn-join-token service account which will be deleted with the
+# undeploy of spire.
+kubectl patch daemonsets.apps -n spire request-ncn-join-token --type='json' -p='[{"op": "replace", "path": '/spec/template/spec/serviceAccountName', "value":"default"}]'
 undeploy -n spire spire
 
 # Ensure updated pre-cache images have been pulled on each NCN worker,
@@ -137,10 +181,12 @@ else
 fi
 
 # Deploy Nexus
-deploy "${BUILDDIR}/manifests/nexus.yaml"
+deploy "${BUILDDIR}/manifests/${nexus_yaml}"
 
-# Deploy Kyverno image verification policy
-deploy "${BUILDDIR}/manifests/kyverno-policy.yaml"
+# Deploy Kyverno image verification policy - only if K8SVER is v1.32
+if [ "${K8SVER}" = "v1.32" ]; then
+    deploy "${BUILDDIR}/manifests/kyverno-policy.yaml"
+fi
 
 # Deploy Vshasta specific services
 function is_vshasta_node {
@@ -167,4 +213,3 @@ cat >&2 <<EOF
 + CSM applications and services upgraded
 ${0##*/}: OK
 EOF
-


### PR DESCRIPTION
## Summary and Scope

CASMPET-7460: Modify upgrade.sh to check K8s version and deploy k8s version specific manifests if they exist, otherwise deploy default manifests (platform.yaml, storage.yaml, etc).

* New manifest-v1.24.yaml files will be deployed when upgrading from CSM 1.6.x running k8s 1.24 to CSM 1.7.x running k8s 1.25+.
* New post-upgrade-00-manifest-k8s_version.yaml manifests will be deployed at the end of upgrade_control_plane.sh.

Installs will continue to use the usual manifest files (platform.yaml, storage.yaml, etc) and will not be affected by this change.

Upgrades will first undeploy kyverno charts.  It will then deploy manifest-v1.24.yaml files during "Upgrade CSM" stage when K8s is still at v1.24.  If a manifest-v1.24.yaml file does not exist for a manifest, it will use the default manifest.

The 1.7.0-alpha.xx vShasta upgrades should now get past the "Upgrade CSM Services" stage and will fail in the "Upgrade Master Nodes" stage.  It will fail during kubernetes-cloudinit in preflight checks because the K8s version gap is too large.

## Issues and Related PRs

* Resolves [CASMPET-7460](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7521)

## Testing
Many upgrades have been executed on the vShasta system `molly` where the <manifest>-v1.24.yaml manifests are deployed and "Upgrade CSM Services" stage completes successfully.

## Risks and Mitigations
Won't affect installs and upgrades will get further but continue to fail.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

