### PR TITLE
CASMCMS-9439/MTL-2569/MTL-2574/MTL-2556/MTL-2555/MTL-2573/CASMPET-7260/CASMCMS-9445: csm-config updates

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.34.0
+    version: 1.35.0
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.33.0
+    version: 1.34.0
     namespace: services
     values:
       cray-import-config:

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.35.0
+    version: 1.36.0
     namespace: services
     values:
       cray-import-config:

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -36,7 +36,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.9-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch
-    - cray-uai-util-2.2.1-1.noarch
     - craycli-0.95.0-1.aarch64
     - craycli-0.95.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -40,12 +40,19 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - craycli-0.95.0-1.aarch64
     - craycli-0.95.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
+    - csm-netif-dracut-2.0-1.noarch
     - csm-node-heartbeat-2.8-1.aarch64
     - csm-node-heartbeat-2.8-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
+    - csm-scripts-dracut-2.0-1.noarch
     - csm-ssh-keys-1.8.0-1.noarch
     - csm-ssh-keys-roles-1.7.1-1.noarch
+    - csm-sbps-dracut-2.0-1.noarch
+    - csm-sbps-utils-2.0-1.noarch
     - csm-testing-1.19.21-1.noarch
+    - csm-udev-network-cn-2.0-1.aarch64
+    - csm-udev-network-cn-2.0-1.x86_64
+    - csm-udev-network-ncn-2.0-1.x86_64
     - goss-servers-1.19.21-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch


### PR DESCRIPTION
Includes:
* CASMCMS-9439 - Create `csm.ssh_config` role
* MTL-2569, MTL-2574, MTL-2556, MTL-2555, MTL-2573: Transfer RPMs from other products to CSM
* CASMPET-7260: Add ability to specify which worker nodes to configure for iSCSI using an HSM group
* CASMCMS-9445: Remove UAI package from install list

CASMCMS-9443 is open to document the `csm.ssh_config` role, including listing it in the CSM 1.7 release notes.
CASMPET-7557 is open to document the new iSCSI option in the CSM 1.7 release notes.

## Pull Request Checklist

- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable
