### PR TITLE
CASMNET-2075 Cray-dns-powerdns version update

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -79,7 +79,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.5.0 # update platform.yaml cray-precache-images with this
+    version: 0.5.1 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -83,7 +83,7 @@ spec:
   # Cray DNS powerdns
   - name: cray-dns-powerdns
     source: csm-algol60
-    version: 0.5.0 # update platform.yaml cray-precache-images with this
+    version: 0.5.1 # update platform.yaml cray-precache-images with this
     namespace: services
 
   - name: cray-powerdns-manager

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -101,7 +101,7 @@ spec:
       # DNS for K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -92,7 +92,7 @@ spec:
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17


### PR DESCRIPTION
## Summary and Scope
 This PR updates 'cray-dns-powerdns' version in CSM repo as per CASMNET-2075

 This fix scales 'cray-dns-powerdns' to multiple replicas and also updates its version in chart.yaml and values.yaml file.

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMNET-2075

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>` 


### Tested on:

Mug

### Test description:

Installed the new tag of powerdns and checked if all the replicas are scaling up.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

