### PR TITLE
CASMCMS-9449 - fix console api documentation.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -163,8 +163,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.16.0
+    version: 1.16.1
     namespace: services
+    swagger:
+    - name: console
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/console-operator/v1.16.1/api/console.md
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

The api document for consoles is not automatically generated using swagger like the rest of the api docs. This fixes the way the manually generated document is included in the docs package.

## Issues and Related PRs
* Resolves [CASMCMS-9449](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9449)

## Testing

Including a reference to an api doc - nothing to test.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

