### PR TITLE
CASMINST-7294 - fix file ownership for console-node aggregation files.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -172,7 +172,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.10.0
+    version: 2.10.1
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install


### PR DESCRIPTION
## Summary and Scope

There is an edge case with systems that have been only upgraded since before csm-1.2.

## Issues and Related PRs
* Resolves [CASMINST-7294](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7294)

## Testing
### Tested on:
  * `Rocket`

### Test description:

I installed the new version via helm and ensured that the files correctly changed ownership to nobody user and the aggregation data started flowing as it is supposed to. Rocket is the only system that was in this state that we have.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

