### PR TITLE
CASMNET-2247 - CVEs in components used for Cilium connectivity tests

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -186,20 +186,6 @@ artifactory.algol60.net/csm-docker/stable:
     quay.io/cilium/hubble-ui-backend:
       - v0.13.2
 
-    # Cilium Tetragon images
-    quay.io/cilium/tetragon:
-      - v0.11.0
-    quay.io/cilium/tetragon-operator:
-      - v0.11.0
-
-    # Cilium images needed for connectivity testing
-    quay.io/cilium/alpine-curl:
-      - v1.6.0
-    quay.io/cilium/json-mock:
-      - v1.3.8
-    docker.io/coredns/coredns:
-      - 1.10.0
-
     # Images needed by IUF and possibly non-CSM products
     cray-nexus-setup:
       - 0.12.2


### PR DESCRIPTION
## Summary and Scope

The quay.io/cilium/json-mock:v1.3.8 image used by the Cilium connectivity tests contains a number of high and critical security vulnerabilities. The recently released v1.3.9 version of the image does not address this.

The Cilium connectivity tests are not referenced in our documentation and can no longer be run without a number of Kyverno policy exceptions being put in place.

As we do not use `cilium connectivity test` this PR removes the images required for this feature.  This PR also removes the Cilium Tetragon images which are over 2 years old and also unused.

## Issues and Related PRs

* Resolves [CASMNET-2247](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2247)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

A full fresh install of CSM 1.7.1 and a CSM 1.6.3 to 1.7.1 upgrade were tested in vshasta without issue.

## Risks and Mitigations

CSM has never used these images nor have we ever documented how to run the connectivity tests. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

