### PR TITLE
CASMPET-7547: Increment cray-vpa chart to version 1.0.3

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -296,7 +296,7 @@ spec:
     namespace: services
   - name: cray-vpa
     source: csm-algol60
-    version: 1.0.2
+    version: 1.0.3
     namespace: services
   # DO NOT INSTALL the cray-hubble chart, install after upgraded to K8s 1.32
   # DO NOT INSTALL the rack-resiliency chart, install after upgraded to K8s 1.32

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -302,7 +302,7 @@ spec:
     namespace: services
   - name: cray-vpa
     source: csm-algol60
-    version: 1.0.2
+    version: 1.0.3
     namespace: services
   - name: cray-hubble
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
CASMPET-7547
Increment the `cray-vpa` chart to 1.0.3. This chart version uses `docker-kubectl:1.32.2` for the tests container image rather than the CVE ridden `library/bitnami/kubectl:1.32` image.

## Issues and Related PRs
* Resolves [CASMPET-7547](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7547)

## Testing

See `cray-vpa` PR for testing details.
https://github.com/Cray-HPE/cray-vpa/pull/10

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

