### PR TITLE
CASM-5686: csm-config: Fix bad path bugs in RR script

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.48.2
+    version: 1.48.3
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

This fixes several bad-path bugs in one of the RR configuration scripts. See [the source PR](https://github.com/Cray-HPE/csm-config/pull/412) for full details. These fixes were deferred from the 1.7.0 release to 1.7.1.

## Issues and Related PRs

Resolves CASM-5686

## Testing

See [the source PR](https://github.com/Cray-HPE/csm-config/pull/412).

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable
