### PR TITLE
CASMHMS-6596: SMD: Use new hms-test image with fix for missing distutils dependency

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -48,7 +48,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.8
+    version: 7.2.9
     namespace: services
     values:
       cray-service:
@@ -60,7 +60,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.40.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.41.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -43,7 +43,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.8
+    version: 7.2.9
     namespace: services
     values:
       cray-service:
@@ -55,7 +55,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.40.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.41.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3


### PR DESCRIPTION
### Summary and Scope

Use new hms-test image with fix for missing distutils dependency.  Without this, CT execution with newer builds were failing because setuptools disappeared from the environment.

Adopted app version 2.41.0 for CSM 1.7.1 (helm chart 7.2.9)

### Issues and Related PRs

* Resolves [CASMHMS-6596](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6596)

### Testing

Tested via pipeline execution of CT tests.  Dev branch failed without the changes.  Once changes pushed up, dev branch started passing CT tests.  No need to test on a real system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

