### PR TITLE
CRAYSAT-2022: Update csm-testing to 1.19.34-1

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.33-1.noarch
+    - csm-testing-1.19.34-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.33-1.noarch
+    - goss-servers-1.19.34-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Update the csm-testing and goss-servers RPMs to 1.19.34-1. Includes the
following:

* CRAYSAT-2022: Dynamically generate SAT Goss tests
* CRAYSAT-2013: Create functional tests for `sat hwinv` summarize
  options

## Issues and Related PRs

* Resolves CRAYSAT-2022
* Resolves CRAYSAT-2013

## Testing

### Tested on:

* Various systems including rocket

### Test description:

See csm-testing PRs for detailed testing descriptions.

## Risks and Mitigations

This is pretty low-risk as the changes are confined to the SAT functional test
Goss files and the `sat_functional` Python package that implements the tests.
These tests will soon be included in the DST install test pipeline, but they are
not yet included in the vShasta pipeline, so it should not affect anything
there.

The only change that could affect perhaps the vShasta pipeline is a change to
the `run-ncn-tests.sh` script to generate the SAT variables. I had Mikhail and
Jacob review that change, and I tested that manually, but there could be some
small risk there to the vShasta pipeline.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

