### PR TITLE
CASMSEC-576,578: velero-node-plugin exceptions, cilium-argo-upgrade exceptions

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,7 +111,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.17
+    version: 1.7.18
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,7 +111,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.16
+    version: 1.7.17
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

As velero updated recently, the velero-node-agent DaemonSet required more exceptions for hostPath volumes. This PR adds the exceptions.

## Issues and Related PRs

Resolves [CASMSEC-576](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-576)
Resolves [CASMSEC-578](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-578)

## Testing

### Tested on:

  * `surtur`
  * `wasp`

### Test description:

- Install, Upgrade, Rollback tested
- velero upgrade
[CASMSEC-576-surtur.txt](https://github.com/user-attachments/files/20876970/CASMSEC-576-surtur.txt)
[CASMSEC-578-wasp.txt](https://github.com/user-attachments/files/20915440/CASMSEC-578-wasp.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable TBD

