### PR TITLE
CASMINST-7104, CASM-4572 updating nls and iuf-cli versions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -267,11 +267,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.0
+    version: 5.1.1
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.0
+    version: 5.1.1
     namespace: argo
     swagger:
     - name: nls

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -57,7 +57,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.7.0-1.x86_64
+    - iuf-cli-1.7.1-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
     - metal-init-1.4.11-1.noarch


### PR DESCRIPTION
## Summary and Scope

updating iuf-cli rpm to 1.7.1 and nls chart to 5.1.1

## Issues and Related PRs

* Resolves [CASMINST-7104](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7104),  [CASM-4572](https://jira-pro.it.hpe.com:8443/browse/CASM-4572)


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

