### PR TITLE
CASMHMS-6390: CAPMC: Explicitly closed all request and response bodies

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -45,12 +45,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.33.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.2
     namespace: services
     swagger:
     - name: capmc
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.7.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.8.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
     version: 3.2.4


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Updated Go to v1.24, which required some code changes to avoid some compile errors.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 3.8.0 for CSM 1.7.0 (helm chart 5.1.2).

### Issues and Related PRs

* Resolves [CASMHMS-6390](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6390)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

