### PR TITLE
CASMPET-7598 :adding .done files

### DIFF
--- a/hooks/deploy-product-onexit.sh
+++ b/hooks/deploy-product-onexit.sh
@@ -26,67 +26,104 @@
 echo "INFO Running Onexit handler for deploy product"
 . /etc/cray/upgrade/csm/myenv
 
-echo "INFO Upgrading weave and multus"
-/srv/cray/scripts/common/apply-networking-manifests.sh
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to upgrade weave and multus"
-    exit 1
+DONE_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}"
+
+if [[ -f "$DONE_DIR/apply-networking-manifests.done" ]]; then
+    echo "INFO weave and multus upgrade already completed, skipping."
 else
-    echo "INFO Successfully upgraded weave and multus"
+    echo "INFO Upgrading weave and multus"
+    /srv/cray/scripts/common/apply-networking-manifests.sh
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to upgrade weave and multus"
+        exit 1
+    else
+        touch "$DONE_DIR/apply-networking-manifests.done"
+        echo "INFO Successfully upgraded weave and multus"
+    fi
 fi
 
-echo "INFO Upgrading coredns anti-affinity"
-/usr/share/doc/csm/upgrade/scripts/k8s/apply-coredns-pod-affinity.sh
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to upgrade coredns anti-affinity"
-    exit 1
+if [[ -f "$DONE_DIR/apply-coredns-pod-affinity.done" ]]; then
+    echo "INFO coredns anti-affinity upgrade already completed, skipping."
 else
-    echo "INFO Successfully upgraded coredns anti-affinity"
+    echo "INFO Upgrading coredns anti-affinity"
+    /usr/share/doc/csm/upgrade/scripts/k8s/apply-coredns-pod-affinity.sh
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to upgrade coredns anti-affinity"
+        exit 1
+    else
+        touch "$DONE_DIR/apply-coredns-pod-affinity.done"
+        echo "INFO Successfully upgraded coredns anti-affinity"
+    fi
 fi
 
-echo "INFO Starting the kubernetes control plane upgrade"
-/usr/share/doc/csm/upgrade/scripts/k8s/upgrade_control_plane.sh
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to upgrade kubernetes control plane"
-    exit 1
+if [[ -f "$DONE_DIR/upgrade_control_plane.done" ]]; then
+    echo "INFO kubernetes control plane upgrade already completed, skipping."
 else
-    echo "INFO Successfully upgraded kubernetes control plane"
+    echo "INFO Starting the kubernetes control plane upgrade"
+    /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_control_plane.sh
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to upgrade kubernetes control plane"
+        exit 1
+    else
+        touch "$DONE_DIR/upgrade_control_plane.done"
+        echo "INFO Successfully upgraded kubernetes control plane"
+    fi
 fi
 
-echo "INFO Starting the kubernetes upgrade to v1.29"
-/usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.27.16 1.28.15 1.29.15"
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to upgrade kubernetes to v1.29"
-    exit 1
+if [[ -f "$DONE_DIR/upgrade_k8s_1_29.done" ]]; then
+    echo "INFO kubernetes upgrade to v1.29 already completed, skipping."
 else
-    echo "INFO Successfully upgraded kubernetes to v1.29"
+    echo "INFO Starting the kubernetes upgrade to v1.29"
+    /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.27.16 1.28.15 1.29.15"
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to upgrade kubernetes to v1.29"
+        exit 1
+    else
+        touch "$DONE_DIR/upgrade_k8s_1_29.done"
+        echo "INFO Successfully upgraded kubernetes to v1.29"
+    fi
 fi
 
-echo "INFO Deploying manifests for v1.29"
-/usr/share/doc/csm/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to deploy manifests for v1.29"
-    exit 1
+if [[ -f "$DONE_DIR/deploy_charts_post_k8s_upgrade.done" ]]; then
+    echo "INFO deploy manifests for v1.29 already completed, skipping."
 else
-    echo "INFO Successfully deployed manifests for v1.29"
+    echo "INFO Deploying manifests for v1.29"
+    /usr/share/doc/csm/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to deploy manifests for v1.29"
+        exit 1
+    else
+        touch "$DONE_DIR/deploy_charts_post_k8s_upgrade.done"
+        echo "INFO Successfully deployed manifests for v1.29"
+    fi
 fi
 
-echo "INFO Starting the kubernetes upgrade to v1.32"
-/usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.30.12 1.31.8 1.32.5"
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to upgrade kubernetes to v1.32"
-    exit 1
+if [[ -f "$DONE_DIR/upgrade_k8s_1_32.done" ]]; then
+    echo "INFO kubernetes upgrade to v1.32 already completed, skipping."
 else
-    echo "INFO Successfully upgraded kubernetes to v1.32"
+    echo "INFO Starting the kubernetes upgrade to v1.32"
+    /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.30.12 1.31.8 1.32.5"
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to upgrade kubernetes to v1.32"
+        exit 1
+    else
+        touch "$DONE_DIR/upgrade_k8s_1_32.done"
+        echo "INFO Successfully upgraded kubernetes to v1.32"
+    fi
 fi
 
-echo "INFO Remove upgrade and upgrade_version file creation from BSS for masters and workers."
-/usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.sh
-if [[ $? -ne 0 ]]; then
-  echo "ERROR Failed to update BSS to remove upgrade and upgrade_version."
-  exit 1
+if [[ -f "$DONE_DIR/cleanup_bss.done" ]]; then
+    echo "INFO BSS cleanup already completed, skipping."
 else
-  echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
+    echo "INFO Remove upgrade and upgrade_version file creation from BSS for masters and workers."
+    /usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.sh
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR Failed to update BSS to remove upgrade and upgrade_version."
+        exit 1
+    else
+        touch "$DONE_DIR/cleanup_bss.done"
+        echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
+    fi
 fi
 
 echo "INFO Deploying manifests for v1.32"
@@ -99,5 +136,8 @@ else
     popd +0
     echo "INFO Successfully deployed manifests for v1.32"
 fi
+
+# If all steps succeeded, remove all .done files
+rm -f "$DONE_DIR"/*.done
 
 echo "INFO Onexit handler for deploy product completed"


### PR DESCRIPTION
## Summary and Scope

Adding done files in deploy product on-exit script to avoid unnecessary repetition of steps during k8s upgrade.

Resolves [CASMPET-7598](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7598)
## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

