### PR TITLE
CASMTRIAGE-8638: Manifest PR

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.48.0
+    version: 1.48.1
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

New version for CSM-config in sysmgmt.yaml. 
## Issues and Related PRs

[CASMTRIAGE-8638](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8638) RR k8s zone prefix is not getting applied correctly

## Testing

### Tested on:

  * `fanta`

### Test description:

Refer to [csm-config PR](https://github.com/Cray-HPE/csm-config/pull/413) for detailed description.

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X ] Target branch correct
- [X ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

