### PR TITLE
CASMHMS-6570: Convert PCS status requests from GET to POST in CAPMC (CSM 1.6.3)

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -45,12 +45,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.30.1/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 5.0.0
+    version: 5.0.1
     namespace: services
     swagger:
     - name: capmc
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.1/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
     version: 3.1.13


### PR DESCRIPTION
### Summary and Scope

Customer reported CT test failures showing a capmc CT test constructing GET status requests to PCS with URLs containing too many characters due to specifying all xnames in the system.  This PR changes capmc from using GET to POST for PCS status requests so that lengthy lists of xnames are passed in the request body rather than encoded into the URL.

Changes in capmc's test environment were also required as part of this change.

The 1.6.3 PR included some changes not required by the 1.7.0 PR.  The CT docker-compose file was referencing an old version of PCS that did not have POST support for component status.  I updated the docker-compose file to reference the version of PCS in the CSM 1.6.3 release as well as 1.6.3 versions of other HMS components.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 because we were having build issues.

Adopted app version 3.6.1 for CSM 1.6.3 (helm chart 5.0.1)
Adopted app version 3.9.0 for CSM 1.7.0 (helm chart 5.1.3)

### Issues and Related PRs

* Resolves [CASMHMS-6570](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6570)

### Testing

#### Tested on:

* Laptop
* `rocket` (1.6.3 system)

#### Test Description:

Loaded dev version of capmc on to rocket.  Watched both capmc and PCS logs for issues.  Ran various capmc status requests to ensure properly formated requests and responses passed between capmc and PCS.

Ran the capmc CT smoke and integration tests.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable