### PR TITLE
CASMNET-2120: Use asset image IDs with multus-cni v4.2.2

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.16-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.2
+KUBERNETES_IMAGE_ID=7.2.3
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.2
+PIT_IMAGE_ID=7.2.3
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.2
+STORAGE_CEPH_IMAGE_ID=7.2.3
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.2
+COMPUTE_IMAGE_ID=7.2.3
 
 # Public keys for RPM signature validation.
 #

--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -114,7 +114,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Multus required by platform
     ghcr.io/k8snetworkplumbingwg/multus-cni:
-      - v3.9.3
+      - v4.2.2
 
     registry.k8s.io/coredns/coredns:
       - v1.8.6

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -59,7 +59,7 @@ spec:
       # Kubernetes
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
 
       # K8s 1.26
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.9.3

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -50,7 +50,7 @@ spec:
       # Kubernetes
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
       - artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
-      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
+      - artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
 
       # K8s 1.26
       - artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.9.3


### PR DESCRIPTION
## Summary and Scope
CASMNET-2120: Use asset image IDs with multus-cni v4.2.2
  * Update multus-cni image in index and precache to v4.2.2

## Issues and Related PRs
* Resolves [CASMNET-2120](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2120)

## Testing
Install on `molly`
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2511/

Upgrade on `molly`
https://jenkins.algol60.net/job/Cray-HPE/job/csm-vshasta-deploy/job/main/2524/

Additional testing see [node-images PR](https://github.com/Cray-HPE/node-images/pull/1304)

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

