### PR TITLE
CASMPET-7615: Reconcile the v1.24 manifests so that the CSM blob does not contain bloat

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -44,15 +44,15 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.1
+    version: 6.1.3
     namespace: services
     swagger:
     - name: sls
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.8.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.5
+    version: 7.2.7
     namespace: services
     values:
       cray-service:
@@ -64,10 +64,10 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.36.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.38.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
-    version: 3.1.2
+    version: 3.1.3
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
@@ -75,24 +75,28 @@ spec:
     namespace: services
 
   # Cray DHCP Kea
-  - name: cray-dhcp-kea
-    source: csm-algol60
-    version: 0.11.6   # DO NOT UPDATE cray-dhcp-kea version that works with K8s 1.24
-    namespace: services
+  # DO NOT INSTALL cray-dhcp-kea chart, we want to keep CSM 1.6 version running
+  # until we upgrade to K8s 1.32
+  # - name: cray-dhcp-kea
+  #   source: csm-algol60
+  #   version: 0.11.6 # update platform.yaml cray-precache-images with this
+  #   namespace: services
 
   # Cray DNS unbound (resolver)
-  - name: cray-dns-unbound
-    source: csm-algol60
-    version: 0.8.4   # DO NOT UPDATE cray-dns-unbound version that works with K8s 1.24
-    namespace: services
-    values:
-      global:
-        appVersion: 0.8.4
+  # DO NOT INSTALL cray-dns-unbound chart, we want to keep CSM 1.6 version running
+  # until we upgrade to K8s 1.32
+  # - name: cray-dns-unbound
+  #   source: csm-algol60
+  #   version: 0.8.4 # update platform.yaml cray-precache-images with this
+  #   namespace: services
+  #   values:
+  #     global:
+  #       appVersion: 0.8.4
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.4.2 # update platform.yaml cray-precache-images with this
+    version: 0.5.0 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -75,23 +75,10 @@ spec:
     namespace: services
 
   # Cray DHCP Kea
-  # DO NOT INSTALL cray-dhcp-kea chart, we want to keep CSM 1.6 version running
-  # until we upgrade to K8s 1.32
-  # - name: cray-dhcp-kea
-  #   source: csm-algol60
-  #   version: 0.11.6 # update platform.yaml cray-precache-images with this
-  #   namespace: services
+  # DO NOT INSTALL cray-dhcp-kea chart, we want to keep running the CSM 1.6 version
 
   # Cray DNS unbound (resolver)
-  # DO NOT INSTALL cray-dns-unbound chart, we want to keep CSM 1.6 version running
-  # until we upgrade to K8s 1.32
-  # - name: cray-dns-unbound
-  #   source: csm-algol60
-  #   version: 0.8.4 # update platform.yaml cray-precache-images with this
-  #   namespace: services
-  #   values:
-  #     global:
-  #       appVersion: 0.8.4
+  # DO NOT INSTALL cray-dns-unbound chart, we want to keep running the CSM 1.6 version
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -46,7 +46,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.20.1
+    version: 2.20.2
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60
@@ -84,16 +84,11 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.5
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.5
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
+
       # Istio
       - artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
       - artifactory.algol60.net/csm-docker/stable/istio/pilot:1.26.0-cray1-distroless
-      # Kyverno for K8s 1.24
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7
-      # Kyverno for K8s 1.32
+      # Kyverno
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4
       - artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.4
@@ -106,12 +101,11 @@ spec:
       # DNS for K8s 1.24
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.4.2
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # DNS for K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
@@ -142,6 +136,8 @@ spec:
     source: csm-algol60
     version: 1.7.6
     namespace: kyverno
+  # DO NOT INSTALL the kyverno-policy chart, keep running the CSM 1.6 version
+  # DO NOt INSTALL the cray-kyverno-policies-upstream chart, keep running the CSM 1.6 version
   - name: cray-velero
     source: csm-algol60
     version: 1.16.1
@@ -168,7 +164,7 @@ spec:
     namespace: cert-manager
   - name: cray-opa
     source: csm-algol60
-    version: 1.34.6
+    version: 1.34.9
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
@@ -202,9 +198,11 @@ spec:
     source: csm-algol60
     version: 1.6.1
     namespace: services
+  # DO NOT INSTALL the cray-sysmgmt-health chart, install after upgraded to K8s 1.32
+  # DO NOT INSTALL the cray-postgres-operator, it gets upgraded in prerequisites.sh
   - name: cray-kafka-operator
     source: csm-algol60
-    version: 1.2.1
+    version: 1.3.1
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
@@ -220,11 +218,11 @@ spec:
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60
-    version: 5.1.4
+    version: 5.3.1
     namespace: services
   - name: cray-keycloak-users-localize
     source: csm-algol60
-    version: 1.11.5
+    version: 1.11.7
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
@@ -232,7 +230,7 @@ spec:
     namespace: services
   - name: cray-shared-kafka
     source: csm-algol60
-    version: 1.1.1
+    version: 1.2.0
     namespace: services
   - name: cray-sts
     source: csm-algol60
@@ -258,10 +256,6 @@ spec:
     source: csm-algol60
     version: 2.0.3
     namespace: metallb-system
-    values:
-      metallb:
-        psp:
-          create: false
   - name: cray-baremetal-etcd-backup
     source: csm-algol60
     version: 0.2.3
@@ -304,3 +298,5 @@ spec:
     source: csm-algol60
     version: 1.0.2
     namespace: services
+  # DO NOT INSTALL the cray-hubble chart, install after upgraded to K8s 1.32
+  # DO NOT INSTALL the rack-resiliency chart, install after upgraded to K8s 1.32

--- a/manifests/storage-v1.24.yaml
+++ b/manifests/storage-v1.24.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -20,6 +20,8 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+#
+# Need to deploy with PSP disabled while still on K8s 1.24
 #
 apiVersion: manifests/v1beta1
 metadata:


### PR DESCRIPTION
## Summary and Scope
CASMPET-7615: Reconcile the v1.24 manifests so that the CSM blob does not contain bloat or unintentionally downgrade a chart
* Add comment to storage-v1.24.yaml stating that old ceph charts need to be re-deployed with PSP disabled when at K8s 1.24

## Issues and Related PRs

* Resolves [CASMPET-7615](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7615)

## Testing
Tested on the vShasta system `orym`

### Test description:
Tagged branch with `v1.7.0-k8s.5` and ran upgrade on `orym`.  Upgrade succeeded.  
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2188/

The only charts we have two version of are the `cray-ceph-csi-cephfs` chart and the `cray-ceph-csi-rbd` chart.  We were hoping to not upgrade these charts until we reached K8s 1.32, but the deployment of the new charts failed because the old charts were using the PodSecurityPolicy api.  Therefore, we need to re-deploy the old `cray-ceph-csi` charts with PSP disabled when we're at K8s 1.24, so keeping `storage-v1.24.yaml` as is with comment to that effect.

