### PR TITLE
CASMPET-7304: update ceph-grafana image version

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -58,7 +58,7 @@ artifactory.algol60.net/csm-docker/stable:
       - v17.2.6
 
     quay.io/ceph/ceph-grafana:
-      - 9.4.7
+      - 9.4.12
 
     quay.io/prometheus/prometheus:
       - v2.43.0


### PR DESCRIPTION
## Summary and Scope

Update ceph-grafana image version for CSM 1.7.0.
 
## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7304](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7304)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

