### PR TITLE
CASMINST-7373 : kubernetes upgrade as a Job

### DIFF
--- a/hooks/deploy-product-onexit.sh
+++ b/hooks/deploy-product-onexit.sh
@@ -72,7 +72,13 @@ fi
 
 echo "INFO Running job to complete k8s upgrade from 1.26 to 1.32"
 
-result=$(kubectl create -f /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s_job.yaml)
+
+result=$(kubectl create -f /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s_job.yaml 2>&1)
+if [[ $? -ne 0 ]]; then
+  echo "ERROR Failed to create the Kubernetes upgrade job: $result"
+  exit 1
+fi
+
 job_name=$(echo $result | awk '{print $1}' | awk -F '/' '{print $2}')
 echo "INFO Job $job_name has been created in the argo namespace. This is performing k8s upgrade from 1.26 to 1.32"
 echo "INFO Monitor the job and ensure it is successful before proceeding to next stage."

--- a/hooks/deploy-product-onexit.sh
+++ b/hooks/deploy-product-onexit.sh
@@ -70,74 +70,12 @@ else
     fi
 fi
 
-if [[ -f "$DONE_DIR/upgrade_k8s_1_29.done" ]]; then
-    echo "INFO kubernetes upgrade to v1.29 already completed, skipping."
-else
-    echo "INFO Starting the kubernetes upgrade to v1.29"
-    /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.27.16 1.28.15 1.29.15"
-    if [[ $? -ne 0 ]]; then
-        echo "ERROR Failed to upgrade kubernetes to v1.29"
-        exit 1
-    else
-        touch "$DONE_DIR/upgrade_k8s_1_29.done"
-        echo "INFO Successfully upgraded kubernetes to v1.29"
-    fi
-fi
+echo "INFO Running job to complete k8s upgrade from 1.26 to 1.32"
 
-if [[ -f "$DONE_DIR/deploy_charts_post_k8s_upgrade.done" ]]; then
-    echo "INFO deploy manifests for v1.29 already completed, skipping."
-else
-    echo "INFO Deploying manifests for v1.29"
-    /usr/share/doc/csm/upgrade/scripts/k8s/deploy_charts_post_k8s_upgrade.sh
-    if [[ $? -ne 0 ]]; then
-        echo "ERROR Failed to deploy manifests for v1.29"
-        exit 1
-    else
-        touch "$DONE_DIR/deploy_charts_post_k8s_upgrade.done"
-        echo "INFO Successfully deployed manifests for v1.29"
-    fi
-fi
-
-if [[ -f "$DONE_DIR/upgrade_k8s_1_32.done" ]]; then
-    echo "INFO kubernetes upgrade to v1.32 already completed, skipping."
-else
-    echo "INFO Starting the kubernetes upgrade to v1.32"
-    /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s.sh -v "1.30.12 1.31.8 1.32.5"
-    if [[ $? -ne 0 ]]; then
-        echo "ERROR Failed to upgrade kubernetes to v1.32"
-        exit 1
-    else
-        touch "$DONE_DIR/upgrade_k8s_1_32.done"
-        echo "INFO Successfully upgraded kubernetes to v1.32"
-    fi
-fi
-
-if [[ -f "$DONE_DIR/cleanup_bss.done" ]]; then
-    echo "INFO BSS cleanup already completed, skipping."
-else
-    echo "INFO Remove upgrade and upgrade_version file creation from BSS for masters and workers."
-    /usr/share/doc/csm/upgrade/scripts/upgrade/cleanup.sh
-    if [[ $? -ne 0 ]]; then
-        echo "ERROR Failed to update BSS to remove upgrade and upgrade_version."
-        exit 1
-    else
-        touch "$DONE_DIR/cleanup_bss.done"
-        echo "INFO Successfully updated BSS to remove upgrade and upgrade_version."
-    fi
-fi
-
-echo "INFO Deploying manifests for v1.32"
-pushd ${CSM_ARTI_DIR}
-./upgrade.sh
-if [[ $? -ne 0 ]]; then
-    echo "ERROR Failed to deploy manifests for v1.32"
-    exit 1
-else
-    popd +0
-    echo "INFO Successfully deployed manifests for v1.32"
-fi
-
-# If all steps succeeded, remove all .done files
-rm -f "$DONE_DIR"/*.done
+result=$(kubectl create -f /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_k8s_job.yaml)
+job_name=$(echo $result | awk '{print $1}' | awk -F '/' '{print $2}')
+echo "INFO Job $job_name has been created in the argo namespace. This is performing k8s upgrade from 1.26 to 1.32"
+echo "INFO Monitor the job and ensure it is successful before proceeding to next stage."
 
 echo "INFO Onexit handler for deploy product completed"
+

--- a/hooks/post-install-service-check-posthook.sh
+++ b/hooks/post-install-service-check-posthook.sh
@@ -23,4 +23,61 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# to-do: will add k8s version check post k8s upgrade
+. /etc/cray/upgrade/csm/myenv
+
+DONE_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}"
+
+JOB_NAMESPACE="argo"
+JOB_PREFIX="upgrade-k8s-job-"
+EXPECTED_VERSION="v1.32.5"
+
+echo "INFO Starting post-upgrade checks..."
+
+### 1. Check Kubernetes upgrade job status
+echo "INFO Checking status of Kubernetes upgrade job..."
+
+job_name=$(kubectl get jobs -n "$JOB_NAMESPACE" \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep "^$JOB_PREFIX" | tail -n1)
+if [[ -z "$job_name" ]]; then
+  echo "ERROR No job found for kubernetes upgrade in namespace $JOB_NAMESPACE"
+  echo "ERROR Kubernetes upgrade job did not run successfully"
+  exit 1
+fi
+
+echo "INFO Found job: $job_name"
+
+job_status=$(kubectl get job "$job_name" -n "$JOB_NAMESPACE" -o jsonpath='{.status.succeeded}')
+if [[ "$job_status" != "1" ]]; then
+  echo "ERROR Kubernetes upgrade job $job_name did not complete successfully"
+  exit 1
+else
+  echo "INFO Kubernetes upgrade job $job_name completed successfully"
+fi
+
+### 2. Check for any .done files
+echo "INFO Checking for .done files in $DONE_DIR..."
+
+done_files_found=$(find "$DONE_DIR" -name "*.done")
+if [[ -n "$done_files_found" ]]; then
+  echo "ERROR Found .done files:"
+  echo "$done_files_found"
+  echo "ERROR Kubernetes upgrade job did not complete successfully"
+  exit 1
+else
+  echo "INFO No .done files found"
+fi
+
+### 3. Check Kubernetes client and server versions
+echo "INFO Verifying Kubernetes client and server versions..."
+
+client_version=$(kubectl version -o json | jq -r '.clientVersion.gitVersion')
+server_version=$(kubectl version -o json | jq -r '.serverVersion.gitVersion')
+if [[ "$client_version" == "$EXPECTED_VERSION" && "$server_version" == "$EXPECTED_VERSION" ]]; then
+  echo "INFO Kubernetes client and server versions are both $EXPECTED_VERSION"
+else
+  echo "ERROR Kubernetes version is not as expected. Client: $client_version, Server: $server_version, Expected: $EXPECTED_VERSION"
+  exit 1
+fi
+
+echo "INFO All post-upgrade checks passed successfully."

--- a/hooks/post-install-service-check-posthook.sh
+++ b/hooks/post-install-service-check-posthook.sh
@@ -58,7 +58,7 @@ fi
 ### 2. Check for any .done files
 echo "INFO Checking for .done files in $DONE_DIR..."
 
-done_files_found=$(find "$DONE_DIR" -name "*.done")
+done_files_found=$(find "$DONE_DIR" -maxdepth 1 -name "*.done")
 if [[ -n "$done_files_found" ]]; then
   echo "ERROR Found .done files:"
   echo "$done_files_found"


### PR DESCRIPTION
## Summary and Scope

The Kubernetes upgrade, previously part of the deploy-product-onexit hook, was causing issues due to a kubelet restart during execution.

This PR moves the upgrade logic to a dedicated script: upgrade_k8s_steps.sh, located under the docs-csm.
The Kubernetes upgrade will now be performed through a Job defined in upgrade_k8s_job.yaml, which will be triggered by the deploy-product-onexit hook.

## Issues and Related PRs

* Resolves [CASMINST-7373](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7373)
* https://github.com/Cray-HPE/docs-csm/pull/6141

### Tested on:

  * molly

### Test description:

- The fix was tested on #molly by executing the deploy-product stage.
- During the upgrade, the kubelet restarted, which caused the pod executing the Job to be terminated.
- Due to the Job's restart policy, it automatically restarted and successfully completed the upgrade.
- This confirms that the Job is resilient to kubelet restarts and performs the upgrade reliably.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

