### PR TITLE
CASMTRIAGE-8333 Bump csm-sbps-utils to 2.0.1

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -46,7 +46,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-1.8.0-1.noarch
     - csm-ssh-keys-roles-1.7.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
-    - csm-sbps-utils-2.0-1.noarch
+    - csm-sbps-utils-2.0.1-1.noarch
     - csm-testing-1.19.21-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

Bump `csm-sbps-utils` RPM version to `2.0.1` to address CASMTRIAGE-8333.

## Issues and Related PRs

* Resolves CASMTRIAGE-8333

## Testing

Tested on `starlord`.

### Tested on:

  * `starlord`

### Test description:

> We used it last night to help the system move through.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

