### PR TITLE
CASMHMS-6602: Update various HMS service dependencies

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -40,12 +40,12 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.3
+    version: 6.1.4
     namespace: services
     swagger:
     - name: sls
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.12.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
     version: 7.2.11
@@ -67,7 +67,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 3.1.1
+    version: 3.1.2
     namespace: services
 
   # Cray DHCP Kea

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -35,12 +35,12 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.3
+    version: 6.1.4
     namespace: services
     swagger:
     - name: sls
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.10.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.12.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
     version: 7.2.11
@@ -62,7 +62,7 @@ spec:
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60
-    version: 3.1.1
+    version: 3.1.2
     namespace: services
 
   # Cray DHCP Kea

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,21 +36,21 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.3.4
+    version: 3.3.5
     namespace: services
     timeout: 10m
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.34.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.35.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.4
     namespace: services
     swagger:
     - name: capmc
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.9.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-capmc/v3.10.0/api/swagger.yaml
   - name: cray-hms-firmware-action
     source: csm-algol60
     version: 3.2.5


### PR DESCRIPTION
### Summary and Scope

Made the following changes for SLS, BSS, CAPMC, and Discovery:

- Updated Alpine base image from 3.21 to 3.22 to pick up security fixes
- Updated all of the HMS and Go module image dependencies.

### Issues and Related PRs

* Resolves [CASMHMS-6602](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6602)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable