### PR TITLE
CASMHMS-6389: Explicitly closed all request and response bodies using…

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,13 +36,13 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.3.3
+    version: 3.3.4
     namespace: services
     timeout: 10m
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.33.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.34.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 5.1.1


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Updated Go to v1.24.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.34.0 for CSM 1.7.0 (helm chart 3.3.4).

### Issues and Related PRs

* Resolves [CASMHMS-6389](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6389)
* Also resolves CASMHMS-6535: Update BSS API spec examples to use SBPS instead of CPS/DVS

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

Note that testing used the stable 3.3.2 helm chart as 3.3.3 and later are unable to be deployed on mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

