### PR TITLE
CASMPET-7390: Upgrade istio to 1.26.0 and cray-kiali

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -160,7 +160,7 @@ spec:
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60
-    version: 0.6.1
+    version: 0.7.0
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -58,9 +58,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.2
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
       # Istio
-      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.19.10-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.19.10-cray1-distroless
-      - artifactory.algol60.net/csm-docker/stable/istio/operator:1.19.10-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
+      - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.26.0-cray1-distroless
       # Kyverno
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4
@@ -119,13 +118,13 @@ spec:
     source: csm-algol60
     version: 1.11.1
     namespace: kube-system
-  - name: cray-istio-operator
+  - name: cray-istio-base
     source: csm-algol60
-    version: 2.0.0
+    version: 1.0.0
     namespace: istio-system
-  - name: cray-istio-deploy
+  - name: cray-istio-pilot
     source: csm-algol60
-    version: 2.0.1   # Update cray-precache-images above on proxyv2 tag change.
+    version: 1.0.0   # Update cray-precache-images above on proxyv2 tag change.
     namespace: istio-system
   - name: cray-certmanager
     source: csm-algol60
@@ -155,9 +154,9 @@ spec:
     source: csm-algol60
     version: 0.7.2
     namespace: cert-manager
-  - name: cray-istio
+  - name: cray-istio-ingress
     source: csm-algol60
-    version: 3.1.0
+    version: 4.0.0
     namespace: istio-system
   - name: cray-kiali
     source: csm-algol60

--- a/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
+++ b/vendor/github.com/Cray-HPE/shasta-cfg/customizations.yaml
@@ -62,7 +62,7 @@ spec:
   proxiedWebAppExternalHostnames:
     customerManagement:
       - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
-      - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
+      - '{{ kubernetes.services[''cray-istio-ingress''].istio.tracing.externalAuthority }}'
       - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
       - '{{ kubernetes.services[''cray-sysmgmt-health''][''victoria-metrics-k8s-stack''].vmselect.vmselectSpec.externalAuthority }}'
       - '{{ kubernetes.services[''cray-sysmgmt-health''][''victoria-metrics-k8s-stack''].vmagent.vmagentSpec.externalAuthority }}'
@@ -335,7 +335,7 @@ spec:
         api_gw:
           api_gw_service_name: istio-ingressgateway
           api_gw_service_namespace: istio-system
-      cray-istio:
+      cray-istio-ingress:
         # Override for the ingress-gateway certificate (requested from
         # cert-manager). The list of master nodes must be reviewed and
         # updated per system until a source exists from which to dynamically


### PR DESCRIPTION
## Summary and Scope

We need to upgrade to istio 1.26.0 (our current version is 1.19.10) and cray-kiali in order to support Kubernetes 1.32. 
New Images provided are built from this [Repo](https://github.com/Cray-HPE/istio/tree/work-1.26.0)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7390](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7390)
* Resolves [CASMPET-7376](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7376)
## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No specific risks.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

