### PR TITLE
CASM-5685: RR storage play still assumes kubectl configured on all storage nodes

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.47.0
+    version: 1.48.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

The csm.rr.mgmt_nodes_placement_discovery role uses kubectl command to run on the management nodes to get Kubernetes info and that needs to change to use native Ansible inside the CFS pod to get the information from Kubernetes in order to avoid any failures on management nodes (Master and Storage nodes) which are not configured with kubectl.

## Issues and Related PRs
[CASM-5685](https://jira-pro.it.hpe.com:8443/browse/CASM-5685): RR storage play still assumes kubectl configured on all storage nodes

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

Tested Ansible plays deployments with CFS.

### Test description:

Verifying on Storage nodes:

Fanta has only 3 storage nodes as below. We have tested CFS to make it runs on storage node-3 (mention of XNAME during management rollout) and it has been successful.

| x3000c0s13b0n0 | ncn-s001 | Node | 100007 | Ready | OK | True | X86 | River | Management | Storage | Sling | management-csm-1.6.2 | configured | 0 | stable | MISSING | MISSING |
| x3000c0s15b0n0 | ncn-s002 | Node | 100008 | Ready | OK | True | X86 | River | Management | Storage | Sling | management-csm-1.6.2 | configured | 0 | stable | MISSING | MISSING |
| x3000c0s17b0n0 | ncn-s003 | Node | 100009 | Ready | OK | True | X86 | River | Management | Storage | Sling | management-csm-1.6.2 | configured | 0 | stable | MISSING | MISSING |

PLAY RECAP *********************************************************************

Running rack_resiliency_for_mgmt_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Master:!cfs_image] ********************************************
skipping: no hosts matched

PLAY [Management_Storage:!cfs_image] *******************************************

TASK [csm.rr.mgmt_nodes_placement_discovery : Discover racks and corresponding management nodes placement] ***
changed: [x3000c0s7b0n0 -> x3000c0s7b0n0]

PLAY RECAP *********************************************************************
x3000c0s7b0n0 : ok=5 changed=1 unreachable=0 failed=0 skipped=0 rescued=0 ignored=0

All playbooks completed successfully
ncn-m001:/etc/cray/upgrade/csm #

Verifying on Master nodes:

ncn-m001:~/sav/csm-config-management # kubectl logs -n services "${CFS_POD_NAME}" ansible
'/etc/pki/trust/anchors/46Rvw3.certificate_authority.crt' -> '/etc/cray/ca/certificate_authority.crt'
Inventory generation completed
SSH keys migrated to /root/.ssh
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0
HTTP/1.1 200 OK
content-type: text/html; charset=UTF-8
cache-control: no-cache, max-age=0
x-content-type-options: nosniff
date: Fri, 15 Aug 2025 06:24:06 GMT
server: envoy
transfer-encoding: chunked

Sidecar available
Running ncn_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Master,Management_Worker,Management_Storage] ******************

TASK [trust-csm-ssh-keys : Inject CSM public Key into SSH authorized_keys file] ***
changed: [x3000c0s3b0n0]

TASK [csm.ca_cert : Run certificate update scripts] ****************************
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/50java.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 405, 'inode': 70980, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/70openssl.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 336, 'inode': 70981, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/80etc_ssl.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1868, 'inode': 70982, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/99certbundle.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 961, 'inode': 70983, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})

TASK [passwordless-ssh : Write private keyfile to disk with appropriate permissions] ***
changed: [x3000c0s3b0n0]

TASK [passwordless-ssh : Create the CSM public key file on target hosts] *******
changed: [x3000c0s3b0n0]

TASK [csm.ssh_config : Lookup the SSH config value in Vault] *******************
fatal: [x3000c0s3b0n0 -> localhost]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}

PLAY [Management_Master,Management_Worker] *************************************

TASK [csm.gpg_keys : include_tasks] ********************************************
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.packages : Configure CSM RPM Repos (SLES-based)] *********************
changed: [x3000c0s3b0n0] => (item={'name': 'csm-sle', 'description': 'CSM SLE Packages (added by Ansible)', 'repo': '[https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}'}](https://packages.local/repository/csm-sle-$%7Breleasever_major%7Dsp$%7Breleasever_minor%7D'%7D))

TASK [csm.packages : Allow unsigned repo metadata] *****************************
changed: [x3000c0s3b0n0] => (item={'name': 'csm-sle', 'description': 'CSM SLE Packages (added by Ansible)', 'repo': '[https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}'}](https://packages.local/repository/csm-sle-$%7Breleasever_major%7Dsp$%7Breleasever_minor%7D'%7D))
changed: [x3000c0s3b0n0] => (item={'name': 'csm-noos', 'description': 'CSM No-OS Packages (added by Ansible)', 'repo': '[https://packages.local/repository/csm-noos'}](https://packages.local/repository/csm-noos'%7D))
changed: [x3000c0s3b0n0] => (item={'name': 'csm-embedded', 'description': 'CSM Embedded NCN Packages (added by Ansible)', 'repo': '[https://packages.local/repository/csm-embedded'}](https://packages.local/repository/csm-embedded'%7D))

PLAY [Management_Worker] *******************************************************
skipping: no hosts matched

PLAY [Management_Storage] ******************************************************
skipping: no hosts matched
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Storage:!cfs_image] *******************************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
x3000c0s3b0n0 : ok=69 changed=24 unreachable=0 failed=0 skipped=3 rescued=1 ignored=0

Running ncn-initrd.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Master:Management_Worker:Management_Storage:&cfs_image] *******
skipping: no hosts matched

PLAY RECAP *********************************************************************

Running rack_resiliency_for_mgmt_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Master:!cfs_image] ********************************************

TASK [csm.rr.mgmt_nodes_placement_discovery : Discover racks and corresponding management nodes placement] ***
changed: [x3000c0s3b0n0 -> x3000c0s3b0n0]

PLAY [Management_Storage:!cfs_image] *******************************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
x3000c0s3b0n0 : ok=6 changed=1 unreachable=0 failed=0 skipped=0 rescued=0 ignored=0

All playbooks completed successfully
ncn-m001:/sav/csm-config-management # ssh ncn-m003
...
ncn-m003: # cat /tmp/rack_info.txt
{
"x3000": [
"ncn-s002",
"ncn-s003",
"ncn-m001",
"ncn-s001",
"ncn-m003",
"ncn-w002",
"ncn-w001",
"ncn-w003",
"ncn-m002"
]
}
ncn-m003:~ # ls -ltr /tmp/rack_info.txt
-rw-r--r-- 1 root root 204 Aug 15 06:26 /tmp/rack_info.txt
ncn-m003:~ #?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

