### PR TITLE
CASMPET-7604 postgres CRD install/upgrade fix

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -195,7 +195,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.10.1
+    version: 1.10.2
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
This pulls in a version of the cray-postgres-operator chart, where the top level CRDs have been moved from the /files directory to the /crds directory.  With this change, and initial install will now use the CRDs in the /crds directory, instead of the /charts/postgres-operator/crds directory.  The difference between them is that the /crds version enables patroni failsafe mode.

## Issues and Related PRs

* Resolves [CASMPET-7604](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7604)
* Change will also be needed in `docs-csm`
* Merge after https://github.com/Cray-HPE/cray-postgres-operator/pull/24

## Testing

### Tested on:
  * `sigma7` (Mercury test system with CSM 1.6 manifests)

### Test description:
The modified chart was deployed as a clean install, and then the CRD was checked to verify that the patroni failsafe mode is enabled. Prior to this change, on a clean install the patroni failsafe mode was disabled.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
In `docs-csm` the `prerequisites.sh` script needs to be modified to know about the new location for the CRDs in the chart

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

