### PR TITLE
CRAYSAT-2032: Update sat image to 3.33.11

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.33.10
+      - 3.33.11
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Update the cray-sat version to 3.33.11 to include fixes for:

[CRAYSAT-2032](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2032): 'NoneType' object has no attribute 'hostnames' from
get_ssh_client

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2032](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2032): https://github.com/Cray-HPE/sat/pull/371

## Testing

_See the linked PR._

## Risks and Mitigations

_See the linked PR_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

