### PR TITLE
CASM-5664: Updated platform.yaml to take the new kyverno-policy chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -119,7 +119,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.20
+    version: 1.7.21
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -119,7 +119,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.21
+    version: 1.7.22
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

kubernetes upgrade is being run out of IUF stage as a separate job now. so exception is needed for the same

## Issues and Related PRs

* Resolves [CASM-5664](https://jira-pro.it.hpe.com:8443/browse/CASM-5664)

## Tested on
* Starlord
## Test description
Tested upgrade and install scenarios of the new chart
## Test logs:
[arti-kyverno-policy-1_7_21_install_logs.txt](https://github.com/user-attachments/files/21407928/arti-kyverno-policy-1_7_21_install_logs.txt)
[arti-kyverno-policy-1_7_21_upgrade_logs.txt](https://github.com/user-attachments/files/21407929/arti-kyverno-policy-1_7_21_upgrade_logs.txt)
