### PR TITLE
CASMNET-2350 - CANI: Add support for IPv6 enabled SLS schema

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -26,7 +26,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.aarch64
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
-    - cani-0.4.0-1.x86_64
+    - cani-0.5.0-1.x86_64
     - canu-1.9.13-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch


### PR DESCRIPTION
## Summary and Scope

`cani` fails on a system where SLS has been enhanced with IPv6 data.

```
ncn-m001:~ # cani alpha session init csm --csm-keycloak-username cspiller --csm-keycloak-password ${PASSW} --csm-api-host api-gw-service-nmn.local
10:05AM INF /root/.cani/canidb.json does not exist, creating default datastore
10:05AM INF No API Gateway token provided, getting one from provider api-gw-service-nmn.local
2025/07/07 10:05:42 [DEBUG] POST https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
2025/07/07 10:05:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
2025/07/07 10:05:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
10:05AM WRN DatastoreJSONCSM's Validate was called. This is not fully implemented
10:05AM INF Validated CANI inventory
2025/07/07 10:05:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate
Error: Validation failed. Networks/CHN/ExtraProperties/Subnets/2/IPReservations/0: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/1: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/3: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/4: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/5: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/6: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/7: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/8: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2/IPReservations/9: additionalProperties 'IPAddress6' not allowed
Networks/CHN/ExtraProperties/Subnets/2: additionalProperties 'CIDR6', 'Gateway6' not allowed
Networks/CHN/ExtraProperties: additionalProperties 'CIDR6' not allowed
Networks/CMN/ExtraProperties/Subnets/2/IPReservations/0: additionalProperties 'IPAddress6' not allowed
Networks/CMN/ExtraProperties/Subnets/2/IPReservations/1: additionalProperties 'IPAddress6' not allowed
Networks/CMN/ExtraProperties/Subnets/2: additionalProperties 'CIDR6', 'Gateway6' not allowed
Networks/CMN/ExtraProperties/Subnets/3/IPReservations/9: additionalProperties 'IPAddress6' not allowed
Networks/CMN/ExtraProperties/Subnets/3/IPReservations/10: additionalProperties 'IPAddress6' not allowed
Networks/CMN/ExtraProperties/Subnets/3/IPReservations/11: additionalProperties 'IPAddress6' not allowed
Networks/CMN/ExtraProperties/Subnets/3/IPReservations/12: additionalProperties 'IPAddress6' not allowed
Networks/CMN/ExtraProperties/Subnets/3: additionalProperties 'CIDR6', 'Gateway6' not allowed
Networks/CMN/ExtraProperties: additionalProperties 'CIDR6' not allowed
```
This PR adds the `IPAddress6`, `CIDR6`, and `Gateway6` fields to the schema used for validation but does not require them.

## Issues and Related PRs

* Resolves [CASMNET-2350](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2350)

## Testing

### Tested on:

  * `tyr`
  * `odin`

### Test description:

Installed RPM on `tyr`, verified `cani` no longer fails due to IPv6 schema validation issues.
```
ncn-m001:~ # cani alpha session init csm --csm-keycloak-username cspiller --csm-keycloak-password ${PASSW} --csm-api-host api-gw-service-nmn.local
10:09AM INF No API Gateway token provided, getting one from provider api-gw-service-nmn.local
2025/07/07 10:09:42 [DEBUG] POST https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
2025/07/07 10:09:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
2025/07/07 10:09:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
10:09AM WRN DatastoreJSONCSM's Validate was called. This is not fully implemented
10:09AM INF Validated CANI inventory
2025/07/07 10:09:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate
10:09AM INF Validated external inventory provider
2025/07/07 10:09:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate
2025/07/07 10:09:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components
2025/07/07 10:09:42 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware
10:09AM INF Cabinet x9000 does not exist in datastore at System:0->Cabinet:9000
10:09AM INF Cabinet x9000 device type slug is hpe-ex2000
10:09AM INF Hardware from cabinet x9000: 2f132805-5583-4192-a911-2dfde81e8d9b
10:09AM INF Hardware from cabinet x9000: fda0d832-6d1d-4d8d-8932-4d6c15a79704
10:09AM INF Hardware from cabinet x9000: 6211f386-a056-4b30-adb0-8c4c4ec77c65
10:09AM INF Hardware from cabinet x9000: cf98daf1-48a0-438f-bd19-b14da9b19428
10:09AM INF Hardware from cabinet x9000: 4f0e01c0-c77d-4003-bbfe-a0c74528c08b
10:09AM INF Hardware from cabinet x9000: f90433bd-ef76-4609-a8cd-a62ea7c8b805
10:09AM INF SLS extra properties changed for x9000
10:09AM INF SLS extra properties changed for x9000c3
10:09AM INF SLS extra properties changed for x9000c1
10:09AM INF SLS extra properties changed for x9000c1b0
10:09AM INF SLS extra properties changed for x9000c3b0
10:09AM WRN x9000c1s5e0 unable to determine blade device slug from Node Enclosure FRU data: unable to find corrensponding device slug for manufacturer (HPE) and model (ParryPeakNC)
10:09AM WRN x9000c1s5e1 unable to determine blade device slug from Node Enclosure FRU data: unable to find corrensponding device slug for manufacturer (HPE) and model (ParryPeakNC)
10:09AM WRN x9000c1s6e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c1s6e1 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c1s7e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c1s7e1 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s1e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s3e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s4e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s4e1 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s5e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s5e1 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s6e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s6e1 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s7e0 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN x9000c3s7e1 is missing from HSM hardware inventory, possible phantom hardware
10:09AM WRN Hardware does not exist (possible phantom hardware): System:0->Cabinet:9000->Chassis:1->NodeBlade:5->NodeCard:1->Node:0
10:09AM FTL Panic!
```

Installed RPM on `odin` which does not have IPv6 data in SLS to ensure change is backwards compatible.
```
ncn-m001:~ # cani alpha session init csm --csm-keycloak-username cspiller --csm-keycloak-password ${PASSW} --csm-api-host api-gw-service-nmn.local
10:12AM INF /root/.cani/canidb.json does not exist, creating default datastore
10:12AM INF No API Gateway token provided, getting one from provider api-gw-service-nmn.local
2025/07/07 10:12:31 [DEBUG] POST https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
2025/07/07 10:12:31 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
2025/07/07 10:12:31 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
10:12AM WRN DatastoreJSONCSM's Validate was called. This is not fully implemented
10:12AM INF Validated CANI inventory
2025/07/07 10:12:31 [DEBUG] GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate
Error: Validation failed. /Hardware/x3000c0s29b0n0: x3000c0s29b0n0 does not have a NID
/Hardware/x3000c0s29b0n0: x3000c0s29b0n0 Node has an invalid Role: HPCM, Valid Roles are: [Application Storage Management Compute Service System]
/Hardware/x3000c0s29b0n0: x3000c0s29b0n0 Node has an invalid SubRole: Monitoring, Valid SubRoles are: [Master Worker Storage UAN Gateway LNETRouter Visualization UserDefined]
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

