### PR TITLE
CASMHMS-6568: Fixed bug causing duplicate "Detected" hw events in hiwinv history (1.6.3)

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.6.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.22
+    version: 7.1.23
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.32.1/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.32.2/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.0.2


### PR DESCRIPTION
### Summary and Scope

After power on and manual discover operations, the FRUIDs for CPUs and GPUs were changing due to a bug in SMD where it was assuming that the 'range' function would deterministicaly iterate through map data structures.  This assumption use to hold in early versions of Go, but that is no longer the case.

The code block in question occurs in the second step of discovering the CPUs and GPUs on a node.  SMD was semi-randomly iterating through the redfish data for them to create their FRUIDs.  This resulted in FRUIDs semi-randomly rotating around on the CPUs and GPUs and ultimately prevented the event pruning logic in SMD from discarding duplicate "Detected" events for the CPUs and GPUs because it compares the FRUID of the new event with the FRUID of the last event to make a determination whether or not drop the event.  "Detected" events are very common so they were accumulating rapidly and resulted in very large hwinv_hist tables on large customer systems.

The fix is to extract the keys from the map into a slice and then sort the slice so that the 'range' function can deterministically iterate through the slice to index into the map.  Go guarantees deterministic ordering when the 'range' function is applied to arrays, slices, and strings.

Adopted app version 2.32.2 for CSM 1.6.3 (helm chart 7.1.23)
Adopted app version 2.39.0 for CSM 1.7.0 (helm chart 7.2.7)

### Issues and Related PRs

* Resolves [CASMHMS-6568](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6568)

### Testing

#### Tested on:

* `tyr`

#### Test Description:

Powered x9000c1s2b0n0 off and on without the fix applied to confirm bug present.  After power on operations the FRUID changed for each CPU and GPU.  New "Detected" events were added to the hwinv_hist table.

Upgraded SMD helm chart with fix and repeated power off and on operation three times.  Confirmed that after the first power on operation, the FRUIDs changed into correct aliglment with the serial numbers obtained through redfish.  Confirmed that the two additional power operations did not result in changing FRUIDs and did not result in additional "Detected" events in the hwinv_hist table.

Ran a manual discover and again confirmed that the FRUIDs stayed correctly aligned.

Ran the SMD CT smoke and integration tests.  Confirmed no additonal failures.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable