### PR TITLE
CASMTRIAGE-8687: Update csm-testing and goss-servers to 1.19.39

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.37-1.noarch
+    - csm-testing-1.19.39-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.37-1.noarch
+    - goss-servers-1.19.39-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

CASMTRIAGE-8687: Increase iuf activity resume test case timeout and sleep time

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?

Backwards compatible fix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8687](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8687)
* Merge after `https://github.com/Cray-HPE/csm-testing/pull/752`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Tyr
  
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
yes

## Risks and Mitigations

Low (increase in test case timeout)


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

