### PR TITLE
CASMPET-7575: Only create PSP rolebindings if PSP capability exists

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -165,7 +165,7 @@ spec:
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.5.1
+    version: 1.5.2
     namespace: vault
   - name: cray-vault
     source: csm-algol60
@@ -203,15 +203,15 @@ spec:
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
-    version: 0.5.1
+    version: 0.5.2
     namespace: vault
   - name: tpm-intermediate
     source: csm-algol60
-    version: 1.0.0
+    version: 1.0.1
     namespace: vault
   - name: tpm-provisioner
     source: csm-algol60
-    version: 1.0.0
+    version: 1.0.1
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -155,7 +155,7 @@ spec:
     namespace: opa
   - name: cray-vault-operator
     source: csm-algol60
-    version: 1.5.1
+    version: 1.5.2
     namespace: vault
   - name: cray-vault
     source: csm-algol60
@@ -211,15 +211,15 @@ spec:
     namespace: operators
   - name: spire-intermediate
     source: csm-algol60
-    version: 0.5.1
+    version: 0.5.2
     namespace: vault
   - name: tpm-intermediate
     source: csm-algol60
-    version: 1.0.0
+    version: 1.0.1
     namespace: vault
   - name: tpm-provisioner
     source: csm-algol60
-    version: 1.0.0
+    version: 1.0.1
     namespace: spire
   - name: cray-keycloak
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
Only create PSP rolebindings if PSP capability exists
  * CASMPET-7670: Only create tpm-provisioner-psp rolebinding if PSP capability exists
  * CASMPET-7671: Only create spire-intermediate-psp rolebinding if PSP capability exists
  * CASMPET-7672: Only create tmp-intermediate-psp rolebinding if PSP capability exists
  * CASMPET-7673: Only create vault-psp rolebinding if PSP capability exists

## Issues and Related PRs

* Resolves [CASMPET-7670](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7670)
* Resolves [CASMPET-7671](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7671)
* Resolves [CASMPET-7672](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7672)
* Resolves [CASMPET-7673](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7673)

## Testing
See PRs for testing information
tpm-provisioner PR: https://github.com/Cray-HPE/tpm-provisioner/pull/28
spire-intermediate PR: https://github.com/Cray-HPE/cray-spire/pull/115
tpm-intermediate PR: https://github.com/Cray-HPE/tpm-intermediate/pull/4
cray-vault-operator PR: https://github.com/Cray-HPE/cray-vault/pull/22


## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

