### PR TITLE
CASMSEC-569: IUF exceptions for node rebuild stages

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -101,7 +101,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.12
+    version: 1.7.13
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

After consulting with the IUF team, they released a list of stages and tasks in IUF workflows where hostPath volumes are expected to be used. Comparing the currently written exceptions, and the given list, it was found certain exceptions were required for the non-lifecycle-rebuild stage. Those exceptions are added in this PR.

## Issues and Related PRs


* Resolves [CASMSEC-569](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-569)

## Testing

### Tested on:

  * `wasp`

### Test description:

- Install, Rollback tested
[CASMSEC-569-wasp.txt](https://github.com/user-attachments/files/20591037/CASMSEC-569-wasp.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable TBD

