### PR TITLE
CASMTRIAGE-8682: Fix false positive test failure in FAS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -53,12 +53,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.6.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
-    version: 3.1.13
+    version: 3.1.14
     namespace: services
     swagger:
     - name: firmware-action
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.33.0/api/docs/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-firmware-action/v1.38.1/api/docs/swagger.yaml
   - name: cray-hms-hbtd
     source: csm-algol60
     version: 3.1.3


### PR DESCRIPTION
### Summary and Scope

Fixed false positive test failure.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 so that builds complete.

Adopted app version 1.38.1 for CSM 1.6.3 (helm chart 3.1.14).

### Issues and Related PRs

* Resolves [CASMTRIAGE-8682](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8682)
* Resolves [CASMTRIAGE-8151](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8151)

### Testing

Tested on:

* `rocket`

Test description:

Ran CT tests to ensure no issues or failures present.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

