### PR TITLE
CRAYSAT-2040: Update csm-testing and goss-servers to 1.19.41

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -48,11 +48,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-ssh-keys-roles-1.8.1-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
-    - csm-testing-1.19.40-1.noarch
+    - csm-testing-1.19.41-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
-    - goss-servers-1.19.40-1.noarch
+    - goss-servers-1.19.41-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

Update csm-testing and goss-servers to [1.19.41](https://github.com/Cray-HPE/csm-testing/releases/tag/v1.19.41)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

- [CRAYSAT-2040](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2040): Improve resiliency of sat firmware functional tests by @ethanholen-hpe in https://github.com/Cray-HPE/csm-testing/pull/755
- [CASMCMS-9565](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9565) - increase timeout for cmsdev tests. by @dlaine-hpe in https://github.com/Cray-HPE/csm-testing/pull/757

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

