### PR TITLE
CRAYSAT-2038: Update csm-testing and goss-servers to 1.19.42

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -49,12 +49,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
     # Keep goss-servers and csm-testing in sync
-    - csm-testing-1.19.41-1.noarch
+    - csm-testing-1.19.42-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
     # Keep goss-servers and csm-testing in sync
-    - goss-servers-1.19.41-1.noarch
+    - goss-servers-1.19.42-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Update the csm-testing and goss-servers packages from 1.19.41 to
1.19.42. These are the changes included in each version:

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2038](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2038): Cleanup IMS Jobs  https://github.com/Cray-HPE/csm-testing/pull/756
* Resolves [CRAYSAT-2044](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2044): Gracefully handle None configurations from CFS https://github.com/Cray-HPE/csm-testing/pull/758

## Testing

See individual PRs for detailed testing descriptions.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

