### PR TITLE
CASMPET-7624/CASMPET-7625: Fix issues in iSCSI playbook

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.42.0
+    version: 1.42.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
This addresses a few issues in the current implementation of the iSCSI playbook, preventing problems that would otherwise require workarounds and additional documentation.