### PR TITLE
CASMCMS-9574 -- kata upgrade

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.16-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.3
+KUBERNETES_IMAGE_ID=7.2.4
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.3
+PIT_IMAGE_ID=7.2.4
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.3
+STORAGE_CEPH_IMAGE_ID=7.2.4
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.3
+COMPUTE_IMAGE_ID=7.2.4
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope

update kata version to 3.21.0

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9574
https://github.com/Cray-HPE/node-images/pull/1305

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct