### PR TITLE
CASMSEC-571, CASMSEC-572: Update kyverno policy chart and image verification charts to update exceptions

### DIFF
--- a/manifests/kyverno-policy.yaml
+++ b/manifests/kyverno-policy.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: image-verification-policy
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: kyverno

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,7 +111,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.13
+    version: 1.7.14
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR includes two commits for two tickets. CASMSEC-571 includes exceptions for rack-resiliency services under the PSS policy, and CASMSEC-572 includes changes to the exceptions issued for Diags under the check-image policy.

## Issues and Related PRs

* Resolves [CASMSEC-571](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-571), [CASMSEC-572](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-572)

## Testing

### Tested on:

  * `surtur`, `starlord`

### Test description:

- Install, Rollback tested for CASMSEC-571 in surtur
[CASMSEC-571-surtur.txt](https://github.com/user-attachments/files/20654100/CASMSEC-571-surtur.txt)
- Fresh Install, Upgrade, Rollback, Uninstall tested for CASMSEC-572(CASM-4838) in starlord
[CASM-4838-starlord.txt](https://github.com/user-attachments/files/20654103/CASM-4838-starlord.txt)

## Risks and Mitigations
None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable TBD

