### PR TITLE
CASM-5671/CASM-5672/CASM-5673/CASMTRIAGE-8547: Resolve problems in rack resiliency playbook

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.45.0
+    version: 1.46.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This resolves several problems with the rack resiliency CFS playbook.

## Issues and Related PRs

* Resolves CASM-5671
* Resolves CASM-5672
* Resolves CASM-5673
* Resolves CASMTRIAGE-8547

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

