### PR TITLE
CASMCMS-9454 - Add security context to cms-ipxe for ceph upgrade.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -130,7 +130,7 @@ spec:
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
-    version: 1.16.0
+    version: 1.16.1
     namespace: services
   - name: cray-bos
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Add pod security context so that the ceph pvc mounts will create volumes with the correct ownership.

## Issues and Related PRs
* Resolves [CASMCMS-9454](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9454)

## Testing
### Tested on:
  * Virtual Shasta

### Test description:

Mikhail manually tested the helm chart changes on vshasta during the last release build. This just implements it in the code.

## Risks and Mitigations

Low risk.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

