### PR TITLE
CASMTRIAGE-8296: exclude pre-upgrade pods in etcd pod count

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -64,7 +64,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-ipxe-2.7.0-1.noarch
     - metal-nexus-1.7.0-3.70.4.x86_64
     - metal-observability-1.1.0-1.x86_64
-    - platform-utils-1.8.2-1.noarch
+    - platform-utils-1.8.3-1.noarch
     - python3-liveness-1.4.4-1.noarch
     - python3-requests-retry-session-0.1.8-1.noarch
     - python3-requests-retry-session-0.2.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

Use platform-utils 1.8.3 to exclude pre-upgrade pods in etcd pod count.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8296](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8296)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

