### PR TITLE
CASMTRIAGE-8566 - canu report switch firmware fails for Mellanox

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.34
+KUBERNETES_IMAGE_ID=7.1.35
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.34
+PIT_IMAGE_ID=7.1.35
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.34
+STORAGE_CEPH_IMAGE_ID=7.1.35
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.34
+COMPUTE_IMAGE_ID=7.1.35
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.0-1.x86_64
-    - canu-2.0.1-1.x86_64
+    - canu-2.0.3-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

The removal of the canu cache code in https://github.com/Cray-HPE/canu/pull/688 broke firmware version reporting for Mellanox devices because the commands used to gather the data were changed and the output processing doesn't work.

```
ncn-m001:~ # canu report switch firmware --csm 1.7 --ip 10.254.0.2 --password $SW_PASSWD
Traceback (most recent call last):
  File "cli.py", line 289, in <module>
  File "click/core.py", line 1161, in __call__
  File "click/core.py", line 1082, in main
  File "click/core.py", line 1697, in invoke
  File "click/core.py", line 1697, in invoke
  File "click/core.py", line 1697, in invoke
  File "click/core.py", line 1443, in invoke
  File "click/core.py", line 788, in invoke
  File "click/decorators.py", line 33, in new_func
  File "report/switch/firmware/firmware.py", line 146, in firmware
  File "ruamel/yaml/comments.py", line 853, in __getitem__
KeyError: '-----------------------------------------------------------------------------\nModule           Part Number        Serial Number        Asic Rev.    HW Rev.\n-----------------------------------------------------------------------------\nCHASSIS          MSN2100-CB2F       MT1933X19235         N/A          B8\nMGMT             MSN2100-CB2F       MT1933X19235         1            B8'
[PYI-1594451:ERROR] Failed to execute script 'cli' due to unhandled exception!
```

This also broke `canu report network firmware` for Mellanox devices although that command handles it a little more gracefully.

```
ncn-m001:~ # canu report network firmware --csm 1.7 --ips 10.254.0.2,10.254.0.3,10.254.0.4 --password $SW_PASSWD
------------------------------------------------------------------
    STATUS  IP              HOSTNAME            FIRMWARE
------------------------------------------------------------------
 🔺 Error   10.254.0.2
 🔺 Error   10.254.0.3
 🛶 Pass    10.254.0.4      sw-leaf-bmc-001     10.5.1.4


Errors
------------------------------------------------------------------
10.254.0.2      - Could not determine the vendor of the switch.
10.254.0.3      - Could not determine the vendor of the switch.

Summary
------------------------------------------------------------------
🔺 Error - 2 switches
🛶 Pass - 1 switches
10.5.1.4 - 1 switches
```

This PR resolves this issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8566](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8566)
* Change will also be needed in `<insert branch name here>`
* Merge after 
  * https://github.com/Cray-HPE/canu/pull/724
  * https://github.com/Cray-HPE/node-images/pull/1278

## Testing


### Tested on:

  * `wasp`

### Test description:

Installed new RPM containing this change on wasp.

* `canu report switch firmware` output
   ```
   ncn-m001:~ # canu report switch firmware --csm 1.7 --ip 10.254.0.2 --password $SW_PASSWD
   🛶 - Pass - IP: 10.254.0.2 Hostname: sw-spine-001 Firmware: 3.9.3210
   ```
* `canu report network firmware` output
   ```
   ncn-m001:~ # canu report network firmware --csm 1.7 --ips 10.254.0.2,10.254.0.3,10.254.0.4 --password $SW_PASSWD
   ------------------------------------------------------------------
       STATUS  IP              HOSTNAME            FIRMWARE
   ------------------------------------------------------------------
    🛶 Pass    10.254.0.2      sw-spine-001        3.9.3210
    🛶 Pass    10.254.0.3      sw-spine-002        3.9.3210
    🛶 Pass    10.254.0.4      sw-leaf-bmc-001     10.5.1.4

   Summary
   ------------------------------------------------------------------
   🛶 Pass - 3 switches
   3.9.3210 - 2 switches
   10.5.1.4 - 1 switches
   ```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

