### PR TITLE
CASMSEC-525: Kyverno upgrade support for CSM 1.7

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -97,7 +97,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.7.3
+    version: 1.7.4
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -68,7 +68,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.4
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.4
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno-cli:v1.13.4
-      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.32.3
+      - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
@@ -97,7 +97,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.7.4
+    version: 1.7.5
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Kyverno upgrade is failing during CSM upgrade. This is fixed in latest version of cray-kyverno

## Testing

Kyverno upgrade

### Tested on:

Fanta (CSM 1.7)
Drax (CSM 1.6)

### Test description:

[ArtiLogPreHookTest.txt](https://github.com/user-attachments/files/20382616/ArtiLogPreHookTest.txt)
[Kyverno_upgrade_logs_pre_hook.txt](https://github.com/user-attachments/files/20382617/Kyverno_upgrade_logs_pre_hook.txt)
[kubectlCVEfixUpgradeTest.txt](https://github.com/user-attachments/files/20507024/kubectlCVEfixUpgradeTest.txt)

