### PR TITLE
CRAYSAT-2035: Update csm-testing and goss-servers to 1.19.36-1

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.34-1.noarch
+    - csm-testing-1.19.36-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.34-1.noarch
+    - goss-servers-1.19.36-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Update the csm-testing and goss-servers RPMs from 1.19.34-1 to
1.19.36-1.

Changes includes in 1.19.35-1:

* CRAYSAT-1968: create functional tests for sat status --format in csm-testing
* CRAYSAT-2029: Fix nid2xname functional test failure
* CRAYSAT-2009: Split bootprep tests into separate TestCase classes
* CRAYSAT-2024: Improve resiliency of sat_functional.version.test_version test

Changes included in 1.19.36-1:

* CRAYSAT-2006, CRAYSAT-2035: Improve sat bootprep tests
* CRAYSAT-1963: Add new Goss endpoint for SAT functional test suite

## Issues and Related PRs

See above.

## Testing

### Tested on:

  * vinland

### Test description:

See individual csm-testing PRs for detailed test descriptions.

## Risks and Mitigations

This adds a new Goss endpoint, but so far nothing should be using it. We would
like to add a call to it to the vShasta pipeline to ensure that these tests are
executed in the context to detect problems earlier than the DST pipeline.

The tests are now executed in the DST pipeline as functional tests in the
CSM-GOSS configuration file.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

