### PR TITLE
CASMTRIAGE-8214: Update MetalLB version to 2.0.2

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -241,12 +241,8 @@ spec:
     namespace: services
   - name: cray-metallb
     source: csm-algol60
-    version: 2.0.0
+    version: 2.0.2
     namespace: metallb-system
-    values:
-      metallb:
-        psp:
-          create: false
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
     version: 0.2.3


### PR DESCRIPTION
## Summary and Scope

Update MetalLB to version 2.02

## Issues and Related PRs

* Resolves [CASMTRIAGE-8214](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8214)
* MetalLB PR: https://github.com/Cray-HPE/cray-metallb/pull/16

## Testing

### Tested on:

  * `fanta`

### Test description:

See MetalLB PR above

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

