### PR TITLE
CASMCMS-9466: Reverting back python module updates made in tag `aee``1.19.0` to resolve ansible-core dependency issues with target.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.32.0
+    version: 1.33.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
CASMCMS-9466: Reverting back python module updates made in tag `aee``1.19.0` to resolve ansible-core dependency issues with target.