### PR TITLE
CASMPET-7577: Do not uninstall cray-psp before rolling out ncns

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -222,9 +222,6 @@ fi
 #
 undeploy -n operators cray-etcd-operator
 
-# After charts are deployed remove cray-psp in CSM 1.7 with upgrade to K8s >= 1.25, if it exists
-undeploy -n services cray-psp
-
 # Update BSS runcmd for master nodes to create /etc/cray/kubernetes
 # and touch /etc/cray/kubernetes/upgrade. This is necessary to persist
 # upgrade state across node reboots.


### PR DESCRIPTION
## Summary and Scope
CASMPET-7577: Do not uninstall cray-psp before rolling out ncns, remove from upgrade.sh

## Issues and Related PRs

* Resolves [CASMPET-7577](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7577)

## Testing

On orym.

Without `cray-psp` no `keycloak-postgres` pods and could not get a token.  Reinstalled `cray-psp` and `keycloak-postgres` pods came and was able to get a token.

```
ncn-m001:~ # kubectl get pods -n services | grep keycloak
cray-keycloak-0                                                   1/2     Running     0              48m
cray-keycloak-1                                                   1/2     Running     0              47m
cray-keycloak-2                                                   1/2     Running     0              47m
keycloak-setup-2-c92dl                                            0/2     Completed   0              5h21m
keycloak-users-localize-2-66ldg                                   0/2     Completed   0              5h21m
keycloak-vcs-user-2-b8nxk                                         0/2     Completed   0              5h6m
keycloak-wait-for-postgres-2-vngtl                                0/2     Completed   0              5h37m
ncn-m001:~ # TOKEN=$(curl -s -S -d grant_type=client_credentials \
      -d client_id=admin-client \
      -d client_secret="$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)" \
      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
parse error: Invalid literal at line 1, column 3
ncn-m001:~ # exit
logout
Connection to ncn-m001 closed.
pit:/var/www/ephemeral/csm-1.6.2/helm # helm install --replace -n services cray-psp cray-psp-0.4.5.tgz
W0605 18:33:33.603011   24298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0605 18:33:33.741759   24298 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME: cray-psp
LAST DEPLOYED: Thu Jun  5 18:33:32 2025
NAMESPACE: services
STATUS: deployed
REVISION: 1
TEST SUITE: None

pit:/var/www/ephemeral/csm-1.6.2/helm # ssh ncn-m001

ncn-m001:~ # kubectl get pods -n services | grep keycloak
cray-keycloak-0                                                   1/2     Running     0               60m
cray-keycloak-1                                                   1/2     Running     0               60m
cray-keycloak-2                                                   1/2     Running     0               60m
keycloak-setup-2-c92dl                                            0/2     Completed   0               5h34m
keycloak-users-localize-2-66ldg                                   0/2     Completed   0               5h34m
keycloak-vcs-user-2-b8nxk                                         0/2     Completed   0               5h19m
keycloak-wait-for-postgres-2-vngtl                                0/2     Completed   0               5h50m
ncn-m001:~ # kubectl get pods -n services | grep keycloak
cray-keycloak-0                                                   2/2     Running     0               69m
cray-keycloak-1                                                   2/2     Running     0               69m
cray-keycloak-2                                                   2/2     Running     0               69m
keycloak-postgres-0                                               3/3     Running     0               3m21s
keycloak-postgres-1                                               3/3     Running     0               3m5s
keycloak-postgres-2                                               3/3     Running     0               2m50s
keycloak-setup-2-c92dl                                            0/2     Completed   0               5h43m
keycloak-users-localize-2-66ldg                                   0/2     Completed   0               5h43m
keycloak-vcs-user-2-b8nxk                                         0/2     Completed   0               5h27m
keycloak-wait-for-postgres-2-vngtl                                0/2     Completed   0               5h59m
ncn-m001:~ # TOKEN=$(curl -s -S -d grant_type=client_credentials \
      -d client_id=admin-client \
      -d client_secret="$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)" \
      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
ncn-m001:~ #

```
## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

