### PR TITLE
CASMCMS-9542 - update barebones recipes and image to sles15sp7.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -177,7 +177,7 @@ spec:
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
     source: csm-algol60
-    version: 2.8.0
+    version: 2.10.0
     namespace: services
     values:
       cray-import-kiwi-recipe-image:
@@ -185,7 +185,7 @@ spec:
           image:
             # The following version needs to match the above cray-csm-barebones-recipe-install
             # version. Due to included helm charts, it needs to be overridden here as well.
-            tag: 2.8.0
+            tag: 2.10.0
         catalog:
           image:
             # The following version is the cray-product-catalog version.


### PR DESCRIPTION
## Summary and Scope

Update the barebones recipes to use SP7. There was a change in the way the uss kiwi image handled creating and naming the kernel file with SP7. Rather then deal with figuring out how the uss image was working, I modified the Makefile to use our own kiwi-ng-builder image. That required a few changes to the build scripts, but there are no more unknowns in the build mechanism.

## Issues and Related PRs
* Resolves [CASMCMS-9542](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9542)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed via helm - the new images and recipes were installed and included in cray-product-catalog. I built the new recipes and verified they worked for both x86 and aarch64.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as the barebones images and recipes are only used for own testing.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

