### PR TITLE
CASMHMS-6393: HBTD: Explicitly closed all request and response bodies…

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -61,13 +61,13 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.42.0/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
-    version: 3.2.2
+    version: 3.2.3
     namespace: services
     timeout: 10m
     swagger:
     - name: hbtd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.23.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.24.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
     version: 4.1.1


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.24.0 for CSM 1.7.0 (helm chart 3.2.3).

### Issues and Related PRs

* Resolves [CASMHMS-6393](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6393)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

