### PR TITLE
kafka-operator update from 1.2.1 to 1.3.0

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -189,7 +189,7 @@ spec:
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 1.2.1
+    version: 1.3.0
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
@@ -217,7 +217,7 @@ spec:
     namespace: services
   - name: cray-shared-kafka
     source: csm-algol60
-    version: 1.1.1
+    version: 1.2.0
     namespace: services
   - name: cray-sts
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

kafka-operator was updated and the new chart version is 1.3.0. The change was done by @bmcdonald3 
also updating cray-shared-kafka to 1.2.1
This PR is to just update the csm manifests.

## Issues and Related PRs

* https://github.com/Cray-HPE/cray-kafka-operator/pull/10
* https://github.com/Cray-HPE/cray-shared-kafka/pull/13
* https://jira-pro.it.hpe.com:8443/browse/CASMPET-7382


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

