### PR TITLE
CASM-5656 Updating manifest with latest csm-config version

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.43.0
+    version: 1.44.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Changes were made to csm-config to fix the issue - 
CASM-5656 CEPH zoning is failing while testing integrated solution of RR with latest changes
Updating the version with the changes in the manifest

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-5656](https://jira-pro.it.hpe.com:8443/browse/CASM-5656)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

