### PR TITLE
CASMSEC-577: Errors displayed after csm only upgrade

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -130,6 +130,10 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
+  - name: cray-kyverno
+    source: csm-algol60
+    version: 1.7.6
+    namespace: kyverno
   - name: cray-velero
     source: csm-algol60
     version: 1.6.3-3

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -107,7 +107,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.7.5
+    version: 1.7.6
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -103,16 +103,6 @@ if [ "${K8SVER}" = "v1.24" ]; then
     bash +o pipefail -c "kubectl get crd | grep victoriametrics.com | awk '{ print \$1 }' | xargs -i kubectl delete crd {}"
 fi
 
-# Need to undeploy kyverno at K8s 1.24 before upgrading to K8s 1.32
-if [ "${K8SVER}" = "v1.24" ]; then
-    echo "Removing cray-kyverno-policies-upstream chart ..."
-    undeploy -n kyverno cray-kyverno-policies-upstream
-    echo "Removing kyverno-policy chart ..."
-    undeploy -n kyverno kyverno-policy
-    echo "Removing cray-kyverno chart ..."
-    undeploy -n kyverno cray-kyverno
-fi
-
 # Select manifests are we deploying
 core_services_yaml=$(select_manifest_file core-services)
 keycloak_gatekeeper_yaml=$(select_manifest_file keycloak-gatekeeper)


### PR DESCRIPTION
## Summary and Scope

This change helps to upgrade Kyverno without PSPs at k8s 1.24 stage which is currently happening for CSM 1.7.0 release.

## Testing

Upgrade testing.

### Tested on:

Molly

### Test description:

[mollyTestLogs.txt](https://github.com/user-attachments/files/20915366/mollyTestLogs.txt)
