### PR TITLE
CASMTRIAGE-8587 cray-nexus deployment fails on nexus-init post-install hook

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -202,7 +202,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Images needed by IUF and possibly non-CSM products
     cray-nexus-setup:
-      - 0.12.1
+      - 0.12.2
 
     # not needed for build/install as it comes packaged as skopeo.tar
     quay.io/skopeo/stable:

--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -33,6 +33,6 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.14.1
+    version: 0.14.2
     namespace: nexus
     timeout: 10m0s

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -124,7 +124,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2
       # Cilium
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -105,7 +105,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
-      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.1
+      - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2
       # Cilium
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8


### PR DESCRIPTION
## Summary and Scope

It appears that `nexus-ready` script provided with `cray-nexus-setup` image changes state of the system: if script is sourced from another script, it sets up authentication by creating temporary directory, writing `.curlrc` and `.netrc` files into it and exporting it as `CURL_HOME` environment variable. Which causes the following issue: if `nexus-ready` is sourced more then once, during 2nd run a call to `/service/rest/v1/status/writable` API endpoint fails, because it contains authentication headers unnecessary for this call.

The `nexus-init` post-install hook job follows exactly this scenario: it sources `nexus-ready` directly, then runs `nexus-remove-default-repositories` which calls `nexus-ready` again, which fails, because `CURL_HOME` env variable is already exported.

The fix is to override `CURL_HOME` environment variable specifically for `/service/rest/v1/status/writable` API call.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8587](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8587)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Created new job, similar to a failing job, which modifies `nexus-ready` script on the fly, by issuing `sed` command right before `nexus-ready` is sourced for the first time:

    spec:
      containers:
      - command:
        - /bin/bash
        - -c
        - |-
          set -x

          # Wait for Nexus to be available
          while ! nexus-ready; do
              echo >&2 "Trying again in 10 seconds"
              sleep 10
          done

          set -e
          sed -i -e 's/curl -sfk/CURL_HOME="" curl -sfk/' /usr/local/bin/nexus-ready

          . "$(command -v nexus-ready)"

          nexus-remove-default-repos >&2

Pod log from old job:

    pit:~ # kubectl -n nexus logs nexus-init-289vv
    + nexus-ready
    + set -e
    ++ command -v nexus-ready
    + . /usr/local/bin/nexus-ready
    ++ command -v curl
    ++ URL=http://nexus/service/rest
    ++ curl -sfk http://nexus/service/rest/v1/status/writable
    ++ return 0
    ++ [[ ! -v CURL_HOME ]]
    +++ mktemp -d
    ++ curl_home=/tmp/tmp.dokgKe
    ++ trap 'rm -fr '\''/tmp/tmp.dokgKe'\''' EXIT
    ++ nexus-curl-auth /tmp/tmp.dokgKe
    ++ export CURL_HOME=/tmp/tmp.dokgKe
    ++ CURL_HOME=/tmp/tmp.dokgKe
    + nexus-remove-default-repos
    error: not ready: http://nexus
    + rm -fr /tmp/tmp.dokgKe

Pod log from new job:

    pit:~ # kubectl -n nexus logs nexus-init-1-mm99f
    + nexus-ready
    + set -e
    + sed -i -e 's/curl -sfk/CURL_HOME= curl -sfk/' /usr/local/bin/nexus-ready
    ++ command -v nexus-ready
    + . /usr/local/bin/nexus-ready
    ++ command -v curl
    ++ URL=http://nexus/service/rest
    ++ CURL_HOME=
    ++ curl -sfk http://nexus/service/rest/v1/status/writable
    ++ return 0
    ++ [[ ! -v CURL_HOME ]]
    +++ mktemp -d
    ++ curl_home=/tmp/tmp.mGoEej
    ++ trap 'rm -fr '\''/tmp/tmp.mGoEej'\''' EXIT
    ++ nexus-curl-auth /tmp/tmp.mGoEej
    ++ export CURL_HOME=/tmp/tmp.mGoEej
    ++ CURL_HOME=/tmp/tmp.mGoEej
    + nexus-remove-default-repos
    + rm -fr /tmp/tmp.mGoEej


## Risks and Mitigations

None known.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

