### PR TITLE
CRAYSAT-2026, CRAYSAT-2032: Update `cray-sat` to 3.36.2

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.36.0
+      - 3.36.2
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

Update the `cray-sat` version to 3.36.2 to include fixes for:

- CRAYSAT-2032: 'NoneType' object has no attribute 'hostnames' from
  get_ssh_client
- CRAYSAT-2026: sat hwinv summaries display values in non-deterministic
  order

These are both bugs related to CAST tickets filed by customers.

## Issues and Related PRs

* Resolves CRAYSAT-2032
* Resolves CRAYSAT-2026

## Testing

### Tested on:

  * vinland
  * wasp
  * rocket

### Test description:

See PRs to the sat repository for details.

## Risks and Mitigations

Pretty low-risk isolated fixes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

