### PR TITLE
CASMPET-7613: updating cray-vault-operator version

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -172,7 +172,7 @@ spec:
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.5.0
+    version: 1.5.1
     namespace: vault
   - name: cray-vault
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.5.0
+    version: 1.5.1
     namespace: vault
   - name: cray-vault
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

new version of cray-vault-operator has been created. updating the manifest for the same.

## Issues and Related PRs

* Resolves [CASMPET-7613](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7613)
* https://github.com/Cray-HPE/cray-vault/pull/21

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

