### PR TITLE
CASMPET-7587: delay postgres operator upgrade

### DIFF
--- a/lib/fix-postgres.sh
+++ b/lib/fix-postgres.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -eo pipefail
+
+# After postgresql-operator upgrade, a few issues may happen:
+# - operator will try to perform rolling restart of all postgresql clusters to add new mount to each pod, by setting
+#   zalando-postgres-operator-rolling-update-required: true annotation onto sts, but this may fail due to PSP issue (CASMINST-6728).
+#   restarting operator pod clears this error.
+# - operator will perform rolling restart of all postgresql clusters to add new mount to each pod, but restart sequence
+#   may get stuck on pod trying to update it's own label (CASMINST-6728). We mitigate this by explicit rolling restart
+#   of all PostgreSQL stateful sets.
+#
+
+function postgres_operator_running() {
+  if [ "$(kubectl -n services get pod -l app.kubernetes.io/name=postgres-operator --no-headers | awk '{ print $2 ":" $3 }')" == "2/2:Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function postgres_pods_running() {
+  if [ "$(kubectl get pod -l application=spilo -A --no-headers | awk '{ print $3 ":" $4 }' | sort -u)" == "3/3:Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function postgres_clusters_running() {
+  if [ "$(kubectl get postgresql -A -o json | jq -r '.items[].status.PostgresClusterStatus' | sort -u)" == "Running" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function wait_for() {
+  local command="${1}"
+  local message="${2}"
+  local count=0
+  local total=120
+  local sleep=5
+  while true; do
+    if ${command}; then
+      echo "${message}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}'
+      break
+    else
+      if [ "${count}" -ge "${total}" ]; then
+        echo "ERROR: giving up for ${message} after ${total} attempts"
+        exit 1
+      fi
+      count=$((count + 1))
+      echo "Waiting for ${message}, sleeping for ${sleep} seconds and retry, attempt ${count}/${total} ..."
+      sleep ${sleep}
+    fi
+  done
+}
+
+echo "Waiting for 60 seconds for cray-postgres-operator pod to settle after upgrade ..."
+sleep 60
+wait_for postgres_operator_running "postgres-operator pod running"
+# Only restart postgres clusters in argo, services, spire namespaces - but wait for all clusters (such as sma) to be healthy, as
+# preflight checks at the end of prerequisites script will need all clusters anyway.
+kubectl get sts -A -l application=spilo -o json \
+  | jq -r '.items[] | select(.metadata.namespace == "argo" or .metadata.namespace == "services" or .metadata.namespace == "spire") | (.metadata.namespace + ":" + .metadata.name)' \
+  | while IFS=: read -r namespace sts; do
+    echo "Rolling restart ${sts} in namespace ${namespace} ..."
+    kubectl rollout restart -n "${namespace}" statefulset "${sts}"
+  done
+echo "Waiting for 300 seconds for postgres statefulsets rolling restart to commence ..."
+sleep 300
+wait_for postgres_pods_running "all postgres pods running"
+wait_for postgres_clusters_running "all postgres clusters in state Running"
+echo "State of postgres clusters after operator upgrade:"
+kubectl get postgresql -A

--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -190,10 +190,6 @@ spec:
     source: csm-algol60
     version: 1.6.1
     namespace: services
-  - name: cray-postgres-operator
-    source: csm-algol60
-    version: 1.10.1
-    namespace: services
   - name: cray-kafka-operator
     source: csm-algol60
     version: 1.2.1
@@ -270,15 +266,6 @@ spec:
     source: csm-algol60
     version: 5.1.0
     namespace: argo
-  - name: cray-nls
-    source: csm-algol60
-    version: 5.1.0
-    namespace: argo
-    swagger:
-    - name: nls
-      title: "NCN Lifecycle Service"
-      version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.10/docs/NLS_swagger.yaml
   - name: cray-hnc-manager
     source: csm-algol60
     version: 0.1.1

--- a/manifests/sysmgmt-v1.24.yaml
+++ b/manifests/sysmgmt-v1.24.yaml
@@ -1,0 +1,265 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: manifests/v1beta1
+metadata:
+  name: sysmgmt
+spec:
+  sources:
+    charts:
+    - name: csm-algol60
+      type: repo
+      location: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  charts:
+
+  # HMS
+  # Install any operators first, wait for them to come up before continuing.
+  - name: cray-hms-bss
+    source: csm-algol60
+    version: 3.3.4
+    namespace: services
+    timeout: 10m
+    swagger:
+    - name: bss
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.34.0/api/swagger.yaml
+  - name: cray-hms-capmc
+    source: csm-algol60
+    version: 5.1.2
+    namespace: services
+    swagger:
+    - name: capmc
+      version: v3
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.8.0/api/swagger.yaml
+  - name: cray-hms-firmware-action
+    source: csm-algol60
+    version: 3.2.4
+    namespace: services
+    swagger:
+    - name: firmware-action
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.42.0/api/docs/swagger.yaml
+  - name: cray-hms-hbtd
+    source: csm-algol60
+    version: 3.2.3
+    namespace: services
+    timeout: 10m
+    swagger:
+    - name: hbtd
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hbtd/v1.24.0/api/swagger.yaml
+  - name: cray-hms-hmnfd
+    source: csm-algol60
+    version: 4.1.2
+    namespace: services
+    timeout: 10m
+    swagger:
+    - name: hmnfd
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.25.0/api/swagger_v2.yaml
+  - name: cray-hms-hmcollector
+    source: csm-algol60
+    version: 2.17.3
+    namespace: services
+  - name: cray-hms-scsd
+    source: csm-algol60
+    version: 3.1.3
+    namespace: services
+    swagger:
+    - name: scsd
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-scsd/v1.23.0/api/openapi.yaml
+  - name: cray-hms-rts
+    source: csm-algol60
+    # When updating the version also update cray-hms-rts-snmp
+    version: 5.1.5
+    namespace: services
+  - name: cray-hms-rts
+    releaseName: cray-hms-rts-snmp
+    source: csm-algol60
+    # When updating the version also update cray-hms-rts
+    version: 5.1.5
+    namespace: services
+    values:
+      rtsDoInit: false
+      environment:
+        cray_hms_rts:
+          backend_helper: SNMPSwitch
+  - name: cray-power-control
+    source: csm-algol60
+    version: 2.2.4
+    namespace: services
+    timeout: 10m
+    swagger:
+    - name: power-control
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.12.0/api/swagger.yaml
+
+  # CMS
+  - name: cfs-hwsync-agent
+    source: csm-algol60
+    version: 1.13.0
+    namespace: services
+  - name: cfs-trust
+    source: csm-algol60
+    version: 1.9.1
+    namespace: services
+  - name: cms-ipxe
+    source: csm-algol60
+    version: 1.16.1
+    namespace: services
+  - name: cray-bos
+    source: csm-algol60
+    version: 2.46.0
+    namespace: services
+    timeout: 10m
+    swagger:
+    - name: bos
+      version: v2
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.46.0/api/openapi.yaml.in
+  - name: cray-cfs-api
+    source: csm-algol60
+    version: 1.26.1
+    namespace: services
+    swagger:
+    - name: cfs
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.1/api/openapi.yaml
+  - name: cray-cfs-batcher
+    source: csm-algol60
+    version: 1.13.0
+    namespace: services
+  - name: cray-cfs-operator
+    source: csm-algol60
+    version: 1.31.0
+    namespace: services
+  - name: cray-console-operator
+    source: csm-algol60
+    version: 1.16.1
+    namespace: services
+    swagger:
+    - name: console
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/console-operator/v1.16.1/api/console.md
+    timeout: 20m0s
+  - name: cray-console-node
+    source: csm-algol60
+    version: 2.10.0
+    namespace: services
+    timeout: 20m0s
+  - name: cray-csm-barebones-recipe-install
+    source: csm-algol60
+    version: 2.7.0
+    namespace: services
+    values:
+      cray-import-kiwi-recipe-image:
+        import_image:
+          image:
+            # The following version needs to match the above cray-csm-barebones-recipe-install
+            # version. Due to included helm charts, it needs to be overridden here as well.
+            tag: 2.7.0
+        catalog:
+          image:
+            # The following version is the cray-product-catalog version.
+            # Unless there is a specific reason not to, this version should be
+            # updated whenever the cray-product-catalog chart version is updated, and
+            # vice versa.
+            tag: 2.7.0
+  - name: cray-ims
+    source: csm-algol60
+    version: 3.27.0
+    namespace: services
+    swagger:
+    - name: ims
+      version: v3
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.27.0/api/openapi.yaml
+  - name: cray-tftp
+    source: csm-algol60
+    version: 1.12.0
+    namespace: services
+  - name: cray-tftp-pvc
+    source: csm-algol60
+    version: 1.12.0
+    namespace: services
+  - name: csm-config
+    source: csm-algol60
+    version: 1.37.0
+    namespace: services
+    values:
+      cray-import-config:
+        catalog:
+          image:
+            # The following version is the cray-product-catalog version.
+            # Unless there is a specific reason not to, this version should be
+            # updated whenever the cray-product-catalog chart version is updated, and
+            # vice versa.
+            tag: 2.7.0
+        import_job:
+          initContainers:
+          # This init container will write the desired cray-sat version to vars/main.yml
+          # in the csm.ncn.sat role. This allows the loftsman manifest to specify the
+          # cray-sat container image version, which means the CSM build can set it to match
+          # the version of the container image it packages in the CSM release.
+          - name: set-sat-version
+            # release.sh sets image at CSM distribution build time
+            image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.18"
+            volumeMounts:
+            - mountPath: /shared
+              name: config-overlay
+            env:
+            - name: CRAY_SAT_VERSION
+              # release.sh sets value at CSM release distribution build time
+              value: "csm-latest"
+            command: ['/bin/sh']
+            args:
+            - -c
+            - 'mkdir -p /shared/roles/csm.ncn.sat/vars/ && echo "sat_container_image_version: $CRAY_SAT_VERSION" > /shared/roles/csm.ncn.sat/vars/main.yml'
+
+  - name: csm-ssh-keys
+    source: csm-algol60
+    version: 1.8.0
+    namespace: services
+
+  # Cray Product Catalog
+  - name: cray-product-catalog
+    source: csm-algol60
+    # Unless there is a specific reason not to, this version should be
+    # updated whenever the csm-config catalog image version is updated, and
+    # vice versa.
+    # Also update the catalog:image:tag value in the barebones recipe section.
+    version: 2.7.0
+    namespace: services
+
+  # Tapms service
+  - name: cray-tapms-crd
+    source: csm-algol60
+    version: 1.9.1
+    namespace: tapms-operator
+  - name: cray-tapms-operator
+    source: csm-algol60
+    version: 1.9.1
+    namespace: tapms-operator
+    swagger:
+    - name: tapms-operator
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-tapms-operator/v1.8.0/docs/openapi.yaml

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -131,6 +131,23 @@ fi
 deploy "${BUILDDIR}/manifests/${storage_yaml}"
 echo "Deployment of ceph csi provisioners is complete."
 echo "PVC movement will resume when all ceph csi pods are finished starting."
+if [ "${K8SVER}" = "v1.32" ]; then
+    # Update postgres operator crds before upgrading the operator
+    postgres_chart_path=$(find "${ROOTDIR}/helm" -name "cray-postgres-operator*.tgz")
+    if [[ -z $postgres_chart_path ]]; then
+      echo "Error: failed to find cray-postgres-operator chart in ${ROOTDIR}/helm."
+      exit 1
+    fi
+    # check if file exists before applying crds, needed for backwards compatibility
+    if tar -tf "$postgres_chart_path" cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml > /dev/null 2>&1; then
+      # create CRDs for cray-postgres-operator, this is necessary when postgres is upgraded to 1.10.1 in CSM 1.7
+      tar --extract --file="$postgres_chart_path" --to-stdout cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml | kubectl apply -f -
+      # 5 second sleep is necessary for cray-postgres-operator chart deploy. Chart fails with CRD error if no sleep
+      sleep 5
+    else
+      echo "Warning: File 'cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml' does not exist in $postgres_chart_path"
+    fi
+fi
 deploy "${BUILDDIR}/manifests/${platform_yaml}"
 deploy "${BUILDDIR}/manifests/${keycloak_gatekeeper_yaml}"
 
@@ -175,6 +192,11 @@ deploy "${BUILDDIR}/manifests/${sysmgmt_yaml}"
 # undeploy of spire.
 kubectl patch daemonsets.apps -n spire request-ncn-join-token --type='json' -p='[{"op": "replace", "path": '/spec/template/spec/serviceAccountName', "value":"default"}]'
 undeploy -n spire spire
+
+if [ "${K8SVER}" = "v1.32" ]; then
+    # Wait for postgres pods to be running after upgrading postgres operator
+    "${ROOTDIR}/lib/fix-postgres.sh"
+fi
 
 # Ensure updated pre-cache images have been pulled on each NCN worker,
 # otherwise the Nexus upgrade may not be successful. This should be relatively

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -135,7 +135,7 @@ if [ "${K8SVER}" = "v1.32" ]; then
     # Update postgres operator crds before upgrading the operator
     postgres_chart_path=$(find "${ROOTDIR}/helm" -name "cray-postgres-operator*.tgz")
     if [[ -z $postgres_chart_path ]]; then
-      echo "Error: failed to find cray-postgres-operator chart in ${ROOTDIR}/helm."
+      echo >&2 "Error: failed to find cray-postgres-operator chart in ${ROOTDIR}/helm."
       exit 1
     fi
     # check if file exists before applying crds, needed for backwards compatibility
@@ -145,7 +145,7 @@ if [ "${K8SVER}" = "v1.32" ]; then
       # 5 second sleep is necessary for cray-postgres-operator chart deploy. Chart fails with CRD error if no sleep
       sleep 5
     else
-      echo "Warning: File 'cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml' does not exist in $postgres_chart_path"
+      echo >&2 "Warning: File 'cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml' does not exist in $postgres_chart_path"
     fi
 fi
 deploy "${BUILDDIR}/manifests/${platform_yaml}"


### PR DESCRIPTION
## Summary and Scope

In CSM 1.7.0, we upgrade postgres operator version. However, we need to defer it until the final upgrade as some service charts need to be running at an earlier version (therefore with the older postgres operator) to work with Kubernetes 1.24. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7587](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7587)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

