### PR TITLE
CASMTRIAGE-8684: Update nexus-set-admin-password

### DIFF
--- a/manifests/nexus.yaml
+++ b/manifests/nexus.yaml
@@ -33,6 +33,6 @@ spec:
   charts:
   - name: cray-nexus
     source: csm-algol60
-    version: 0.14.4
+    version: 0.14.6
     namespace: nexus
     timeout: 10m0s


### PR DESCRIPTION
## Summary and Scope

Bug where the URL in the nexus-set-admin-password is not correct so it never changes the password.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8684](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8684)

## Testing

### Tested on:

  * beau

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

less risk fixing a bug


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

