### PR TITLE
CASMTRIAGE-8353: Updated image-verification-policy chart to include USS exceptions

### DIFF
--- a/manifests/kyverno-policy.yaml
+++ b/manifests/kyverno-policy.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: image-verification-policy
     source: csm-algol60
-    version: 1.0.3
+    version: 1.0.4
     namespace: kyverno


### PR DESCRIPTION
## Summary and Scope

A few USS images that are being shipped doesn't have signatures. Exceptions are added to the resources that use those images.
New exceptions:
*munge*
*slurmdb*
Removed a duplicate exception:
*slurmdbd*

## Related Jira:

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8353
## Testing

Tested the new chart by upgrading and fresh installing the helm chart

### Tested on:
  * Wasp
### Test description: 
[arti-image-verification-1_0_4-install-logs.txt](https://github.com/user-attachments/files/20929720/arti-image-verification-1_0_4-install-logs.txt)
[arti-image-verification-1_0_4-upgrade-logs.txt](https://github.com/user-attachments/files/20929747/arti-image-verification-1_0_4-upgrade-logs.txt)



