### PR TITLE
CASMINST-7460: Remove cray-dns-unbound:0.8.4 and cray-dhcp-kea:0.11.6 from platform-v1.24.yaml

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -98,9 +98,6 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
-      # DNS for K8s 1.24
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.6
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.8.4
       # DNS for K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1


### PR DESCRIPTION
## Summary and Scope
CASMINST-7460: Remove cray-dns-unbound:0.8.4 and cray-dhcp-kea:0.11.6 from platform-v1.24.yaml cray-precache-images since they are no longer needed for upgrade.

## Issues and Related PRs

* Resolves [CASMINST-7460](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7460)

## Testing
Performed an upgrade from 1.6.3-beta.2 to 1.7.1-k8s.1 (with change) on `molly` successfully.
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2454/

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

