### PR TITLE
CASMNET-2322/2323 - Update cray-service and cray-postgresql dependencies for CSM 1.7

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -68,7 +68,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.12.0 # update platform.yaml cray-precache-images with this
+    version: 0.13.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)
@@ -83,7 +83,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.4.2 # update platform.yaml cray-precache-images with this
+    version: 0.5.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -72,9 +72,9 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.12.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.9.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17


### PR DESCRIPTION
## Summary and Scope

Update `cray-service` and `cray-postgresql` dependencies for the `cray-dns-powerdns` and `cray-dhcp-kea` charts.

## Issues and Related PRs

* Resolves 
  * [CASMNET-2322](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2322)
  * [CASMNET-2323](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2323)

## Testing

### Tested on:

  * `starlord`

### Test description:

#### cray-dns-powerdns

Deployed chart on starlord, verified services are running as expected
```
ncn-m001:~ # kubectl get pod -A | grep powerdns
services                 cray-dns-powerdns-69454c558b-5dpmm                                2/2     Running            0                2m42s
services                 cray-dns-powerdns-postgres-0                                      3/3     Running            0                2m28s
services                 cray-dns-powerdns-postgres-1                                      3/3     Running            0                89s
services                 cray-dns-powerdns-postgres-2                                      3/3     Running            0                119s
services                 cray-dns-powerdns-wait-for-postgres-5-l2qc7                       0/3     Completed          0                2m42s
```
Verified DNS service is functioning as expected
```
ncn-m001:~ # host api.cmn.starlord.hpc.amslabs.hpecorp.net 10.92.100.85
Using domain server:
Name: 10.92.100.85
Address: 10.92.100.85#53
Aliases:

api.cmn.starlord.hpc.amslabs.hpecorp.net has address 10.102.103.65
```

#### cray-dhcp-kea 

Deployed chart on starlord

Verified services came up correctly
```
ncn-m001:~/cspiller/upgrades # kubectl get pod -A | grep kea
services                 cray-dhcp-kea-757c846f5f-4gbqw                                    3/3     Running            0                  2m28s
services                 cray-dhcp-kea-757c846f5f-mczss                                    3/3     Running            0                  2m28s
services                 cray-dhcp-kea-757c846f5f-wxg9w                                    3/3     Running            0                  2m28s
services                 cray-dhcp-kea-helper-29128878-bng67                               0/2     Completed          0                  8m49s
services                 cray-dhcp-kea-helper-29128881-9r8rr                               0/2     Completed          0                  5m49s
services                 cray-dhcp-kea-helper-29128884-6nnh5                               0/2     Completed          0                  2m49s
services                 cray-dhcp-kea-init-5-6pvtx                                        0/2     Completed          0                  2m28s
services                 cray-dhcp-kea-postgres-0                                          3/3     Running            0                  73s
services                 cray-dhcp-kea-postgres-1                                          3/3     Running            0                  2m16s
services                 cray-dhcp-kea-postgres-2                                          3/3     Running            0                  107s
```
Verified Kea has active leases
```
ncn-m001:~ # curl -sH "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq .[].text
"61 IPv4 lease(s) found."
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

