### PR TITLE
CASMNET-2329 - IPv6 Network attachment definition for DNS and LDAPS

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -74,11 +74,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.9.0 # update platform.yaml cray-precache-images with this
+    version: 0.10.0 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.9.0
+        appVersion: 0.10.0
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -102,7 +102,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # DNS for K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.9.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -83,7 +83,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.9.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
@@ -215,7 +215,7 @@ spec:
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.2.1
+    version: 5.3.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR adds limited IPv6 support for the `cray-dns-unbound` and `cray-keycloak` services. The scope is limited to enabling access to upstream DNS and LDAP servers over IPv6.

CSM does not (yet) deploy Kubernetes in dual-stack mode so this is achieved by creating a macvlan Multus NetworkAttachmentDefinition which is bound to the Customer Management Network (CMN) interface and attached to the Keycloak and Unbound Pods allowing them direct access to an IPv6 network.

## Issues and Related PRs

* Resolves CASMNET-2329
* Documentation changes required in [CASMNET-2342](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2342)

## Testing

### Tested on:

  * `surtur`

### Test description:

Please see component PRs for testing performed

* cray-dns-unbound - https://github.com/Cray-HPE/cray-dns-unbound/pull/99
* cray-keycloak - https://github.com/Cray-HPE/cray-keycloak/pull/2

## Risks and Mitigations

This feature targets a limited number of customers and is disabled by default.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

