### PR TITLE
CASMTRIAGE-8447 - k8s_nexus_can_pull pull test uses invalid image

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.26-1.noarch
+    - csm-testing-1.19.27-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.26-1.noarch
+    - goss-servers-1.19.27-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The `goss-k8s-nexus-can-pull.yaml` test uses a hard-coded image and the image tag doesn't exist in CSM 1.7.

This PR modifies the test to get the image to use from the `cray-precache-images` ConfigMap.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8447](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8447)

## Testing

### Tested on:

  * `starlord`

### Test description:

Before fix
```
ncn-m001:/opt/cray/tests/install/ncn/tests # goss  -g goss-k8s-nexus-can-pull.yaml validate
F

Failures/Skipped:

Title: Validate nexus (registry.local) can pull images
Meta:
    desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to determine why the test was unable to pull a docker image.
    sev: 0
Command: k8s_nexus_can_pull: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 0.127s
Count: 1, Failed: 1, Skipped: 0
```

With fix
```
ncn-m001:/opt/cray/tests/install/ncn/tests # goss  -g goss-k8s-nexus-can-pull.yaml validate
.

Total Duration: 0.256s
Count: 1, Failed: 0, Skipped: 0
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable