### PR TITLE
CASMTRIAGE-8224,CASMTRIAGE-8181, CASMCMS-9349: cmsdev CFS Add create/modify/delete tests

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.10.2-1.noarch
     - cfs-state-reporter-1.12.3-1.noarch
     - cfs-trust-1.9.1-1.noarch
-    - cray-cmstools-crayctldeploy-1.31.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.32.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.9-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch


### PR DESCRIPTION
CASMCMS-9349: cmsdev CFS Add create/modify/delete tests
CASMTRIAGE-8181: cmsdev test cfs fails intermittently in the pipeline, but passes on manual execution
[CASMTRIAGE-8224](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8224): Check bos service: FAIL