### PR TITLE
Manifest PR for CASMTRIAGE-8171 fix

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -76,7 +76,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python312-requests-retry-session-0.2.4-1.noarch
     - python39-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.2.4-1.noarch
-    - sbps-marshal-0.0.14-1.noarch
+    - sbps-marshal-1.0.1-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.12.aarch64
     - spire-agent-1.5.5-1.12.x86_64


### PR DESCRIPTION
## Summary and Scope

This is to install the iSCSI SBPS Marshal agent RPM sbps-marshal-1.0.1-1.noarch having the fix for CASMTRIAGE-8171.

## Issues and Related PRs
For the complete fix, we need to have below fix as the fix is spread across csm-config repo (ansible plays) and iSCSI SBPS marshal agent. 
https://github.com/Cray-HPE/csm-config/pull/370

* Resolves [issue id](issue link): CASMTRIAGE-8171
* Change will also be needed in `<insert branch name here>`: N/A 
* Future work required by [issue id](issue link): N/A
* Documentation changes required in [issue id](issue link): N/A
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
CASMTRIAGE-8171 has all the details where the fix is tested on Lemondrop. 

### Tested on:
Lemondrop

### Test description:
Unit test results are uploaded to the CASMTRIAGE-8171 ticket. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: Yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: TBD
- Was downgrade tested? If not, why?: N/A
- Were new tests (or test issues/Jiras) created for this change?: N/A

## Risks and Mitigations
None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

