### PR TITLE
CASMPET-7597: intermediate chart upgrade

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -244,12 +244,8 @@ spec:
     namespace: services
   - name: cray-metallb
     source: csm-algol60
-    version: 1.2.2   # DO NOT UPDATE cray-metallb version that works with K8s 1.24
+    version: 2.0.3
     namespace: metallb-system
-    values:
-      metallb:
-        psp:
-          create: false
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
     version: 0.2.3
@@ -266,6 +262,15 @@ spec:
     source: csm-algol60
     version: 5.1.0
     namespace: argo
+  - name: cray-nls
+    source: csm-algol60
+    version: 4.1.3
+    namespace: argo
+    swagger:
+    - name: nls
+      title: "NCN Lifecycle Service"
+      version: v1
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-nls/v0.10.10/docs/NLS_swagger.yaml
   - name: cray-hnc-manager
     source: csm-algol60
     version: 0.1.1

--- a/manifests/sysmgmt-v1.24.yaml
+++ b/manifests/sysmgmt-v1.24.yaml
@@ -250,6 +250,12 @@ spec:
     version: 2.7.0
     namespace: services
 
+  # Spire service
+  - name: cray-spire
+    source: csm-algol60
+    version: 1.7.7
+    namespace: spire
+
   # Tapms service
   - name: cray-tapms-crd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

We had a few charts (including cray-nls, cray-spire, and metallb) that ran into upgrade issues when k8s is at 1.32, due to various reasons (removal of deprecated k8s apis, psp removal, etc.) This PR upgrades those charts to either intermediate or latest versions when k8s is still at 1.24 to resolve the issues. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7597](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7597)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `wasp`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. Verified on both bare-metal and vshasta.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

