### PR TITLE
CRAYSAT-1962: update csm-testing to 1.19.37

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,7 +48,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.36-1.noarch
+    - csm-testing-1.19.37-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -52,7 +52,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.36-1.noarch
+    - goss-servers-1.19.37-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Changes included in csm-testing 1.19.37

* CRAYSAT-1962: Fix errors produced when running sat functional tests on vShasta by @ethanholen-hpe in https://github.com/Cray-HPE/csm-testing/pull/748
* CRAYSAT-2034: Skip bootprep image build tests if repos unavailable by @haasken-hpe in https://github.com/Cray-HPE/csm-testing/pull/749

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CRAYSAT-1962
* Resolves CRAYSAT-2034

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * beau
  * wasp

### Test description:

See individual csm-testing PRs for detailed test descriptions.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

