### PR TITLE
Set CSM_BASE_VERSION to 1.7.0-rc.9

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -59,7 +59,7 @@ pipeline {
 
     environment {
         DOCS_CSM_BRANCH = "release/1.7"
-        CSM_BASE_VERSION = "1.7.0-rc.8"
+        CSM_BASE_VERSION = "1.7.0-rc.9"
         ARTIFACTORY = credentials('artifactory-algol60-readonly')
         PARALLEL_JOBS = "75%"
         SNYK_TOKEN = credentials('SNYK_TOKEN')


### PR DESCRIPTION
## Summary and Scope
Set CSM_BASE_VERSION to 1.7.0-rc.9

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

