### PR TITLE
CASMCMS-9420 - resolve CVE's for cray-csm-sles15sp6-barebones-recipe

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -30,7 +30,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:
-      - 2.7.2
+      - 2.8.0
     cray-grafterm:
       - 1.0.3
     # XXX Are these HMS images missing from a chart or are they used to


### PR DESCRIPTION
## Summary and Scope

The image 'cray-csm-sles15sp6-barebones-recipe:2.7.0' uses the base image `ims-load-artifacts:2.8.0'. Since `ims-load-artifacts:2.8.0` was not included in the manifest files, it was not getting automatically rebuilt. Once I triggered a manual rebuild of the base image, then the barebones image, the CVS's were resolved.

This change updates the version of `ims-load-artifacts` to what is really being used so the correct version gets automatically rebuilt to include security updates.

## Issues and Related PRs
* Resolves [CASMCMS-9420](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9420)

## Testing
### Tested on:
  * Build System

### Test description:

The manually started rebuilds resolved the SNYK scan issues. This should have been happening automatically, so I didn't manually test the result.

## Risks and Mitigations

Low risk.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

