### PR TITLE
CASMCMS-9512: Remove inappropriate calls to end_play in csm.ssh roles

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.46.0
+    version: 1.46.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This fixes a longstanding bug in `csm-config` that can prevent some Ansible roles from being skipped when they shouldn't be.

## Issues and Related PRs

* Resolves CASMCMS-9512
* CASMCMS-9517 is open update the 1.7.1 release notes to list this fix
* CASMCMS-9511 is open to document this bug as a known issue in CSM releases where it is not fixed
* If https://github.com/Cray-HPE/csm/pull/4294 merges before this PR does, then this one can be closed, as that PR contains the fix that is in this one.

## Testing

Tested on wasp to make sure that it no longer skips the roles when the credentials in Vault are not set.

## Risks and Mitigations

Low risk -- minor change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

