### PR TITLE
CASMPET-7644: Remove v1.24.17 kube-* images from CSM 1.7

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.31
+KUBERNETES_IMAGE_ID=7.1.34
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.31
+PIT_IMAGE_ID=7.1.34
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.31
+STORAGE_CEPH_IMAGE_ID=7.1.34
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.31
+COMPUTE_IMAGE_ID=7.1.34
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -125,7 +125,6 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Kube images required by platform
     registry.k8s.io/kube-apiserver:
-      - v1.24.17
       - v1.26.15
       - v1.27.16
       - v1.28.15
@@ -134,7 +133,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.31.8
       - v1.32.5
     registry.k8s.io/kube-controller-manager:
-      - v1.24.17
       - v1.26.15
       - v1.27.16
       - v1.28.15
@@ -143,7 +141,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.31.8
       - v1.32.5
     registry.k8s.io/kube-proxy:
-      - v1.24.17
       - v1.26.15
       - v1.27.16
       - v1.28.15
@@ -152,7 +149,6 @@ artifactory.algol60.net/csm-docker/stable:
       - v1.31.8
       - v1.32.5
     registry.k8s.io/kube-scheduler:
-      - v1.24.17
       - v1.26.15
       - v1.27.16
       - v1.28.15


### PR DESCRIPTION
## Summary and Scope
CASMPET-7644: Remove v1.24.17 kube-* images from CSM 1.7 since they are not needed and contain CVEs

## Issues and Related PRs
* Resolves [CASMPET-7644](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7644)

## Testing
Tested install on `molly`
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2222/

Tested upgrade on `orym`
csm changes w/o node-images changes:
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2212/

csm changes with node-images changes:
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2241/
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2237/

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

