### PR TITLE
CASMPET-7351: Manifest PR for SBPS rpm

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -71,7 +71,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python312-requests-retry-session-0.2.4-1.noarch
     - python39-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.2.4-1.noarch
-    - sbps-marshal-0.0.14-1.noarch
+    - sbps-marshal-1.0.0-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.12.aarch64
     - spire-agent-1.5.5-1.12.x86_64


### PR DESCRIPTION
## Summary and Scope

This is regarding the CASMPET-7351 fix where this PR is to install the latest version of RPM i.e sbps-marshal-1.0.0-1.noarch having this fix to install. 

## Issues and Related PRs
CASMPET-7351
https://github.com/Cray-HPE/sbps-marshal/pull/22

* Resolves [issue id](issue link): CASMPET-7351
* Change will also be needed in `<insert branch name here>`: N/A 
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): N/A
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
CASMPET-7351 fix has been tested on Starlord having CSM 1.7.0-alpha.11

### Tested on:
Starlord

### Test description:
Testing is done by adding and remove the "iscsi=sbps" label to the worker nodes. More details are in the Unit test results of CASMPET-7351 attached in the Jira.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: N/A
- Was downgrade tested? If not, why?: N/A
- Were new tests (or test issues/Jiras) created for this change?: N/A

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [NA ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable