### PR TITLE
CASMTRIAGE-8500 updating iuf-cli rpm version

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -58,7 +58,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.7.1-1.x86_64
+    - iuf-cli-1.7.2-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
     - metal-init-1.4.12-1.noarch


### PR DESCRIPTION
## Summary and Scope

updating iuf-cli rpm version to 1.7.2

## Issues and Related PRs

* Resolves [CASMTRIAGE-8500](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8500)
* https://github.com/Cray-HPE/iuf-cli/pull/195

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

