### PR TITLE
CASMPET-7553: Check for helm status 'uninstalled' during undeploy

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -55,8 +55,13 @@ function deploy() {
 # Use this if a chart has been removed from a manifest and needs
 # to be removed from the system as part of an upgrade.
 function undeploy() {
-    # If the chart is missing (rc==1) just return success.
+    # Now that we're using --keep-history, helm status will return with a STATUS
+    # of "uninstalled" if the chart has already been uninstalled.
+    # If the chart is missing (rc==1) or if uninstalled, return success.
     helm status "$@" || return 0
+    if [ "$(helm status "$@" | grep STATUS | awk '{print $2}')" = "uninstalled" ]; then
+      return 0
+    fi
     # Remove the chart.
     helm uninstall "$@" --keep-history
 }


### PR DESCRIPTION
## Summary and Scope

Now that we're using the `--keep-history` flag during undeploy, `helm status` will return successfully with STATUS "uninstalled" for charts that have been uninstalled.  To make the `undeploy` function idempotent, we need to check for the "uninstalled" status or return code of 1.  If found, then return 0 since chart is already uninstalled or doesn't exist.

## Issues and Related PRs

* Resolves [CASMPET-7553](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7553)

## Testing

Tested on `molly` during k8s upgrade testing.

```
ncn-m001:/usr/share/doc/csm/upgrade/scripts/k8s # function undeploy() {
>     # Now that we're using --keep-history, helm status will return with a STATUS
>     # of "uninstalled" if the chart has already been uninstalled.
>     # If the chart is missing (rc==1) or if uninstalled, return success.
>     helm status "$@" || return 0
>     if [ "$(helm status "$@" | grep STATUS | awk '{print $2}')" = "uninstalled" ]; then
>       echo "STATUS is 'uninstalled'"
>       return 0
>     fi
>     # Remove the chart.
>     helm uninstall "$@" --keep-history
> }
ncn-m001:/usr/share/doc/csm/upgrade/scripts/k8s # undeploy -n services cray-psp
Error: release: not found
ncn-m001:/usr/share/doc/csm/upgrade/scripts/k8s # undeploy -n spire spire
NAME: spire
LAST DEPLOYED: Thu May 22 06:01:53 2025
NAMESPACE: spire
STATUS: uninstalled
REVISION: 1
TEST SUITE: None
STATUS is 'uninstalled'
ncn-m001:/usr/share/doc/csm/upgrade/scripts/k8s # undeploy -n sysmgmt-health cray-sysmgmt-health
NAME: cray-sysmgmt-health
LAST DEPLOYED: Tue May 27 12:51:37 2025
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 2
release "cray-sysmgmt-health" uninstalled
ncn-m001:/usr/share/doc/csm/upgrade/scripts/k8s # helm status -n sysmgmt-health cray-sysmgmt-health
NAME: cray-sysmgmt-health
LAST DEPLOYED: Tue May 27 12:51:37 2025
NAMESPACE: sysmgmt-health
STATUS: uninstalled
REVISION: 2
ncn-m001:/usr/share/doc/csm/upgrade/scripts/k8s #
```

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

