### PR TITLE
CASMCMS-9565/CRAYSAT-2040 - increase timeout values for longer running tests.

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,13 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.40-1.noarch
+    # Keep goss-servers and csm-testing in sync
+    - csm-testing-1.19.41-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.40-1.noarch
+    # Keep goss-servers and csm-testing in sync
+    - goss-servers-1.19.41-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

A couple of changes to the gos tests to increase timeouts for longer running tests. Sometimes they would succeed and sometimes they would fail due to a timeout. This should allow sufficient time for them to always succees.

## Issues and Related PRs
* Resolves [CASMCMS-9565](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9565)
* Resolves [CRAYSAT-2040](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2040)

## Risks and Mitigations

Low risk

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

