### PR TITLE
CASMPET-7531: Update Spire chart for TPM enablment

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -262,7 +262,7 @@ spec:
   # Spire service
   - name: cray-spire
     source: csm-algol60
-    version: 1.7.6
+    version: 1.7.7
     namespace: spire
 
   # Tapms service


### PR DESCRIPTION
## Summary and Scope

This fixes a bug where if the ncns have been converted to use TPM for node attestation and then the request-join-ncn pods are restarted it wipes away the new spire config. This also makes it so the tpm enabled nodes do not even get a token to improve security for TPM enabled nodes.

## Issues and Related PRs

* Resolves [CASMPET-7531](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7531)

## Testing

### Tested on:

  * mug

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

This takes away risk of generating a join token for each node while TPM node attestation is enabled. There is a risk that a node does not join spire with TPM but the enabled flag is set, which can be mitagated by manually unsetting the file and re-running the join process

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

