### PR TITLE
CASMTRIAGE-8342 , CASMTRIAGE-8345 Update cray-nls helm chart to 5.1.2

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -268,7 +268,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.2
     namespace: argo
     swagger:
     - name: nls

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -271,7 +271,7 @@ spec:
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.2
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

CASMTRIAGE-8342 Make rollout as default ManagementRolloutStrategy

CASMTRIAGE-8345: skip management-nodes-rollout prehook in ManagementRolloutStrategy reboot

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8342](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8342)
* Resolves [CASMTRIAGE-8342](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8345)

* Merge after (https://github.com/Cray-HPE/cray-nls-charts/pull/78)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

