### PR TITLE
CASMPET-7410: Fixed prometheus format

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.10
+    version: 1.2.11
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -169,7 +169,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.11
+    version: 1.2.12
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope

CASMPET-7410: For cray-sysmgmt-health, fix the prometheus format in the iscsi-metrics container
CASMMON-532: Fix all the minor bugs reported as a part of Victoria-metrics-k8s-stack upgrade

## Issues and Related PRs

* Re-resolves [CASMPET-7410](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7410)
* Resolves [CASMMON-532](https://jira-pro.it.hpe.com:8443/browse/CASMMON-532)
## Testing

### Tested on:

  * `tyr`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

