### PR TITLE
CASMTRIAGE-8205 Update nexus-setup image to 0.12.1

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -195,7 +195,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Images needed by IUF and possibly non-CSM products
     cray-nexus-setup:
-      - 0.12.0
+      - 0.12.1
 
     # not needed for build/install as it comes packaged as skopeo.tar
     quay.io/skopeo/stable:


### PR DESCRIPTION
## Summary and Scope

CASMTRIAGE-8205 Update nexus-setup image to 0.12.1 to support image signatures

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8205](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8205)
* Merge with  `https://github.com/Cray-HPE/docs-csm/pull/5984`
* Merge after `https://github.com/Cray-HPE/nexus-setup/pull/33`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Starlord



## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

