### PR TITLE
CASMPET-7666, CASMPET-7667, CASMPET-7669: Only create PSP rolebindings if PSP capability exists

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -46,7 +46,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.20.2
+    version: 2.20.3
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -226,7 +226,7 @@ spec:
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
-    version: 1.2.5
+    version: 1.2.6
     namespace: services
   - name: cray-shared-kafka
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -37,7 +37,7 @@ spec:
     namespace: kube-system
   - name: cray-drydock
     source: csm-algol60
-    version: 2.20.2
+    version: 2.20.3
     namespace: loftsman
   - name: cray-precache-images
     source: csm-algol60
@@ -203,7 +203,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.10.3
+    version: 1.10.4
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -231,7 +231,7 @@ spec:
     namespace: services
   - name: cray-node-discovery
     source: csm-algol60
-    version: 1.2.5
+    version: 1.2.6
     namespace: services
   - name: cray-shared-kafka
     source: csm-algol60

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -163,12 +163,12 @@ spec:
     namespace: services
   - name: cray-console-operator
     source: csm-algol60
-    version: 1.16.1
+    version: 1.17.0
     namespace: services
     swagger:
     - name: console
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/console-operator/v1.16.1/api/console.md
+      url: https://raw.githubusercontent.com/Cray-HPE/console-operator/v1.17.0/api/console.md
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
* CASMPET-7666: Only create PSP rolebindings in cray-drydock if PSP capability exists
* CASMPET-7667: Only create cray-console-operator-psp rolebinding if PSP capability exists
* CASMPET-7668: Only create cray-node-discovery rolebinding if PSP capability exists
* CASMPET-7669: Only create cray-postgres-operator-psp rolebinding if PSP capability exists

## Issues and Related PRs

* Resolves [CASMPET-7666](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7666)
* Resolves [CASMPET-7667](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7667)
* Resolves [CASMPET-7668](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7668)
* Resolves [CASMPET-7669](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7669)

## Testing
See PRs for testing details:
cray-drydock PR: https://github.com/Cray-HPE/cray-drydock/pull/49
console-operator PR: https://github.com/Cray-HPE/console-operator/pull/101
node-discovery PR: https://github.com/Cray-HPE/node-discovery/pull/11
cray-postgres-operator PR: https://github.com/Cray-HPE/cray-postgres-operator/pull/28

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

