### PR TITLE
CASMCMS-7801/8101 - console services bug fixing.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -163,12 +163,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.15.0
+    version: 1.16.0
     namespace: services
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.9.0
+    version: 2.10.0
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

Fixes for console stability:
- Better handling of when the hsm service is unavailable or unreliable
- Keep BMC ssh keys on container local storage to avoid PVC permission issues 

## Issues and Related PRs
* Resolves [CASMTRIAGE-7801](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7801)
* Resolves [CASMTRIAGE-8101](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8101)

## Testing
### Tested on:
  * `Mug, Rocket`

### Test description:

Installed the new services via helm, then tested for the conditions that we causing issues. I simulated issues contacting the hsm service and verified the console node connections were stable. I also verified the bmc ssh keys were kept on container local storage.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
