### PR TITLE
CASMTRIAGE-8417: Add K8s 1.29 packages to precache

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -69,6 +69,14 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.26.15
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
 
+      # K8s 1.29
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.1
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
+
       # K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.5

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -60,6 +60,14 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.26.15
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
 
+      # K8s 1.29
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.1
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.29.15
+      - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
+
       # K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.5


### PR DESCRIPTION
## Summary and Scope

* Add K8s 1.29.15 (and adjacent) packages to fix an upgrade issue where kube-proxy is unavailable because Nexus is unavailable, and things break.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8417](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8417)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

