### PR TITLE
CASMINST-7376: removing cilium check from post-install-service-check

### DIFF
--- a/hooks/post-install-service-check-posthook.sh
+++ b/hooks/post-install-service-check-posthook.sh
@@ -23,11 +23,4 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-echo "INFO Verifying k8s-primary-cni value in BSS after migration"
-CNI_VALUE_POST=$(cray bss bootparameters list --hosts Global --format json | jq -r '.[]."cloud-init"."meta-data"."k8s-primary-cni"')
-if [[ "$CNI_VALUE_POST" == "cilium" ]]; then
-    echo "INFO k8s-primary-cni is now set to 'cilium'. Migration successful."
-else
-    echo "ERROR k8s-primary-cni is still '$CNI_VALUE_POST'. Migration may have failed."
-    exit 1
-fi
+# to-do: will add k8s version check post k8s upgrade


### PR DESCRIPTION
## Summary and Scope

Removing the cilium form the hook script. Keeping the script in place as we are planning to put k8s version after k8s upgrade in this hook script.

## Issues and Related PRs

* Resolves [CASMINST-7376](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7376)

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

