### PR TITLE
CASMHMS-6535: Update BSS API spec examples to use SBPS instead of CPS/DVS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -42,7 +42,7 @@ spec:
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.33.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.33.1/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 5.1.1


### PR DESCRIPTION
- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

