### PR TITLE
CASMPET-7477: Update external-dns to version 0.17.0

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -196,7 +196,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.6.1
+    version: 1.7.0
     namespace: services
   # DO NOT INSTALL the cray-sysmgmt-health chart, install after upgraded to K8s 1.32
   # DO NOT INSTALL the cray-postgres-operator, it gets upgraded in prerequisites.sh

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -183,7 +183,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.6.1
+    version: 1.7.0
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
CASMPET-7477: Update external-dns to version 0.17.0 to decrease CVEs.
Update `cray-externaldns` chart to version 1.7.0 which uses `external-dns 0.17.0`.

## Issues and Related PRs

* Resolves [CASMPET-7477](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7477)

## Testing
Tested on `beau` and `wasp`.  See [cray-externaldns](https://github.com/Cray-HPE/cray-externaldns/pull/8) for testing details.

## Risks and Mitigations
Low. `external-dns` 0.17.0 didn't have any documented breaking changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

