### PR TITLE
CASMPET-7526, CASMPET-7533: Update keycloak to use new postgres version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -205,11 +205,11 @@ spec:
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.1.4
+    version: 5.2.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.5
+    version: 1.11.7
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This updates the keycloak charts to use the new version of postgres. This also fixes the issue with dependencies to allow for better versioning of the keycloak charts and container images. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7533](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7533)
* Resolves [CASMPET-7526](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7526)

## Testing

### Tested on:

  * Beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

No risks that are known

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

