### PR TITLE
CASM-5499: Add conditional deployment for RRS (Rack Resiliency Service) helm chart

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -310,9 +310,9 @@ spec:
     namespace: kube-system
   - name: cray-rrs
     source: csm-algol60
-    version: 1.0.2
+    version: 1.0.3
     namespace: rack-resiliency
     swagger:
     - name: rrs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.0.1/src/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.0.3/src/api/openapi.yaml


### PR DESCRIPTION
## Summary and Scope
[CASM-5499](https://jira-pro.it.hpe.com:8443/browse/CASM-5499): Add conditional deployment for RRS (Rack Resiliency Service) helm chart.

Deploy RRS (Rack Resiliency Service) helm chart only when Rack Resiliency feature is enabled and also configured/ setup
with zones (k8s and Ceph).

## Issues and Related PRs

[CASM-5499](https://jira-pro.it.hpe.com:8443/browse/CASM-5499): As a developer, I need to add management nodes rollout post-hook for RRS helm chart deployment

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:
surtur baremetal system

### Test description:

Tested cases with upgrade, where RR is disabled and also RR enabled:
- When RR is disabled RRS chart is not deployed
- When RR is enabled and also when zones (k8s and Ceph) are created/ present, RRS chart is deployed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ NA] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

