### PR TITLE
CASMTRIAGE-8340: Include platform-utils 1.7.1

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -64,6 +64,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-ipxe-2.7.0-1.noarch
     - metal-nexus-1.7.0-3.70.4.x86_64
     - metal-observability-1.1.0-1.x86_64
+    - platform-utils-1.7.1-1.noarch
     - platform-utils-1.8.3-1.noarch
     - python3-liveness-1.4.4-1.noarch
     - python3-requests-retry-session-0.1.8-1.noarch


### PR DESCRIPTION
## Summary and Scope

Bundle `platform-utils` 1.7.1 as part of CSM so it's available during the upgrade. This is necessary to include a backported bugfix that's in 1.8.3, but which we are unable to install pre-upgrade due to a Python 3.11 dependency in 1.8.3.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8340](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8340)

## Testing

### Tested on:

  * `drax`

### Test description:

We attempted to install `platform-utils` 1.8.3 on drax, which failed, as expected. We then installed 1.7.1, which succeeded.

```
ncn-m001:~/studenym # rpm -qa platform-utils
platform-utils-1.7.0-1.noarch
ncn-m001:~/studenym # rpm -Uhv platform-utils-1.8.3-1.noarch.rpm
error: Failed dependencies:
	python311-boto3 is needed by platform-utils-1.8.3-1.noarch
ncn-m001:~/studenym # rpm -Uhv platform-utils-1.7.1-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:platform-utils-1.7.1-1           ################################# [ 50%]
Cleaning up / removing...
   2:platform-utils-1.7.0-1           ################################# [100%]
ncn-m001:~/studenym # rpm -Uhv --oldpackage platform-utils-1.7.0-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:platform-utils-1.7.0-1           ################################# [ 50%]
Cleaning up / removing...
   2:platform-utils-1.7.1-1           ################################# [100%]
ncn-m001:~/studenym # rpm -qa platform-utils
platform-utils-1.7.0-1.noarch
```

## Risks and Mitigations

As 1.7.1 includes a single backported fix, the blast radius should be pretty low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable