### PR TITLE
CASMSEC-574,573,571: Modify k8s Registry in ceph-nodeplugin exceptions, IUF management-node-rollout stage & cos-config-service exceptions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,7 +111,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.15
+    version: 1.7.16
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,7 +111,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.14
+    version: 1.7.15
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

CASMSEC-574: With a recent update to ceph-nodeplugin, the k8s registry was changed. Hence, changing that in the images section of the respective policy as well.
CASMSEC-573: A recent IUF run of management-node-rollout stage including rebuild and reboot stage was tested to check if further exceptions are required. It was found that two more exceptions were required for IUF. This has been added in this PR.

## Issues and Related PRs

Resolves [CASMSEC-574](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-574)
Resolves [CASMSEC-573](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-573)

## Testing
### Tested on:
*`wasp` for CASMSEC-574
*`fanta` for CASMSEC-573

### Test description:

Upgrade, Rollback Tested
[CASMSEC-574-wasp.txt](https://github.com/user-attachments/files/20773517/CASMSEC-574-wasp.txt)
IUF stage tested with exception
[CASMSEC-573-FANTA.txt](https://github.com/user-attachments/files/20774236/CASMSEC-573-FANTA.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

