### PR TITLE
CASMTRIAGE-8244: Update cray-kafka-operator chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -189,7 +189,7 @@ spec:
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 1.3.0
+    version: 1.3.1
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

cray-kafka-operator was updated and the new chart version is 1.3.1.

This PR is to just update the csm manifests.

## Issues and Related PRs

* https://github.com/Cray-HPE/cray-kafka-operator/pull/11
* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8244

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `gordo`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

