### PR TITLE
CASMHMS-6605: Bump SLS chart version +1

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -40,7 +40,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.4
+    version: 6.1.5
     namespace: services
     swagger:
     - name: sls

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -35,7 +35,7 @@ spec:
   # HMS
   - name: cray-hms-sls
     source: csm-algol60
-    version: 6.1.4
+    version: 6.1.5
     namespace: services
     swagger:
     - name: sls


### PR DESCRIPTION
### Summary and Scope

Bumped SLS chart version +1 in https://github.com/Cray-HPE/csm/pull/4337 instead of +2.  This PR does another +1.

### Issues and Related PRs

* Resolves [CASMHMS-6605](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6605)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable