### PR TITLE
 CASM-5675: The length of zone name to be fixed

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.37
+KUBERNETES_IMAGE_ID=7.1.38
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.37
+PIT_IMAGE_ID=7.1.38
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.37
+STORAGE_CEPH_IMAGE_ID=7.1.38
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.37
+COMPUTE_IMAGE_ID=7.1.38
 
 # Public keys for RPM signature validation.
 #

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -310,9 +310,9 @@ spec:
     namespace: kube-system
   - name: cray-rrs
     source: csm-algol60
-    version: 1.0.3
+    version: 1.0.4
     namespace: rack-resiliency
     swagger:
     - name: rrs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.0.3/src/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.0.4/src/api/openapi.yaml

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -36,8 +36,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-2.0.5-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch
-    - craycli-0.98.0-1.aarch64
-    - craycli-0.98.0-1.x86_64
+    - craycli-0.99.0-1.aarch64
+    - craycli-0.99.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
     - csm-netif-dracut-2.0-1.noarch
     - csm-node-heartbeat-2.8-1.aarch64


### PR DESCRIPTION
  - new RRS version for CASM-5675

## Summary and Scope

New version for RRS helm chart for  [CASM-5675](https://jira-pro.it.hpe.com:8443/browse/CASM-5675)

Need to fix the length of the Rack Resiliency zone (Kubernetes and Ceph) names. Since the zone name is a label, as per Kubernetes standards, the name length should be 1-63.

## Issues and Related PRs

[CASM-5675](https://jira-pro.it.hpe.com:8443/browse/CASM-5675)

## Testing

_List the environments in which these changes were tested._

### Tested on:

Odin bare metal

### Test description:

- Tested the zones name length with `cray rrs zones describe zone-name` command
 
_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [NA] Testing is appropriate and complete, if applicable
- [NA] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable