### PR TITLE
CASMPET-7551: upgrade cephcsi

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -122,20 +122,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.8.6
       - v1.11.3
 
-    # Workaround for https://jira-pro.it.hpe.com:8443/browse/CASMPET-7545 - image is not delivered with char
-    registry.k8s.io/sig-storage/csi-provisioner:
-     - v5.2.0
-    registry.k8s.io/sig-storage/csi-attacher:
-     - v4.8.1
-    registry.k8s.io/sig-storage/csi-snapshotter:
-     - v8.2.1
-    registry.k8s.io/sig-storage/csi-node-driver-registrar:
-     - v2.13.0
-    registry.k8s.io/sig-storage/csi-resizer:
-     - v1.13.2
-    quay.io/cephcsi/cephcsi:
-     - v3.14.0
-
     # Kube images required by platform
     registry.k8s.io/kube-apiserver:
       - v1.24.17

--- a/manifests/storage-v1.24.yaml
+++ b/manifests/storage-v1.24.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ spec:
   - name: cray-ceph-csi-rbd
     source: csm-algol60
     namespace: ceph-rbd
-    version: 3.14.0
+    version: 3.6.2-1
     values:
       ceph-csi-rbd:
         nodeplugin:
@@ -46,7 +46,7 @@ spec:
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs
-    version: 3.14.0
+    version: 3.6.3-1
     values:
       ceph-csi-cephfs:
         nodeplugin:

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -119,9 +119,14 @@ storage_yaml=$(select_manifest_file storage)
 sysmgmt_yaml=$(select_manifest_file sysmgmt)
 
 # Deploy services critical for Nexus to run
-echo "Deploying new ceph csi provisioners..."
+echo "Deploying ceph csi provisioners..."
+if [ "${K8SVER}" = "v1.32" ]; then
+    # Apply the workaround for cephcsi upgrade known issues
+    kubectl delete csidriver rbd.csi.ceph.com || true
+    kubectl delete csidriver cephfs.csi.ceph.com || true
+fi
 deploy "${BUILDDIR}/manifests/${storage_yaml}"
-echo "Deployment of new ceph csi provisioners is complete."
+echo "Deployment of ceph csi provisioners is complete."
 echo "PVC movement will resume when all ceph csi pods are finished starting."
 deploy "${BUILDDIR}/manifests/${platform_yaml}"
 deploy "${BUILDDIR}/manifests/${keycloak_gatekeeper_yaml}"


### PR DESCRIPTION
## Summary and Scope

This PR upgrades cephcsi to v3.14.0 that supports k8s 1.32 for CSM 1.7.0. Since cephcsi v3.14.0 does not support k8s 1.24 ~ 1.28 and our existing cephcsi version still functions on k8s 1.32, we'll upgrade cephcsi after k8s has been upgraded to 1.32.

## Issues and Related PRs

* Resolves [CASMPET-6947](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6947) and [CASMPET-7551](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7551)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * Virtual Shasta

### Test description:

Upgraded cephcsi multiple times with new charts and a workaround to address a known upgrade issue.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. We can always decide to rollback the helm upgrade when needed. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

