### PR TITLE
CAST-38539: Update cray-sat to 3.36.3

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -26,7 +26,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # cray-sat is not included in any Helm charts
     cray-sat:
-      - 3.36.2
+      - 3.36.3
 
     # XXX Is this missing from the cray-ims chart?
     cray-ims-load-artifacts:


### PR DESCRIPTION
## Summary and Scope

This includes the fix for CAST-38539. This adds a warning and a prompt
to the `sat bmccreds` command if the user attempts to set a password
longer than 20 characters.

## Issues and Related PRs

* Resolves [CAST-38539](https://jira-pro.it.hpe.com:8443/browse/CAST-38539)

## Testing

See https://github.com/Cray-HPE/sat/pull/376 for testing details.

## Risks and Mitigations

See https://github.com/Cray-HPE/sat/pull/376 for risks and mitigations details.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

