### PR TITLE
CASMSEC-565: Exceptions for cray-hms-sls chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -101,7 +101,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.11
+    version: 1.7.12
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

As certain charts are still not adhering to the PSS policy, more exceptions are found to be required. This change reverts Enforce mode back to Audit mode so that installation and upgrade is not blocked. 
In addition, it also includes the exception for the mentioned error for cray-hms-sls chart. 

## Issues and Related PRs

* Resolves [CASMSEC-565](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-565)

## Testing

### Tested on:

  * `wasp`

### Test description:

* Install tested on wasp
[CASMSEC-565-wasp.txt](https://github.com/user-attachments/files/20436780/CASMSEC-565-wasp.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

