### PR TITLE
CASMPET-7600: upgrade cephcsi to v3.14.2

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.38
+KUBERNETES_IMAGE_ID=7.1.39
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.38
+PIT_IMAGE_ID=7.1.39
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.38
+STORAGE_CEPH_IMAGE_ID=7.1.39
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.38
+COMPUTE_IMAGE_ID=7.1.39
 
 # Public keys for RPM signature validation.
 #

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -121,7 +121,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer:v1.13.2
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.2
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -102,7 +102,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer:v1.13.2
-      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
+      - artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.2
       # cray-nexus
       - artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
       - artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -34,7 +34,7 @@ spec:
   - name: cray-ceph-csi-rbd
     source: csm-algol60
     namespace: ceph-rbd
-    version: 3.14.0
+    version: 3.14.2
     values:
       ceph-csi-rbd:
         nodeplugin:
@@ -46,7 +46,7 @@ spec:
   - name: cray-ceph-csi-cephfs
     source: csm-algol60
     namespace: ceph-cephfs
-    version: 3.14.0
+    version: 3.14.2
     values:
       ceph-csi-cephfs:
         nodeplugin:


### PR DESCRIPTION
## Summary and Scope

Upgrade cephcsi to v3.14.2 for CVE count reduction.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7600](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7600)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * `fanta`

### Test description:

Followed the cephcsi testing section under https://rndwiki-pro.its.hpecorp.net/display/~lindsay.eliasen@hpe.com/Procedure+to+test+Ceph and verified that cephcsi worked after upgrading the charts using the new cephcsi v3.14.2 image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

