### PR TITLE
CASM-5651: Update cray-nexus-setup image 0.12.1 in cray-nexus helm chart

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.14.0
+    version: 0.14.1
     namespace: nexus

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -122,7 +122,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
       # Cilium
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -97,7 +97,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
       # Cilium
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8


### PR DESCRIPTION
## Summary and Scope

CASM-5651: Update cray-nexus-setup image 0.12.1 in cray-nexus helm chart

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-5651](https://jira-pro.it.hpe.com:8443/browse/CASM-5651)
* Merge with/before/after `https://github.com/Cray-HPE/cray-nexus/pull/20`




## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

