### PR TITLE
CASMSEC-545: Enable Enforce mode for PSS Baseline Policy

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -105,7 +105,7 @@ spec:
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60
-    version: 1.1.1
+    version: 1.2.0
     namespace: kyverno
   - name: cray-velero
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Enabled Enforce mode for `podsecurity-subrule-baseline` policy.

## Issues and Related PRs

* Resolves [CASMSEC-545](jira-pro.it.hpe.com:8443/browse/CASMSEC-545)

## Testing

### Tested on:

  * `wasp`

### Test description:
* Install, Uninstall, Upgrade, Rollback tested on `wasp`
[CASMSEC-545-wasp.txt](https://github.com/user-attachments/files/20366004/CASMSEC-545-wasp.txt)

## Risks and Mitigations

Pods and resources not adhering to this policy will be blocked. If they should be allowed, exceptions can be provided. Exceptions are in place for a lot of resources already, but might require more for IUF pods.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable TBD

