### PR TITLE
CASMCMS-9447: Update csm-config

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -207,7 +207,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.36.0
+    version: 1.37.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9447: Update csm-config to remove long-deprecated playbooks.
Release notes will be updated with CASMCMS-9448

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

