### PR TITLE
CASM-5650: Update cray-iuf helm chart to latest (5.1.2)

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -268,7 +268,7 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.2
     namespace: argo
   - name: cray-nls
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -267,7 +267,7 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.1
+    version: 5.1.2
     namespace: argo
   - name: cray-nls
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

CASM-5650: Update cray-iuf helm chart to latest (5.1.2)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8342](https://jira-pro.it.hpe.com:8443/browse/CASM-5650)


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

