### PR TITLE
CASMCMS-9468/CASMCMS-9298/CASMCMS-9479: Update/pin CMS service dependencies

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,21 +134,21 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.48.1
+    version: 2.48.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.48.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.48.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.26.3
+    version: 1.27.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.3/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.27.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.13.1
@@ -250,7 +250,7 @@ spec:
 
   - name: gitea
     source: csm-algol60
-    version: 2.9.0
+    version: 2.9.1
     namespace: services
 
   # Cray Product Catalog

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -122,11 +122,11 @@ spec:
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.14.0
+    version: 1.14.1
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.9.1
+    version: 1.9.2
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -134,24 +134,24 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.48.0
+    version: 2.48.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.48.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.48.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.26.2
+    version: 1.26.3
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.26.3/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.13.0
+    version: 1.13.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
@@ -192,7 +192,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.7.0
+            tag: 2.7.1
   - name: cray-ims
     source: csm-algol60
     version: 3.30.0
@@ -221,7 +221,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.7.0
+            tag: 2.7.1
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -245,7 +245,7 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.8.0
+    version: 1.8.1
     namespace: services
 
   - name: gitea
@@ -260,7 +260,7 @@ spec:
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
     # Also update the catalog:image:tag value in the barebones recipe section.
-    version: 2.7.0
+    version: 2.7.1
     namespace: services
 
   # Spire service

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -25,13 +25,13 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
   rpms:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
-    - bos-reporter-3.3.3-1.noarch
+    - bos-reporter-3.3.4-1.noarch
     - cani-0.4.0-1.x86_64
     - canu-1.9.13-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
-    - cfs-debugger-1.10.2-1.noarch
-    - cfs-state-reporter-1.12.3-1.noarch
-    - cfs-trust-1.9.1-1.noarch
+    - cfs-debugger-1.10.3-1.noarch
+    - cfs-state-reporter-1.12.4-1.noarch
+    - cfs-trust-1.9.2-1.noarch
     - cray-cmstools-crayctldeploy-1.33.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-1.36.10-1.x86_64
@@ -44,8 +44,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.8-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-scripts-dracut-2.0-1.noarch
-    - csm-ssh-keys-1.8.0-1.noarch
-    - csm-ssh-keys-roles-1.7.1-1.noarch
+    - csm-ssh-keys-1.8.1-1.noarch
+    - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.1-1.noarch
     - csm-testing-1.19.21-1.noarch
@@ -70,14 +70,29 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python3-liveness-1.4.4-1.noarch
     - python3-requests-retry-session-0.1.8-1.noarch
     - python3-requests-retry-session-0.2.4-1.noarch
+    - python3-requests-retry-session-0.5.4-1.noarch
     - python310-requests-retry-session-0.1.8-1.noarch
     - python310-requests-retry-session-0.2.4-1.noarch
+    - python310-requests-retry-session-0.5.4-1.noarch
+    - python310-requests-retry-session-1.0.4-1.noarch
+    - python310-requests-retry-session-2.0.3-1.noarch
     - python311-requests-retry-session-0.1.8-1.noarch
     - python311-requests-retry-session-0.2.4-1.noarch
+    - python311-requests-retry-session-0.5.4-1.noarch
+    - python311-requests-retry-session-1.0.4-1.noarch
+    - python311-requests-retry-session-2.0.3-1.noarch
+    - python311-requests-retry-session-3.0.0-1.noarch
     - python312-requests-retry-session-0.1.8-1.noarch
     - python312-requests-retry-session-0.2.4-1.noarch
+    - python312-requests-retry-session-0.5.4-1.noarch
+    - python312-requests-retry-session-1.0.4-1.noarch
+    - python312-requests-retry-session-2.0.3-1.noarch
+    - python312-requests-retry-session-3.0.0-1.noarch
+    - python312-requests-retry-session-4.0.0-1.noarch
     - python39-requests-retry-session-0.1.8-1.noarch
     - python39-requests-retry-session-0.2.4-1.noarch
+    - python39-requests-retry-session-0.5.4-1.noarch
+    - python39-requests-retry-session-1.0.4-1.noarch
     - sbps-marshal-1.0.1-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.12.aarch64

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
     - cray-switchboard-2.1.0-1.x86_64
     - csm-install-workarounds-1.12.1-1.noarch
