### PR TITLE
CRAYSAT-2018: Update csm-testing and goss-servers RPMs

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.29-1.noarch
+    - csm-testing-1.19.31-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.29-1.noarch
+    - goss-servers-1.19.31-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Update csm-testing and goss-servers to latest 1.19.31-1 version for CSM
1.7. This includes the fix for CRAYSAT-2018.

## Issues and Related PRs

* Resolves CRAYSAT-2018

## Testing

### Tested on:

  * noname

### Test description:

Executed goss tests on noname.

## Risks and Mitigations

Very low risk change to SAT functional testing Goss files.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

