### PR TITLE
- New RRS (Rack Resiliency Service) helm chart version for CASMTRIAGE…

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -310,7 +310,7 @@ spec:
     namespace: kube-system
   - name: cray-rrs
     source: csm-algol60
-    version: 1.0.1
+    version: 1.0.2
     namespace: rack-resiliency
     swagger:
     - name: rrs


### PR DESCRIPTION
…-8508

## Summary and Scope

New RRS (Rack Resiliency Service) helm chart version for [CASMTRIAGE-8508](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8508) fix.

When the pods are not distributed across racks properly due to Kubernetes scheduler failure, RMS is not populating balanced field of those services properly. Its listing the balance as true. This PR addresses this issue.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

* Resolves [CASMTRIAGE-8508](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8508)

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

Drax

### Test description:

Test description:

Simulated the scenario with a test script and tested multiple scenarios.
Scenario 1 - **Without the fix.** When pod distribution is not equal (ie., rack drax-k8s-rack-x6002 is up but there are no pods assigned to nodes running in it). Balance is wrongly showing as `true`

```
ncn-m001:~/sravani # python3 balance_test.py 
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Distribution array is [2, 1]
Balance for istio-ingressway service is: true
```

Scenario 2 - **With the fix**. When pod distribution is not equal (ie., rack drax-k8s-rack-x6002 is up but there are no pods assigned to nodes running in it). Balance is correctly showing as `false`

```
ncn-m001:~/sravani # python3 balance_test.py 
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Adding zone drax-k8s-rack-x6002 to zone_pod_map with empty list
Final mapping is -
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}, 'drax-k8s-rack-x6002': {}}
Distribution array is [2, 1, 0]
Balance for istio-ingressway service is: false
``` 

Scenario 3 - With the fix. When the rack `drax-k8s-rack-x6001` is down (i.e., none of the nodes in that rack are Ready). The balance in this case should be `true` as the above rack should not be considered.

```
ncn-m001:~/sravani # python3 balance_test.py 
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Final mapping is -
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Distribution array is [2, 1]
Balance for istio-ingressway service is: true
```

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [ NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [NA] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

