### PR TITLE
CASMPET-7565: add node-images asset fix

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -30,19 +30,19 @@ NCN_ARCH='x86_64'
 CN_ARCH=("x86_64" "aarch64")
 
 # All images must use the same, exact kernel version.
-KERNEL_VERSION='6.4.0-150600.23.17-default'
+KERNEL_VERSION='6.4.0-150600.23.47-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.15
+KUBERNETES_IMAGE_ID=7.1.17
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.15
+PIT_IMAGE_ID=7.1.17
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.15
+STORAGE_CEPH_IMAGE_ID=7.1.17
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.15
+COMPUTE_IMAGE_ID=7.1.17
 
 # Public keys for RPM signature validation.
 #

--- a/hack/resolve-globs.sh
+++ b/hack/resolve-globs.sh
@@ -40,7 +40,7 @@ KERNEL_VERSION=${KERNEL_VERSION%-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.kernel}
 # by doing a zypper search for the corresponding kernel-default-debuginfo package
 # in the SLE-Module-Basesystem update_debug repo
 # zypper --plus-repo=https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update_debug se -s kernel-default-debuginfo
-KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.1"
+KERNEL_DEFAULT_DEBUGINFO_VERSION="${KERNEL_VERSION//-default/}.2"
 
 KUBERNETES_ASSETS=(
     "https://artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/${KUBERNETES_IMAGE_ID}/kubernetes-${KUBERNETES_IMAGE_ID}-${NCN_ARCH}.squashfs"

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.3-1.noarch
     - cani-0.4.0-1.x86_64
-    - canu-1.9.10-1.x86_64
+    - canu-1.9.12-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.2-1.noarch
     - cfs-state-reporter-1.12.3-1.noarch
@@ -36,8 +36,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.10-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch
-    - craycli-0.95.0-1.aarch64
-    - craycli-0.95.0-1.x86_64
+    - craycli-0.96.0-1.aarch64
+    - craycli-0.96.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-netif-dracut-2.0-1.noarch
     - csm-node-heartbeat-2.8-1.aarch64
@@ -62,7 +62,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
     - metal-init-1.4.11-1.noarch
-    - metal-ipxe-2.6.1-1.noarch
+    - metal-ipxe-2.7.0-1.noarch
     - metal-nexus-1.7.0-3.70.4.x86_64
     - metal-observability-1.1.0-1.x86_64
     - platform-utils-1.8.2-1.noarch


### PR DESCRIPTION
## Summary and Scope

The node-images add a workaround to create csi subvolumegroup for the new cephcsi release.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7565](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7565)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `scanlan`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. Tested on vshasta, and we can revert if it fails.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

