### PR TITLE
CASMNET-2343 - Cilium hubble-ui CVE remediation

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.31
+KUBERNETES_IMAGE_ID=7.1.32
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.31
+PIT_IMAGE_ID=7.1.32
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.31
+STORAGE_CEPH_IMAGE_ID=7.1.32
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.31
+COMPUTE_IMAGE_ID=7.1.32
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -186,9 +186,9 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/cilium/hubble-relay:
       - v1.16.5
     quay.io/cilium/hubble-ui:
-      - v0.13.1
+      - v0.13.2
     quay.io/cilium/hubble-ui-backend:
-      - v0.13.1
+      - v0.13.2
 
     # Cilium Tetragon images
     quay.io/cilium/tetragon:

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -130,8 +130,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.2
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.2
   - name: cray-kyverno
     source: csm-algol60
     version: 1.7.6

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -111,8 +111,8 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.1
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.1
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.2
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.2
   - name: cray-kyverno
     source: csm-algol60
     version: 1.7.6


### PR DESCRIPTION
## Summary and Scope

Cilium Hubble UI CVE remediation

## Issues and Related PRs

* Resolves [CASMNET-2343](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2343)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Tested on vshasta environment `scanlan` as part of a full CSM 1.7.0 installation.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

