### PR TITLE
CASMPET-7554: Upgrade velero to 1.16.1

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -132,7 +132,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-velero
     source: csm-algol60
-    version: 1.6.3-3
+    version: 1.16.1
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -119,7 +119,7 @@ spec:
     namespace: kyverno
   - name: cray-velero
     source: csm-algol60
-    version: 1.6.3-3
+    version: 1.16.1
     namespace: velero
   - name: sealed-secrets
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Pick up the new `cray-velero-1.16.1` helm chart for CSM 1.7

## Issues and Related PRs

* Resolves [CASMPET-7554](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7554)

## Testing

### Tested on:

  * `starlord`

### Test description:
the unstable cray-velero chart was deployed on the cluster and velero commands were ran according to documentation.
https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

## Risks and Mitigations
No known issues

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

