### PR TITLE
CASMPET-7578: Return kubernetes-cni-1.2.0

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -98,6 +98,7 @@ https://artifactory.algol60.net/artifactory/opensuse-mirror/isv:kubernetes:/core
     - kubeadm-1.26.15-150500.1.1.x86_64
     - kubectl-1.26.15-150500.1.1.x86_64
     - kubelet-1.26.15-150500.1.1.x86_64
+    - kubernetes-cni-1.2.0-150500.2.1.x86_64
 
 https://artifactory.algol60.net/artifactory/opensuse-mirror/isv:kubernetes:/core:/stable:/v1.27/rpm/:
   rpms:


### PR DESCRIPTION
## Summary and Scope

Return `kubernetes-cni-1.2.0` to CSM. It was accidentally deleted when removing Kubernetes 1.25-related packages, and `kubernetes-cloudinit.sh` fails without it when upgrading to 1.26.

## Issues and Related PRs

* Resolves [CASMPET-7578](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7578)

## Risks and Mitigations

Minimal risk. This is purely an additive package change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

