### PR TITLE
CASMHMS-6398: SCSD: Resolve some scaling and resource usage issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -83,12 +83,12 @@ spec:
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: services
     swagger:
     - name: scsd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.22.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.23.0/api/openapi.yaml
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Fixed a bug in three places where response bodies were not being closed

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Ignoring resource issues associated with TRS in this PR as the version used is very old and there is an HMS ticket open to update it to a more recent version.

Adopted app version 1.23.0 for CSM 1.7.0 (helm chart 3.1.3).

### Issues and Related PRs

* Resolves [CASMHMS-6398](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6398)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

