### PR TITLE
Manifest PR for csm-testing repo

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,7 +48,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.7.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.1-1.noarch
-    - csm-testing-1.19.21-1.noarch
+    - csm-testing-1.19.26-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -52,7 +52,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.21-1.noarch
+    - goss-servers-1.19.26-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

This is the manifest PR for 'csm-testing' rpm having fix for CASMTRIAGE-8343 to be installed. 

## Issues and Related PRs
CASMTRIAGE-8343

* Resolves [issue id](issue link): CASMTRIAGE-8343
* Change will also be needed in `<insert branch name here>`: N/A 
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): N/A
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
As mentioned in CASMTRIAGE-8343, tested on Lemondrop. 

### Tested on:
Lemondrop

### Test description:
As mentioned in CASMTRIAGE-8343 testing by running ncn-health checks which will trigger goss tests for iSCSI SBPS on all worker nodes and also running goss tests individual on single worker node. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: Yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?; TBD
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: No 

## Risks and Mitigations
None. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable