### PR TITLE
CASMNET-2355 New CSI and Metal-init (IPv6)

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.28
+KUBERNETES_IMAGE_ID=7.1.30
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.28
+PIT_IMAGE_ID=7.1.30
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.28
+STORAGE_CEPH_IMAGE_ID=7.1.30
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.28
+COMPUTE_IMAGE_ID=7.1.30
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-trust-1.9.2-1.noarch
     - cray-cmstools-crayctldeploy-1.33.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cray-site-init-1.36.10-1.x86_64
+    - cray-site-init-2.0.0-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch
     - craycli-0.97.0-1.aarch64
     - craycli-0.97.0-1.x86_64
@@ -61,7 +61,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - iuf-cli-1.7.1-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
-    - metal-init-1.4.11-1.noarch
+    - metal-init-1.4.12-1.noarch
     - metal-ipxe-2.7.0-1.noarch
     - metal-nexus-1.7.0-3.70.4.x86_64
     - metal-observability-1.1.0-1.x86_64


### PR DESCRIPTION
Brings in a new CSI and metal-init.
This version of CSI provides IPv6 enablement for fresh installs and existing CSM deployments.
Builds off of #4244 