### PR TITLE
CASMNET-2366 - cray-dns-unbound-manager should not remove records if Kea response is empty

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -74,11 +74,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.10.0 # update platform.yaml cray-precache-images with this
+    version: 0.10.1 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.10.0
+        appVersion: 0.10.1
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -91,7 +91,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

It's possible for `cray-dns-unbound-manager` to get a response from the Kea API that contains no reservation data.

When this occurs `cray-dns-unbound-manager` continues processing which can result in records being deleted.

```
2025-08-28 11:54:15,647 - __main__ - ERROR - Kea API returned successfully, but with no leases.
2025-08-28 11:54:15,647 - __main__ - ERROR -     return code: 1
2025-08-28 11:54:15,647 - __main__ - ERROR -     return data: [{'result': 1, 'text': 'unable to forward command to the dhcp4 service: No such file or directory. The server is likely to be offline'}]
---
2025-08-28 11:54:17,284 - __main__ - INFO - Number of new records (including duplicates) 14431
```
The next run that occurs when Kea is working properly restores the records.
```
2025-08-28 11:56:39,447 - __main__ - INFO - Retrieved Kea data 26s
2025-08-28 11:56:39,448 - __main__ - INFO - Found 213 leases and reservations in Kea globals
2025-08-28 11:56:39,448 - __main__ - INFO - Found 87 subnets in Kea
2025-08-28 11:56:39,454 - __main__ - INFO - Found 8954 leases and reservations in Kea local subnets 0s
2025-08-28 11:56:42,338 - __main__ - INFO - Gathered 8954 total leases and reservations local and global 2s
---
2025-08-28 11:57:36,179 - __main__ - INFO - Number of existing records 14431
2025-08-28 11:57:36,179 - __main__ - INFO - Number of new records (including duplicates) 56206
```
This behaviour is undesirable as loss of access to hardware components can occur until DNS rights itself.

This PR changes the behaviour of `cray-dns-unbound-manager` such that if the response from Kea is empty and fewer records were generated than already exist, the DNS configuration is left untouched.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-2366](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2366)

## Testing

### Tested on:

  * `wasp`

### Test description:

Simulated failure by shutting down the `cray-dhcp-kea-postgres` database to force a bad response from the API.

Verified DNS configuration was not updated.

```
ncn-m001:~/cspiller # kubectl -n services logs cray-dns-unbound-manager-29280320-tcpk5
2025-09-02 13:20:08,992 - __main__ - INFO - Using interface h0 to build the nid alias
2025-09-02 13:20:08,992 - __main__ - INFO - Querying Kea in the cluster to find any updated records we need to set
2025-09-02 13:20:09,016 - __main__ - ERROR - Kea response contains error in results code:
2025-09-02 13:20:09,016 - __main__ - ERROR -     results code: 1
2025-09-02 13:20:09,016 - __main__ - ERROR - Kea API returned successfully, but with no leases.
2025-09-02 13:20:09,016 - __main__ - ERROR -     return code: 1
2025-09-02 13:20:09,017 - __main__ - ERROR -     return data: [{'result': 1, 'text': 'unable to forward command to the dhcp4 service: No such file or directory. The server is likely to be offline'}]
2025-09-02 13:20:09,017 - __main__ - INFO - Retrieved Kea data 0s
2025-09-02 13:20:09,017 - __main__ - ERROR - Kea global reservations data is empty
2025-09-02 13:20:09,017 - __main__ - ERROR - Kea Dhcp4 lease and reservation data is empty
2025-09-02 13:20:09,017 - __main__ - INFO - Found 0 leases and reservations in Kea local subnets 0s
2025-09-02 13:20:09,017 - __main__ - INFO - Gathered 0 total leases and reservations local and global 0s
2025-09-02 13:20:09,066 - __main__ - INFO - Queried SMD to find any xname records we need to set 0s
2025-09-02 13:20:09,066 - __main__ - INFO - Found 118 records in SMD
2025-09-02 13:20:09,066 - __main__ - INFO - Merged new SMD xnames into DNS data structure 0s
2025-09-02 13:20:09,093 - __main__ - INFO - Queried SLS to find Management, Application and HSN nid records 0
2025-09-02 13:20:09,093 - __main__ - INFO - Found 39 SLS Hardware records.
2025-09-02 13:20:09,093 - __main__ - INFO - Merged new SLS Application and Management names into DNS data structure
2025-09-02 13:20:09,110 - __main__ - INFO - Queried SLS to find Network records 0
2025-09-02 13:20:09,110 - __main__ - INFO - Found 11 SLS Network records.
2025-09-02 13:20:09,112 - __main__ - INFO - Merged new static and alias SLS entries into DNS data structure 0
2025-09-02 13:20:09,112 - __main__ - INFO - Found 11 compute node nid definitions in SLS hardware.
2025-09-02 13:20:09,112 - __main__ - INFO - Matched 0 compute node nid definitions in SLS network reservations.
2025-09-02 13:20:09,112 - __main__ - INFO - Running kubectl to retrieve existing records and configuration.
Stdout:
apiVersion: v1
binaryData:
  records.json.gz:  <REDACTED>
data:
  custom_records.conf: |-
    # Add any additional local-data or local-data-ptr records here, one per line.
    # See https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#unbound-conf-local-data for syntax.
    # WARNING: Syntax errors here will cause Unbound to fail to start and the cluster DNS service will fail.
    #
    # Examples:
    # local-data: "axfr-service.example.com. A 10.252.4.254"
    # local-data-ptr: "10.252.4.254 axfr-service.example.com"
    # local-data: "_axfr-service._tcp.example.com. 3600 IN SRV 0 100 8080 axfr-service.example.com."
  unbound.conf: |-
    server:
        module-config: "iterator"
        chroot: ""
        interface: 127.0.0.1
        interface: 0.0.0.0
        port: 5053
        so-reuseport: yes
        do-ip6: no
        do-daemonize: no
        use-syslog: no
        logfile: ""
        access-control: 127.0.0.1/32 allow
        num-threads: 2
        verbosity: 0
        log-queries: no
        statistics-interval: 0
        statistics-cumulative: no
        # Minimum lifetime of cache entries in seconds
        cache-min-ttl: 180
        # Maximum lifetime of cached entries
        cache-max-ttl: 3600
        # Maximum lifetime of negative responses
        cache-max-negative-ttl: 5
        prefetch: yes
        prefetch-key: yes
        # Optimisations
        msg-cache-slabs: 2
        rrset-cache-slabs: 2
        infra-cache-slabs: 2
        key-cache-slabs: 2
        # increase memory size of the cache
        rrset-cache-size: 1024m
        msg-cache-size: 512m
        infra-cache-numhosts: 1000000
        # increase buffer size so that no messages are lost in traffic spikes
        so-rcvbuf: 5m
        # Set this to no for compatibility with PBSPro which requires deterministic ordering of rrsets.
        rrset-roundrobin: no
        # Continue to health check down DNS servers so they aren't offline longer than necessary
        infra-keep-probing: yes
        infra-host-ttl: 30

        local-data: "health.check.unbound A 127.0.0.1"
        local-data-ptr: "127.0.0.1 health.check.unbound"
        include: /etc/unbound/records.conf
        include: /etc/unbound/custom_records.conf
        access-control: 10.0.0.0/8 allow
        access-control: 127.0.0.0/8 allow

        local-zone: "local" static
        local-zone: "nmn." static
        local-zone: "hmn." static
        local-zone: "mtl." static
        local-zone: "hsn." static
        local-zone: "can." static
        local-zone: "cmn." static
        local-zone: "chn." static
        local-zone: "10.in-addr.arpa." nodefault

    forward-zone:
        name: .
        forward-addr: 16.110.135.51
        forward-first: yes

    stub-zone:
        name: wasp.hpc.amslabs.hpecorp.net
        stub-addr: 10.92.100.85

    stub-zone:
        name: 10.in-addr.arpa.
        stub-addr: 10.92.100.85

     remote-control:
        control-enable: yes
        control-use-cert: no
        control-interface: 0.0.0.0
kind: ConfigMap
metadata:
  creationTimestamp: "2025-08-19T13:34:09Z"
  labels:
    app.kubernetes.io/instance: cray-dns-unbound
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cray-dns-unbound
    helm.sh/chart: cray-dns-unbound-0.10.0
  name: cray-dns-unbound
  namespace: services
  resourceVersion: "258514"
  uid: 20bf32ba-a48b-44b3-abe5-67bcd83bbcb2

Stderr:

2025-09-02 13:20:09,278 - __main__ - INFO - Loaded current DNS entries from configmap 0
2025-09-02 13:20:09,278 - __main__ - INFO - Number of existing records 402
2025-09-02 13:20:09,278 - __main__ - INFO - Number of new records (including duplicates) 333
2025-09-02 13:20:09,278 - __main__ - INFO - Comparing new and existing DNS records 0
2025-09-02 13:20:09,278 - __main__ - INFO -     Differences found.  NOT writing DNS records to configmap.
2025-09-02 13:20:09,278 - __main__ - INFO -     API errors and generated record was less than previous list
2025-09-02 13:20:09,279 - __main__ - INFO - NO CHANGES to unbound configmap 0
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

