### PR TITLE
CASMTRIAGE-8470: Updated the image-verification-policy chart version

### DIFF
--- a/manifests/kyverno-policy.yaml
+++ b/manifests/kyverno-policy.yaml
@@ -33,5 +33,5 @@ spec:
   charts:
   - name: image-verification-policy
     source: csm-algol60
-    version: 1.0.4
+    version: 1.0.5
     namespace: kyverno


### PR DESCRIPTION
## Summary and Scope

A new version of image-verification-policy chart is updated to add an exception to the slurm-backup pod

## Related Jira
[CASMTRIAGE-8470](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8470)

## Testing

Tested the upgrade and install scenarios of image-verification-policy chart after adding this exception

### Tested on:

  * Starlord

### Test logs:
[arti_image-verification-1_0_5_install.txt](https://github.com/user-attachments/files/21248883/arti_image-verification-1_0_5_install.txt)
[arti_image-verification-1_0_5_upgrade.txt](https://github.com/user-attachments/files/21248884/arti_image-verification-1_0_5_upgrade.txt)

