### PR TITLE
CASMPET-7478: Use spilo-15:3.2-p1 image in cray-postgres-operator

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -203,7 +203,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.10.3
+    version: 1.10.4
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
CASMPET-7478: Use spilo-15:3.2-p1 image in cray-postgres-operator chart to decrease number of CVEs
CASMPET-7669: Wrap cray-postgres-operator-psp rolebinding in conditional so only created when PodSecurityPolicy capability exists

## Issues and Related PRs

* Resolves [CASMPET-7478](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7478)
* Resolves [CASMPET-7669](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7669)

## Testing
See [cray-postgres-operator PR](https://github.com/Cray-HPE/cray-postgres-operator/pull/26)

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

