### PR TITLE
CASMHMS-6557: Fix RTS issue where HTTP server should be started immed…

### DIFF
--- a/manifests/sysmgmt-v1.24.yaml
+++ b/manifests/sysmgmt-v1.24.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.1.5
+    version: 5.1.7
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.1.5
+    version: 5.1.7
     namespace: services
     values:
       rtsDoInit: false

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.1.5
+    version: 5.1.7
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.1.5
+    version: 5.1.7
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
### Summary and Scope

During an upgrade test on wasp, the cray-hms-rts-snmp pods were observed to be continually restarted by kubernetes due to the liveness and readiness probes timing out.  Upon further investigation, this issue seems to have been caused by a change in the [CASMHMS-6415](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6415) PR [52](https://github.com/Cray-HPE/hms-redfish-translation-layer/pull/52).  One of those changes delayed starting the HTTP server until after all initialization was complete.  This was done because handling incoming requests before initialization completed resulted in the following errors within RTS and an error would be returned for the incoming request:

```
... handleRequest Could not authenticate account for username   err="Account with provided user name does not exist" username=testuser xname=x3000c0w28
... handleRequest Could not authenticate account for username   err="Account with provided user name does not exist" username=testuser xname=x3000c0h24s1
... handleRequest Could not authenticate account for username   err="Account with provided user name does not exist" username=testuser xname=x3000c0h24s2
```

However, by doing this it made us susceptible to the problem encountered on wasp.  There appears to be conditions when initialization can take an extended amount of time.  Since the HTTP server isn't started until after initialization is complete, it can't handle the incoming liveness and readiness probes, and the pod gets continually restarted.

The fix is simply to revert the changes made as part of the [CASMHMS-6415](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6415) PR.  RTS will return failures to incoming requests that can't yet be handled due to initialization not yet being complete, but it will be able to respond to liveness and readiness probes.  This appears to have never been an issue previously, as this behavior was present in `cray-hms-rts-snmp` since it was created.

I will note that an alternative fix would be to start the HTTP server early and have it only support handling incoming liveness and readiness requests.  Then, after initalization is complete, add handlers for all other requests.  Unfortunately, adding dynamic routing wouldn't be possible without moving RTS to a different router like `gorilla/mux` or `chi`.  While that's the better technical path, it requires quite a bit of code churn which adds risk which we're trying to avoid at this point in the product life.

Also updated image and module dependencies for security updates.

Adopted app version 1.31.0 for CSM 1.7.0 (helm chart 5.1.7)

### Issues and Related PRs

* Resolves [CASMHMS-6557](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6557)

### Testing

I was unable to reproduce the problem which was previous observed on both fanta and wasp.  There appear to be conditions under which initialization may take excessive time but it is unknown how to reproduce these situations.  I did put the code changes in place and verified by watching the RTS logs that functionality was reverted to prior behavior.

Tested on:

* `fanta`
* `wasp`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