-    - python3-bos-reporter-3.3.3-1.aarch64
-    - python3-bos-reporter-3.3.3-1.x86_64
+    - python3-bos-reporter-3.3.4-1.aarch64
+    - python3-bos-reporter-3.3.4-1.x86_64
     - shasta-authorization-module-1.6.2-1.noarch
     - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
-    - python39-bos-reporter-3.3.3-1.aarch64
-    - python39-bos-reporter-3.3.3-1.x86_64
-    - python39-cfs-debugger-1.10.2-1.aarch64
-    - python39-cfs-debugger-1.10.2-1.x86_64
+    - python39-bos-reporter-3.3.4-1.aarch64
+    - python39-bos-reporter-3.3.4-1.x86_64
+    - python39-cfs-debugger-1.10.3-1.aarch64
+    - python39-cfs-debugger-1.10.3-1.x86_64

--- a/rpm/cray/csm/sle-15sp4/index.yaml
+++ b/rpm/cray/csm/sle-15sp4/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/:
   rpms:
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
-    - python310-bos-reporter-3.3.3-1.aarch64
-    - python310-bos-reporter-3.3.3-1.x86_64
-    - python310-cfs-debugger-1.10.2-1.aarch64
-    - python310-cfs-debugger-1.10.2-1.x86_64
+    - python310-bos-reporter-3.3.4-1.aarch64
+    - python310-bos-reporter-3.3.4-1.x86_64
+    - python310-cfs-debugger-1.10.3-1.aarch64
+    - python310-cfs-debugger-1.10.3-1.x86_64

--- a/rpm/cray/csm/sle-15sp5/index.yaml
+++ b/rpm/cray/csm/sle-15sp5/index.yaml
@@ -25,7 +25,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp5/:
   rpms:
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
-    - python311-bos-reporter-3.3.3-1.aarch64
-    - python311-bos-reporter-3.3.3-1.x86_64
-    - python311-cfs-debugger-1.10.2-1.aarch64
-    - python311-cfs-debugger-1.10.2-1.x86_64
+    - python311-bos-reporter-3.3.4-1.aarch64
+    - python311-bos-reporter-3.3.4-1.x86_64
+    - python311-cfs-debugger-1.10.3-1.aarch64
+    - python311-cfs-debugger-1.10.3-1.x86_64

--- a/rpm/cray/csm/sle-15sp6/index.yaml
+++ b/rpm/cray/csm/sle-15sp6/index.yaml
@@ -25,11 +25,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp6/:
   rpms:
     - libcsm-0.0.5-1.noarch
     - loftsman-1.2.0-3.x86_64
-    - python311-bos-reporter-3.3.3-1.aarch64
-    - python311-bos-reporter-3.3.3-1.x86_64
-    - python312-bos-reporter-3.3.3-1.aarch64
-    - python312-bos-reporter-3.3.3-1.x86_64
-    - python311-cfs-debugger-1.10.2-1.aarch64
-    - python311-cfs-debugger-1.10.2-1.x86_64
-    - python312-cfs-debugger-1.10.2-1.aarch64
-    - python312-cfs-debugger-1.10.2-1.x86_64
+    - python311-bos-reporter-3.3.4-1.aarch64
+    - python311-bos-reporter-3.3.4-1.x86_64
+    - python312-bos-reporter-3.3.4-1.aarch64
+    - python312-bos-reporter-3.3.4-1.x86_64
+    - python311-cfs-debugger-1.10.3-1.aarch64
+    - python311-cfs-debugger-1.10.3-1.x86_64
+    - python312-cfs-debugger-1.10.3-1.aarch64
+    - python312-cfs-debugger-1.10.3-1.x86_64


### PR DESCRIPTION
* CASMCMS-9468: This doesn't involve any actual changes to these services -- it just moves them to versions which have their dependencies more precisely pinned, to avoid changes as we get closer to CSM 1.7 release date.
* CASMCMS-9298: Updates the `gitea` service to use the same version of `cray-keycloak-setup` that the rest of the services do in CSM 1.7
* CASMCMS-9479: Update BOS from redis 7.2.3 to 7.2.9, to pick up security patches. Update CFS to use same redis version as BOS, to reduce unnecessary duplicate images.