### PR TITLE
CASMTRIAGE-8670: Update nexus set password

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -33,6 +33,6 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.14.3
+    version: 0.14.4
     namespace: nexus
     timeout: 10m0s


### PR DESCRIPTION
## Summary and Scope

This is a bugfix

## Issues and Related PRs

* Resolves [CASMTRIAGE-8670](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8670)

## Testing

### Tested on:

  * beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Does not add risk, nexus is already checked to be ready by the time this is called and then it is checked again in the function being called. So there is no reason to check if nexus is ready a third time that is less reliable output.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

