### PR TITLE
CASMHMS-6397: HMNFD: Fix various resource issues

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -70,13 +70,13 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.23.0/api/swagger.yaml
   - name: cray-hms-hmnfd
     source: csm-algol60
-    version: 4.1.1
+    version: 4.1.2
     namespace: services
     timeout: 10m
     swagger:
     - name: hmnfd
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.24.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.25.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
     version: 2.17.3


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Fixed a bug in a few places where response bodies were not being drained and closed

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Adopted app version 1.25.0 for CSM 1.7.0 (helm chart 4.1.2).

### Issues and Related PRs

* Resolves [CASMHMS-6397](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6397)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

