### PR TITLE
CASMHMS-6257: hmcollector: Fixed lost subscription bug when Paradise BMCs reboot

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -79,7 +79,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.24.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.17.2
+    version: 2.17.3
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
### Summary and Scope

Most of the changes in this PR were the addition of code comments and more verbose logging.  These were added to help aid my understanding of what hmcollector was doing in the area of BMC subscriptions and event reception.

The only functional code change was fixing a bug associated with subscriptions never being recreated after Paradise BMCs rebooted.  BMC reboots, for the most part, usually only occur as part of the BMC fw update process.

Hmcollector attempts to create two subscriptions for every component in the system that speaks redfish.  The first subscription uses an empty registry prefix group, while the second subscription uses a "CrayTelemetry" registry prefix group.  The later subscription is used for streaming telemetry, which is only supported on Cray hardware.  Despite this, hmcollector has always attempted to create streaming telemetry subscriptions for all components.  During the streaming telemetry attempt, the POST operation to the BMC fails if the BMC doesn't support it.

When Paradise support was added to hmcollector, code was added to rfSubscribe() to avoid creating the streaming telemetry subscription, because the hardware doesn't support it!  However, hmcollector assumes all component types attempt both subscriptions even if those component types don't support streaming telemetry.  When a Paradise BMC becomes unreachable (because it's rebooting) and then comes back after a period of time, isDupRFSubscription() will never indicate back to rfVerifySub() that it needs to mark the BMC as RFSUBSTATUS_ERROR so that the subscription is re-attempted.  This is due to the "CrayTelemtry" registry prefix being absent when isDupRFSubscription() executes.

The fix here is to remove the code that prevented the streaming telemetry subscription from being attempted on Paradise hardware.  Instead, treat Paradise hardware identically to all the other hardware that doesn't support streaming telemetry.

One further note...  One can easily argue that the hmcollector code should be reworked so that the second streaming telemetry subscription is never attempted against hardware that doesn't support it.  On the surface this seems pretty simple.  However, I did try going down that path but the changes necessary kept spreading and going deeper.  At this point in the product life it doesn't seem worth it to incur the risk of such substantial changes when the current functionality has proven stable over many years, even though we're doing more work here than should really be necessary.

Adopted app version 2.39.0 for CSM 1.7.0 (helm chart 2.17.3).

### Issues and Related PRs

* Resolves [CASMHMS-6257](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6257)

### Testing

Tested on:

* `mug`

Test description:

With dev version of service in place, rebooted a Paradise BMC.  After BMC rebooted and hmcollector started communicating with it again, performed power cycle with PCS.  Verified power events were recieved by watching the hmcollector-poll logs.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

