### PR TITLE
CASMINST-7460: Add cray-dns-unbound 0.8.4 to index.yaml

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -24,6 +24,10 @@
 artifactory.algol60.net/csm-docker/stable:
   images:
 
+    # cray-dns-unbound 0.8.4 needed for upgrade to CSM 1.7.0
+    cray-dns-unbound:
+      - 0.8.4
+
     # cray-sat is not included in any Helm charts
     cray-sat:
       - 3.33.11


### PR DESCRIPTION
## Summary and Scope
CSM 1.6.3-beta.2 and up ship with `cray-dns-unbound` 0.8.5.  CSM 1.7.0 and CSM 1.7.1-x pull `cray-dns-unbound` 0.8.4 into `cray-precache-images` in `platform-v1.24.yaml` assuming that the 1.6.x version it is upgrading from has the `cray-dns-unbound` 0.8.4 image.  Because CSM 1.7.0 has shipped, we need to include the `cray-dns-unbound` 0.8.4 image with CSM 1.6.3.

CASMINST-7460: Add cray-dns-unbound 0.8.4 to index.yaml

## Issues and Related PRs

* Resolves [CASMINST-7460](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7460)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Upgraded `molly` from 1.6.3-k8s.1 tag to 1.7.1-beta.3.  The 1.6.3-k8s.1 tag listed `cray-dns-unbound` 0.8.4 in docker/index.yaml.  

https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2443/artifact/logs/system/ncn-m001/etc/cray/upgrade/log/csm-upgrade-20250916041549.log

```
Ensuring pre-cached images are pulled on NCN workers before upgrading Nexus...++ kubectl get configmap -n nexus cray-precache-images -o json
++ jq -r .data.images_to_cache
+ images='artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.9.3
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.26.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.26.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.26.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.26.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.1
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.29.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.29.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.29.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.29.15
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.5
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.5
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.5
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.5
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
artifactory.algol60.net/csm-docker/stable/istio/pilot:1.26.0-cray1-distroless
artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4
artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4
artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.4
artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.4
artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.4
artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno-cli:v1.13.4
artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher:v4.8.1
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer:v1.13.2
artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.2
artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2
artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.2
artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.2'
+ export 'PDSH_SSH_ARGS_APPEND=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+ PDSH_SSH_ARGS_APPEND='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+++ grep -oP 'ncn-w\w\d+' /etc/hosts
+++ sort -u
+++ tr -t '\n' ,
++ pdsh -b -S -w ncn-w001,ncn-w002,ncn-w003, 'for image in artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1' artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1 artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.9.3 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.26.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.26.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.26.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.26.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.1 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.29.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.29.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.29.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.29.15 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.5 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.5 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.5 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.5 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10 artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless artifactory.algol60.net/csm-docker/stable/istio/pilot:1.26.0-cray1-distroless artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4 artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4 artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.4 artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.4 artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.4 artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno-cli:v1.13.4 artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1 artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6 artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4 artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0 artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1 artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0 artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4 artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17 artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2 artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0 artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0 artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0 artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0 artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.4.0 artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.6.2 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner:v5.2.0 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher:v4.8.1 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0 artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer:v1.13.2 artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.2 artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4 artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2 artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5 artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8 artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5 artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5 artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.2 'artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.2; do crictl pull $image; done'
+ output='ncn-w001: Warning: Permanently added '\''ncn-w001'\'' (ED25519) to the list of known hosts.
ncn-w002: Warning: Permanently added '\''ncn-w002'\'' (ED25519) to the list of known hosts.
ncn-w003: Warning: Permanently added '\''ncn-w003'\'' (ED25519) to the list of known hosts.
ncn-w001: Image is up to date for sha256:53cdbac8d2894ff511a8fef3f03ba47e54e1cdcb28da40ffa63e80ad03f575c0
ncn-w002: Image is up to date for sha256:cd94e7fa0508bf51cd2be77d8d70f6a164a7dfb3899abae0f596341ad7f88ed9
ncn-w003: Image is up to date for sha256:53cdbac8d2894ff511a8fef3f03ba47e54e1cdcb28da40ffa63e80ad03f575c0

<snip>

ncn-w003: Image is up to date for sha256:a625255ae3a53cf91121acd53d9952142274a4d940ac2ebb6a898b5b8b3e0725
ncn-w003: Image is up to date for sha256:8b34dc66f5ccf43f359ef28d227cc5888dcb0ce822dc41b0d37f5382491c8f85
ncn-w003: Image is up to date for sha256:692631d2ce61bd262d6ab75fff1abeedcabe69ba29a49791dce6396e7003db8d
ncn-w003: Image is up to date for sha256:1971512a8e0867034da603f761f6d4fd45f174b32b72cc6229b546297d44c717
ncn-w003: Image is up to date for sha256:af2b77ca7d7249816547a9ab5b619cf3e25eb710a8d2c8a7986c005f29dfdb72 == *\f\a\i\l\e\d* ]]
+ echo OK
OK
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

