### PR TITLE
CASMHMS-6302: Fixed missing supported power transitions bug in PCS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -107,13 +107,13 @@ spec:
           backend_helper: SNMPSwitch
   - name: cray-power-control
     source: csm-algol60
-    version: 2.2.4
+    version: 2.2.5
     namespace: services
     timeout: 10m
     swagger:
     - name: power-control
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.12.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-power-control/v2.13.0/api/swagger.yaml
 
   # CMS
   - name: cfs-ara


### PR DESCRIPTION
### Summary and Scope

#### Background and Context

The genesis of the problem being fixed stems from critical data intermittantly going missing from redfish on Gigabyte BMCs.  This is a known problem, and we even have docs-csm documentation covering it:

- [Gigabyte_BMC_Missing_Redfish_Data.md](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/troubleshooting/known_issues/Gigabyte_BMC_Missing_Redfish_Data.md)

The missing data in this case was the `AllowableValues` array in the following redfish structure:

```bash
> curl -sk -u root:${PASSWD} https://x3000c0s28b0/redfish/v1/Managers/Self/ResetActionInfo | jq .Parameters[]
{
  "AllowableValues": [
    "ForceRestart"
  ],
  "DataType": "String",
  "Name": "ResetType",
  "Required": true
}
```

When `discover` is run against a BMC missing this data, SMD will fail to populate the `ResetType@Redfish.AllowableValues` array in the following `componentEndpoint` structure:

```bash
> cray hsm inventory componentEndpoints describe --format json x3000c0s28b0 | jq .RedfishManagerInfo.Actions
{
  "#Manager.Reset": {
    "ResetType@Redfish.AllowableValues": [
      "ForceRestart"
    ],
    "@Redfish.ActionInfo": "/redfish/v1/Managers/Self/ResetActionInfo",
    "target": "/redfish/v1/Managers/Self/Actions/Manager.Reset"
  },
  "Oem": {}
}
```

When PCS retrieves a new `componentEndpoint` from SMD that is missing this data, it will fail to populate the `supportedPowerTransitions` array in the following status structure:

```bash
> cray power status describe x3000c0s28b0 --format json | jq
{
  "status": [
    {
      "xname": "x3000c0s28b0",
      "powerState": "on",
      "managementState": "available",
      "error": "",
      "supportedPowerTransitions": [
        "Soft-Restart"
      ],
      "lastUpdated": "2025-06-11T20:37:01.581816169Z"
    }
  ]
}
```

#### Problem Definition

If `supportedPowerTransitions` is missing for any component, PCS cannot create power transitions for it.

Additionally, if the redfish data later becomes present and discover is then run against it, SMD will correctly populate the `supportedPowerTransitions` array.  However, PCS will not synchronize this change with the `supportedPowerTransitions` field it maintains for the component in etcd.  It does update its in-memory copy correctly, but does not push the in-memory change into etcd because it only does so if a component's power or management state changes.  PCS always retrieves the `supportedPowerTransitions` array from etcd when returning power status to the user and when attempting to create new power transitions.  It does not reference the in-memory copy (and can't because only one replica maintains an in-memory copy).

#### Problem Solution

The only place to detect and correct the issue for the in-memory copy is in `updateComponentMap()`.

The second step is updating peristent memory in etcd, which is done in the `updateHWState()` routine.  But, as mentioned above, if power or management states do not change it will not push an update to etcd. Neither of these states ever change for node BMCs.

After `updateComponentMap()` returns to the `monitorHW()` goroutine, `getHWStatesFromHW()` is immediately called and from there `updateHWState()` is called for each component.

I first attempted to modify `updateHWState()` to detect changes to the in-memory version of the `supportedPowerTransitions` array and then force an etcd update even if the power and management states didn't change.  However, it quickly became obvious that this wouldn't be possible without more significant changes that might include changing the function signature and/or modifying associated data structures to force an update.

To keep the fix simple and incur less risk, I opted to have `updateComponentMap()` directly call `updateHWState()` for any node BMC that it detects this issue on.  To force an etcd write, `updateComponentMap()` requests that `updateHWState()` change the power and management states to "undefined", which will also cause an update to the `supportedPowerTransitions` array in etcd.  This is fine, because we're guaranteed that `updateHWState()` will be called again shortly after by the `monitorHW()` -> `getHWStatesFromHW()` -> `updateHWState()` path, with the corrected power and management states.  PCS already does something similar when it has communication issues with BMCs (it sets their nodes to have "undefined" states until the BMC resumes communication).

The image and module dependencies were also updated as part of this PR.

Adopted app version 2.13.0 for CSM 1.7.0 (helm chart 2.2.5).

### Issues and Related PRs

* Resolves [CASMHMS-6302](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6302)

### Testing

Tested on:

* `gamora`

Test description:

I tested on gamora since it had about a dozen Gigabyte BMC's with missing `AllowableValues` in SMD and `supportedPowerTransitions` in PCS.

The `AllowableValues` data was now present in all of the BMC's redfish, so I ran discover against a few of them.  After doing this, the `AllowableValues` data then became present in SMD.  However, `supportedPowerTransitions` was still missing in PCS.

I then put the PCS fix in place and repeated the `discover` on a few other BMCs.  In addition to the data correctly populating in SMD, it now also correctly populated in PCS and PCS's etcd backing store.

I had debug logging in place to ensure all the correct paths were being taken.

Finally, I ran CT tests and observed all tests passing.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