```
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0-k8s.5/helm # ls
cfs-ara-1.5.1.tgz			     cray-etcd-defrag-0.4.1.tgz		  cray-keycloak-5.3.1.tgz		    cray-sts-0.8.3.tgz
cfs-hwsync-agent-1.14.1.tgz		     cray-etcd-migration-setup-1.0.2.tgz  cray-keycloak-gatekeeper-2.0.0.tgz	    cray-sysmgmt-health-1.2.18.tgz
cfs-trust-1.9.2.tgz			     cray-externaldns-1.6.1.tgz		  cray-keycloak-users-localize-1.11.7.tgz   cray-tapms-crd-1.9.1.tgz
cms-ipxe-1.16.1.tgz			     cray-hms-bss-3.3.4.tgz		  cray-kiali-0.7.0.tgz			    cray-tapms-operator-1.9.1.tgz
cray-baremetal-etcd-backup-0.2.3.tgz	     cray-hms-capmc-5.1.2.tgz		  cray-kyverno-1.7.6.tgz		    cray-tftp-1.12.0.tgz
cray-bos-2.48.2.tgz			     cray-hms-discovery-3.1.1.tgz	  cray-kyverno-policies-upstream-1.2.0.tgz  cray-tftp-pvc-1.12.0.tgz
cray-ceph-csi-cephfs-3.14.0.tgz		     cray-hms-firmware-action-3.2.4.tgz   cray-metallb-2.0.3.tgz		    cray-vault-1.8.0.tgz
cray-ceph-csi-cephfs-3.6.3-1.tgz	     cray-hms-hbtd-3.2.3.tgz		  cray-metrics-server-0.5.0.tgz		    cray-vault-operator-1.5.1.tgz
cray-ceph-csi-rbd-3.14.0.tgz		     cray-hms-hmcollector-2.17.3.tgz	  cray-nexus-0.14.1.tgz			    cray-velero-1.16.1.tgz
cray-ceph-csi-rbd-3.6.2-1.tgz		     cray-hms-hmnfd-4.1.2.tgz		  cray-nls-5.1.2.tgz			    cray-vpa-1.0.2.tgz
cray-certmanager-0.9.2.tgz		     cray-hms-meds-3.1.3.tgz		  cray-node-discovery-1.2.5.tgz		    cray-vpa-crd-1.0.0.tgz
cray-certmanager-issuers-0.7.2.tgz	     cray-hms-rts-5.1.7.tgz		  cray-node-labels-0.5.0.tgz		    csm-config-1.43.0.tgz
cray-cfs-api-1.27.0.tgz			     cray-hms-scsd-3.1.3.tgz		  cray-node-problem-detector-1.11.1.tgz     csm-redfish-interface-emulator-0.1.1.tgz
cray-cfs-batcher-1.13.1.tgz		     cray-hms-sls-6.1.3.tgz		  cray-oauth2-proxies-0.5.0.tgz		    csm-ssh-keys-1.8.1.tgz
cray-cfs-operator-1.34.1.tgz		     cray-hms-smd-7.2.7.tgz		  cray-opa-1.34.9.tgz			    gitea-2.9.1.tgz
cray-console-data-2.5.0.tgz		     cray-hnc-manager-0.1.1.tgz		  cray-postgres-operator-1.10.3.tgz	    image-verification-policy-1.0.5.tgz
cray-console-node-2.10.1.tgz		     cray-hubble-0.0.1.tgz		  cray-power-control-2.2.5.tgz		    kyverno-policy-1.7.20.tgz
cray-console-operator-1.16.1.tgz	     cray-ims-3.30.0.tgz		  cray-powerdns-manager-0.8.4.tgz	    sealed-secrets-0.5.2.tgz
cray-csm-barebones-recipe-install-2.8.0.tgz  cray-istio-base-1.0.0.tgz		  cray-precache-images-0.6.0.tgz	    spire-intermediate-0.5.1.tgz
cray-dhcp-kea-0.13.0.tgz		     cray-istio-ingress-4.0.0.tgz	  cray-product-catalog-2.7.1.tgz	    tpm-intermediate-1.0.0.tgz
cray-dns-powerdns-0.5.0.tgz		     cray-istio-pilot-1.0.0.tgz		  cray-rrs-1.0.1.tgz			    tpm-provisioner-1.0.0.tgz
cray-dns-unbound-0.10.0.tgz		     cray-iuf-5.1.2.tgz			  cray-s3-1.1.0.tgz			    trustedcerts-operator-0.9.0.tgz
cray-drydock-2.20.2.tgz			     cray-k8s-encryption-0.1.0.tgz	  cray-shared-kafka-1.2.0.tgz
cray-etcd-backup-0.5.6.tgz		     cray-kafka-operator-1.3.1.tgz	  cray-spire-1.8.0.tgz
ncn-m001:/etc/cray/upgrade/csm/media/upgrade-csm/csm-1.7.0-k8s.5/helm #
```

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

