### PR TITLE
CASMCMS-9432: Update BOS API spec to reflect deprecation of CPS/DVS in CSM 1.6

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -140,7 +140,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.13/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.15/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.6


### PR DESCRIPTION
This only updates the BOS API spec for CSM 1.6, to get the automatically-generated API docs updated. No actual change in CSM 1.6 itself.