### PR TITLE
CASMPET-7660: csm-config: Make sbps_dns_srv_records.sh more verbose

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.48.1
+    version: 1.48.2
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

Modify the `sbps_dns_srv_records.sh` script in `csm-config` so that it produces output as it runs, rather than giving no output at all. Under normal circumstances the output from the script is not saved or seen. It is run as part of a CFS session, and the output will only show up if the script fails or if the Ansible verbosity has been increased by the administrator. So under normal circumstances, this PR has no effect.

## Issues and Related PRs

* Resolves [CASMPET-7660](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7660)
* Should help us debug [CASMTRIAGE-8636|https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8636] if it is hit again.

## Testing

I tested this extensively on fanta, verifying that these changes do not impact the script from doing its job, and verifying that when I increase the Ansible verbosity, the desired output is available.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

