### PR TITLE
CASMCMS-9451 - IMS updates for ceph upgrade.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -191,12 +191,12 @@ spec:
             tag: 2.7.0
   - name: cray-ims
     source: csm-algol60
-    version: 3.25.0
+    version: 3.26.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.25.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.26.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
## Summary and Scope

The data directory created on a PVC mount through ceph is getting the wrong owner/permissions setup with the new ceph upgrade installed. This change sets up the user and fsGroup in the container level of the helm chart so that when a new volume is created, it will have the correct permissions so that the ims service can write files to the data dir.

## Issues and Related PRs
* Resolves [CASMCMS-9451](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9451)

## Testing
### Tested on:
  * `Mug`
  * Virtual Shasta - scanlon

### Test description:

I uninstalled the current version of ims that was installed on the system, then did a clean 'helm install' with the new version. I then confirmed that the /var/ims/data directory is created with the correct owner/permissions so that the IMS service could write to the dir and work correctly.

NOTE: I only observed this behavior on a new vshasta system with the upgraded version of ceph and k8s present. With the hardware systems I tested, the old ownership was still seen but that has older version of ceph and k8s installed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Medium risk as these are changes for a configuration that isn't present on a physical system.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
