### PR TITLE
CASMCMS-9426/CASMCMS-9428/CASMCMS-9429/CASMCMS-9430/CASMCMS-9432/CASMCMS-9421: BOS improvements

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.44.1
+    version: 2.45.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.44.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.45.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.43.0
+    version: 2.44.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.43.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.44.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.44.0
+    version: 2.44.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.44.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.44.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.26.1


### PR DESCRIPTION
## Summary and Scope

Improvements to the BOS service and API spec.

No backports except for CASMCMS-9432, which is having the API spec update backported to CSM 1.6:
https://github.com/Cray-HPE/csm/pull/4121

## Issues and Related PRs

* CASMCMS-9421
* CASMCMS-9432
* [CASMCMS-9426](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9426)
* [CASMCMS-9428](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9428)
* [CASMCMS-9429](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9429)
* [CASMCMS-9430](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9430)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

CASMCMS-9427 is open to update the release notes.