### PR TITLE
CRAYSAT-1944: Update cray-sat to 3.35.18

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.35.17
+      - 3.35.18
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

This includes the fix for CRAYSAT-1944, which greatly improves the
performance of the `sat bootprep` and `sat showrev` commands, especially
on systems which have a large number of different versions of products
in the product catalog.

## Issues and Related PRs

* Resolves CRAYSAT-1944

## Testing

### Tested on:

  * rocket

### Test description:

See https://github.com/Cray-HPE/sat/pull/368 for details.

## Risks and Mitigations

There is some risk due to the refactoring necessary to improve the performance of the product-catalog query code, but it is mitigated by the amount of testing performed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

