### PR TITLE
CRAYSAT-2027: Update csm-testing and goss-servers to 1.19.40

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.37-1.noarch
+    - csm-testing-1.19.40-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.37-1.noarch
+    - goss-servers-1.19.40-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Update the `csm-testing` and `goss-servers` packages from 1.19.37 to
1.19.40. These are the changes included in each version:

Version 1.19.38 includes:

* CRAYSAT-1989: create functional tests for source in sat bootprep
* CRAYSAT-2037: extend timeout to 30m for sat tests
* CRAYSAT-2027: Add sat bootprep tests for resolve-branches behavior

Version 1.19.39 includes:

* CASMTRIAGE-8687: Increase iuf activity resume test case timeout and
  sleep time

Version 1.19.40 includes:

* CRAYSAT-2039: Fix the TestNid2Xname.test_xname2nid_format_range

## Issues and Related PRs

* Resolves CRAYSAT-1989
* Resolves CRAYSAT-2037
* Resolves CRAYSAT-2027
* Resolves CASMTRIAGE-8687
* Resolves CRAYSAT-2039

## Testing

See individual PRs for detailed testing descriptions.

## Risks and Mitigations

Low risk. This just modifies SAT and IUF functional tests.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

