### PR TITLE
CASMHMS-6586: SMD: Fixed float vs integer bug in hardware tavern test (CSM 1.7.1)

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -48,7 +48,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.9
+    version: 7.2.10
     namespace: services
     values:
       cray-service:
@@ -60,7 +60,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.41.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.42.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -43,7 +43,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.9
+    version: 7.2.10
     namespace: services
     values:
       cray-service:
@@ -55,7 +55,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.41.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.42.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3


### PR DESCRIPTION
### Summary and Scope

Unsure if its a result of a new BMC fw version, or a particular new kind of SSD device, but the values returned from the following redfish endpoint now sometimes return floating point values rather than integer values on DL River hardware:

```bash
/redfish/v1/Systems/1/Storage/${DEVICE_NAME}/Drives/${DRIVE_NUMBER}
```

This was causing one of the SMD CT tests to fail.  The fix here is to accept either integer or floating point values in the test.

Adopted app version 2.32.7 for CSM 1.6.3 (helm chart 7.1.26)
Adopted app version 2.42.0 for CSM 1.7.1 (helm chart 7.2.10)

### Issues and Related PRs

* Resolves [CASMHMS-6586](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6586)

### Testing

Fudged required redfish endpoints with floating point data from the failing customer system into the DL325 mockup folder in `csm-redfish-interface-emulator` and then updated SMD's `docker-compose.test.ct.yaml` to use only the DL325 mockup for all four RIE emulators.  Ran the CT tests locally on my laptop and observed the failure.  Applied the fix to SMD and reran the CT tests locally on my laptop and observed that the tests no longer failed.

Will not check in the `csm-redfish-interface-emulator` changes as we need to keep the EX235a emulators in SMD's CT test environment.  No point in adding a fifth emulator for DL325 because the CT test randomly selects nodes to test again, and it would be unlikely that the DL325 node would be selected.

CT tests pass in the build pipeline.

Did no harm CT test run on the CSM 1.6.2 system `baldar`.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable