### PR TITLE
CASMSEC-552: Updated kyverno-policy.yaml to include the new chart

### DIFF
--- a/manifests/kyverno-policy.yaml
+++ b/manifests/kyverno-policy.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: image-verification-policy
     source: csm-algol60
-    version: 1.0.0
+    version: 1.0.1
     namespace: kyverno


### PR DESCRIPTION
## Summary and Scope
image-verification-policy chart's version has been upgraded to include exceptions of the following products: 
1) slurm
2) slingshot
3) pbs
4) sma
5) diags

## Related jiras
[CASMSEC-552](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-552)
[CASMSEC-554](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-554)
[CASMSEC-553](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-553)
[CASM-4837](https://jira-pro.it.hpe.com:8443/browse/CASM-4837)
[CASM-4838](https://jira-pro.it.hpe.com:8443/browse/CASM-4838)
## Testing
The following exceptions and the policy reports were tested in the fresh install and upgrade scenarios from the artifactory chart.


### Tested on:

  * `Starlord

### Test description:

[image-verification_1_0_1_arti_install.txt](https://github.com/user-attachments/files/20239128/image-verification_1_0_1_arti_install.txt)
[image-verification_1_0_1_arti_upgrade.txt](https://github.com/user-attachments/files/20239130/image-verification_1_0_1_arti_upgrade.txt)
