### PR TITLE
CASMTRIAGE-8311

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -30,7 +30,7 @@ NCN_ARCH='x86_64'
 CN_ARCH=("x86_64" "aarch64")
 
 # All images must use the same, exact kernel version.
-KERNEL_VERSION='6.4.0-150700.53.16-default-7.2.1-x86_64.kernel'
+KERNEL_VERSION='6.4.0-150700.53.16-default'
 
 # The image ID may not always match the other images and should be defined individually.
 KUBERNETES_IMAGE_ID=7.2.1

--- a/assets.sh
+++ b/assets.sh
@@ -36,13 +36,13 @@ KERNEL_VERSION='6.4.0-150600.23.53-default'
 KUBERNETES_IMAGE_ID=7.2.1
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.1.39
+PIT_IMAGE_ID=7.2.1
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.1.39
+STORAGE_CEPH_IMAGE_ID=7.2.1
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.1.39
+COMPUTE_IMAGE_ID=7.2.1
 
 # Public keys for RPM signature validation.
 #

--- a/assets.sh
+++ b/assets.sh
@@ -30,7 +30,7 @@ NCN_ARCH='x86_64'
 CN_ARCH=("x86_64" "aarch64")
 
 # All images must use the same, exact kernel version.
-KERNEL_VERSION='6.4.0-150600.23.53-default'
+KERNEL_VERSION=7.2.1
 
 # The image ID may not always match the other images and should be defined individually.
 KUBERNETES_IMAGE_ID=7.2.1

--- a/assets.sh
+++ b/assets.sh
@@ -33,7 +33,7 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150600.23.53-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.1.39
+KUBERNETES_IMAGE_ID=7.2.1
 
 # The image ID may not always match the other images and should be defined individually.
 PIT_IMAGE_ID=7.1.39

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.1-1.x86_64
-    - canu-2.0.3-1.x86_64
+    - canu-2.0.4-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

The firmware versions are hard-coded in CANU.
10.13.1040 is the recommended release for CSM 1.6.x
10.13.1080 is the recommended release for CSM 1.7.x

Therefore firmware tests were failing when running on firmware updated switches. This fix make sure the test passes if the firmware is the latest and greater than the version listed in canu.yaml file.



## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8311

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8311
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge after: 
https://github.com/Cray-HPE/canu/pull/736
 https://github.com/Cray-HPE/node-images/pull/1299


## Testing



### Tested on:

Surtur

### Test description:

Tested on Surtur switches with updated firmwares and ran the CLI against multiple CSM versions. 


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

