### PR TITLE
CASMHMS-6578: Added SMD migration to prune SMD database (1.7)

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -52,7 +52,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.7
+    version: 7.2.8
     namespace: services
     values:
       cray-service:
@@ -64,7 +64,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.38.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.40.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -43,7 +43,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.7
+    version: 7.2.8
     namespace: services
     values:
       cray-service:
@@ -55,7 +55,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.39.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.40.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3


### PR DESCRIPTION
### Summary and Scope

This is a follow up change, related to [CASMHMS-6568](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6568).  Those prior changes prevent duplicate "Detected" events from being added to the postgres database.  The changes in this new PR provide the ability to remove duplicate "Detected" events that were added prior to those changes.

This pruning is facilitated in two ways.  First, a postgres migration has been added which prunes out the duplicated "Detected" events during an upgrade of the SMD helm chart.  Second, a bash script has been added that performs the same actions as the migration.  A script is necessary so that it can be delivered to customers outside of a formal release as they need immediate relief.  This script will also be run by `prerequisites.sh` in docs-csm during a CSM 1.5 to 1.6 or 1.6. to 1.7 upgrade.

Scripts to backup and restore the `hwinv_hist` and `hwinv_by_loc` database tables were also added.  These were necessary to facilitate local testing on a laptop with data gathered from the customer system and also provide a way to restore data should the migration have any issues and lead to corruption of the database.

All bash scripts will be added to docs-csm via the PRs below:

- 1.5 docs-csm: [docs-csm/pull/6174](https://github.com/Cray-HPE/docs-csm/pull/6174)
- 1.6 docs-csm: [docs-csm/pull/6173](https://github.com/Cray-HPE/docs-csm/pull/6173)
- 1.7 docs-csm: [docs-csm/pull/6172](https://github.com/Cray-HPE/docs-csm/pull/6172)

File execution bits were also added to the dev scripts that spin up and tear down local dev environments.

Adopted app version 2.32.3 for CSM 1.6.3 (helm chart 7.1.24)
Adopted app version 2.40.0 for CSM 1.7.0 (helm chart 7.2.8)

### Issues and Related PRs

* Resolves [CASMHMS-6578](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6578)

### Testing

#### Tested on:

* Laptop
* `mug`
* `tyr`

#### Test Description:

The `hwinv_hist` and `hwinv_by_loc` tables were dumped from `mug` and `tyr` as well as from the customer system where this issue was originally reported.  Dumps of those tables were loaded into a local laptop dev environment and used to develop the migration and bash scripts.  Confirmed correct events were removed by using a temporary script that printed exactly which events were removed.

In the local laptop dev environment, the `hwinv_hist` table dump from the customer was 79831 MB before pruning and 182 MB after pruning.  It took approximately 17 minutes for the pruning to complete.  I've found that pruning on my laptop was about 2-3 times faster than pruning on tyr so it is likely that for this customer it could take up to 45 minutes for the pruning operaiton to complete.  If they perform manual pruning with the bash script then the migration will run pretty quickly at upgrade time.  I'll add all this info to the docs-csm change.

These changes were also rolled out on `mug` and `tyr` where both the script and migration were run and verified to agree with the results generated in the local laptop dev environment.

Ran the SMD CT smoke and integration tests.  Confirmed no additonal failures.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable