### PR TITLE
CASMTRIAGE-8437: Increase the cray-nexus chart timeout to 10m

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -35,3 +35,4 @@ spec:
     source: csm-algol60
     version: 0.14.1
     namespace: nexus
+    timeout: 10m0s


### PR DESCRIPTION
## Summary and Scope

While upgrading `odin`, the `cray-nexus` chart upgrade hit the 5 minute timeout default and failed deployment.  I was able to deploy successfully without making any changes.  Increasing the `cray-nexus` chart timeout to 10m.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8437](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8437)

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

