### PR TITLE
CASMPET-7633: fix etcd health check

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -66,7 +66,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - metal-nexus-1.7.0-3.70.4.x86_64
     - metal-observability-1.1.0-1.x86_64
     - platform-utils-1.7.1-1.noarch
-    - platform-utils-1.8.3-1.noarch
+    - platform-utils-1.8.4-1.noarch
     - python3-liveness-1.4.4-1.noarch
     - python3-requests-retry-session-0.1.8-1.noarch
     - python3-requests-retry-session-0.2.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

Use the newer platform-utils rpm to reduce false positive report from etcd health check. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7633](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7633)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * Local development environment
  * Virtual Shasta

### Test description:

Scale down an etcd cluster, and verified that the original test code reported "PASSED" result even though a command had failed:

ncn-m003:~ # /opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status

=== Check the Health of the Etcd Clusters in all Namespaces. ===
=== Verify a "healthy" Report for Each Etcd Pod. ===
...
jq: error (at :19): Cannot iterate over null (null)
...
--- PASSED ---

Re-test with the new code, and confirmed that it fixed the false positive reporting issue:

ncn-m003:/opt/cray/platform-utils # /opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status

=== Check the Health of the Etcd Clusters in all Namespaces. ===
=== Verify a "healthy" Report for Each Etcd Pod. ===
...
jq: error (at :19): Cannot iterate over null (null)
FAILED - Unable to get endpoints or ready pods for cray-fas-bitnami-etcd in namespace services.
...
--- FAILED --- not all Etcd pods are "healthy"

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

