### PR TITLE
CASMTRIAGE-8458/CASMPET-7626/CRAYSAT-1957: Update csm-testing/goss-servers RPMs

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.28-1.noarch
+    - csm-testing-1.19.29-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.27-1.noarch
+    - goss-servers-1.19.29-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,7 +48,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.27-1.noarch
+    - csm-testing-1.19.28-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64


### PR DESCRIPTION
## Summary and Scope

updating csm-testing version 

## Issues and Related PRs

* Resolves [CASMTRIAGE-8458](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8458)
* Resolves [CASMPET-7626](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7626)
* Resolves [CRAYSAT-1957](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1957)

## Risks and Mitigations

No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

