### PR TITLE
CASMNET-2353: Release CANU components of NMN Isolation and IPv6

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.27
+KUBERNETES_IMAGE_ID=7.1.28
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.27
+PIT_IMAGE_ID=7.1.28
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.27
+STORAGE_CEPH_IMAGE_ID=7.1.28
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.27
+COMPUTE_IMAGE_ID=7.1.28
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.0-1.x86_64
-    - canu-1.9.13-1.x86_64
+    - canu-2.0.0-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.0-1.x86_64
-    - canu-2.0.0-1.x86_64
+    - canu-2.0.1-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

CANU 2.0.1 has all the features required to release the switch networking components of NMN Isolation and IPv6 to CSM.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-2353](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2353)

## Testing

### Tested on:

  * Three internal systems
  * Local development environment


### Test description:

For all internal systems tested all `canu` commands were tested with system data (except SHCD related which were not changed in the code base).  All commands were tested with and without feature flags `--enable-nmn-isolation` and `--nmn-pvlan`.  IPv6 was tested on a single system.

## Risks and Mitigations

None


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

