### PR TITLE
CASMNET-2295 - Filter CSM DNS traffic from customer DNS

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -74,11 +74,11 @@ spec:
   # Cray DNS unbound (resolver)
   - name: cray-dns-unbound
     source: csm-algol60
-    version: 0.10.1 # update platform.yaml cray-precache-images with this
+    version: 0.10.2 # update platform.yaml cray-precache-images with this
     namespace: services
     values:
       global:
-        appVersion: 0.10.1
+        appVersion: 0.10.2
 
   # Cray DNS powerdns
   - name: cray-dns-powerdns

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -100,7 +100,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS for K8s 1.32
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -91,7 +91,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
-      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs


### PR DESCRIPTION
## Summary and Scope

DNS queries for xnames do not have a domain attached to them. On systems with partially populated cabinets it is possible for some services to issue DNS queries for components that do not exist. Because there is no domain attached to these queries they are automatically forwarded to the upstream DNS server. This places an unnecessary load on the upstream DNS server as these queries should never leave CSM.

This PR introduces `dnsdist` as an extra container and traffic to the customer DNS server is routed through this in order to filter out queries that should never be forwarded.

## Issues and Related PRs

* Resolves [CASMNET-2295](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2295)

## Testing

### Tested on:

  * `mug`
  * `odin`

### Test description:

Using system odin verified that a barrage of xname queries are being forwarded to the upstream DNS server.
```
[2025-10-21 11:17:08] Query: tifa.hpc.amslabs.hpecorp.net. Type: 1
[2025-10-21 11:17:08] Query: x1000c0r2b0. Type: 28
[2025-10-21 11:17:08] Query: x1000c2r0b0. Type: 28
[2025-10-21 11:17:08] Query: x1000c4s1b0. Type: 1
[2025-10-21 11:17:08] Query: x1000c7s7b0. Type: 28
[2025-10-21 11:17:09] Query: x1000c3r4b0. Type: 28
[2025-10-21 11:17:09] Query: x1000c3r4b0. Type: 1
[2025-10-21 11:17:09] Query: x1000c6s7b1. Type: 28
[2025-10-21 11:17:09] Query: . Type: 2
[2025-10-21 11:17:09] Query: x1000c5r2b0. Type: 1
[2025-10-21 11:17:09] Query: x1000c3s4b0. Type: 28
[2025-10-21 11:17:09] Query: x1000c3s4b0. Type: 1
[2025-10-21 11:17:09] Query: x1000c4s6b1. Type: 28
[2025-10-21 11:17:09] Query: x1000c4s6b1. Type: 1
[2025-10-21 11:17:09] Query: x1000c1s0b1. Type: 1
[2025-10-21 11:17:10] Query: x1000c7r4b0. Type: 1
[2025-10-21 11:17:10] Query: x1000c7r4b0. Type: 28
[2025-10-21 11:17:10] Query: x1000c5r4b0. Type: 1
[2025-10-21 11:17:10] Query: x1000c0r2b0. Type: 1
[2025-10-21 11:17:10] Query: x1000c5s1b1. Type: 28
[2025-10-21 11:17:10] Query: x1000c4s2b0. Type: 1
[2025-10-21 11:17:10] Query: x1000c4s2b0. Type: 28
[2025-10-21 11:17:10] Query: x1000c4r4b0. Type: 28
[2025-10-21 11:17:10] Query: x1000c4r4b0. Type: 1
[2025-10-21 11:17:10] Query: x1000c5r0b0. Type: 28
[2025-10-21 11:17:10] Query: x1000c5r0b0. Type: 1
[2025-10-21 11:17:11] Query: x1000c0s4b1. Type: 1
[2025-10-21 11:17:11] Query: tifa.hpc.amslabs.hpecorp.net. Type: 28
[2025-10-21 11:17:12] Query: x1000c6s5b0. Type: 1
[2025-10-21 11:17:12] Query: x1000c0s0b0. Type: 28
[2025-10-21 11:17:13] Query: x1000c7s5b1. Type: 1
[2025-10-21 11:17:13] Query: x1000c1r4b0. Type: 1
[2025-10-21 11:17:13] Query: x1000c1r4b0. Type: 28
[2025-10-21 11:17:14] Query: x1000c0s7b0. Type: 28
[2025-10-21 11:17:14] Query: x1000c0s7b0. Type: 1
[2025-10-21 11:17:14] Query: x1000c6r6b0. Type: 28
[2025-10-21 11:17:14] Query: x1000c6r6b0. Type: 1
[2025-10-21 11:17:14] Query: x1000c3s4b1. Type: 28
[2025-10-21 11:17:14] Query: x1000c3s4b1. Type: 1
[2025-10-21 11:17:14] Query: x1000c2s5b0. Type: 1
[2025-10-21 11:17:14] Query: x1000c2s5b0. Type: 28
[2025-10-21 11:17:16] Query: x1000c7s7b1. Type: 28
[2025-10-21 11:17:16] Query: x1000c7s7b1. Type: 1
[2025-10-21 11:17:16] Query: x1000c7s5b0. Type: 28
[2025-10-21 11:17:16] Query: x1000c2s7b0. Type: 1
[2025-10-21 11:17:17] Query: x1000c7s4b0. Type: 28
[2025-10-21 11:17:17] Query: x1000c7s4b0. Type: 1
[2025-10-21 11:17:17] Query: x1000c7s4b0. Type: 28
[2025-10-21 11:17:17] Query: x1000c7s4b0. Type: 1
[2025-10-21 11:17:18] Query: x1000c0s6b1. Type: 1
[2025-10-21 11:17:18] Query: x1000c0s5b0. Type: 1
[2025-10-21 11:17:18] Query: x1000c0s5b0. Type: 28
[2025-10-21 11:17:18] Query: x1000c0s6b1. Type: 1
[2025-10-21 11:17:18] Query: x1000c0s5b0. Type: 1
[2025-10-21 11:17:18] Query: x1000c0s5b0. Type: 28
[2025-10-21 11:17:18] Query: x1000c6s4b1. Type: 28
[2025-10-21 11:17:18] Query: x1000c6s4b1. Type: 1
[2025-10-21 11:17:18] Query: x1000c6s4b1. Type: 28
[2025-10-21 11:17:18] Query: x1000c6s4b1. Type: 1
[2025-10-21 11:17:19] Query: x1000c0s5b1. Type: 28
[2025-10-21 11:17:19] Query: x1000c0s5b1. Type: 1
[2025-10-21 11:17:19] Query: x1000c0s5b1. Type: 28
[2025-10-21 11:17:19] Query: x1000c0s5b1. Type: 1
[2025-10-21 11:17:19] Query: x1000c2s5b1. Type: 1
[2025-10-21 11:17:19] Query: x1000c2s5b1. Type: 28
[2025-10-21 11:17:19] Query: x1000c2s5b1. Type: 1
[2025-10-21 11:17:19] Query: x1000c2s5b1. Type: 28
[2025-10-21 11:17:20] Query: x1000c2s6b0. Type: 1
[2025-10-21 11:17:20] Query: x1000c2s6b0. Type: 28
[2025-10-21 11:17:20] Query: x1000c2s6b0. Type: 1
```
Installed new chart and image on odin, verified junk xname queries no longer occur.
```
[2025-10-21 11:19:06] Query: . Type: 2
[2025-10-21 11:19:06] Query: . Type: 2
[2025-10-21 11:19:07] Query: . Type: 2
[2025-10-21 11:19:29] Query: grafana.com. Type: 1
[2025-10-21 11:19:29] Query: grafana.com. Type: 28
[2025-10-21 11:19:55] Query: hpcdc-auth-cfc.hpc.amslabs.hpecorp.net. Type: 1
[2025-10-21 11:20:54] Query: tifa.hpc.amslabs.hpecorp.net. Type: 1
[2025-10-21 11:20:54] Query: tifa.hpc.amslabs.hpecorp.net. Type: 28
[2025-10-21 11:23:01] Query: grafana.com. Type: 1
[2025-10-21 11:23:01] Query: grafana.com. Type: 28
[2025-10-21 11:23:01] Query: raw.githubusercontent.com. Type: 1
[2025-10-21 11:23:01] Query: raw.githubusercontent.com. Type: 28
[2025-10-21 11:23:24] Query: tifa.hpc.amslabs.hpecorp.net. Type: 1
[2025-10-21 11:23:24] Query: tifa.hpc.amslabs.hpecorp.net. Type: 28
[2025-10-21 11:23:36] Query: ntp.hpecorp.net. Type: 1
[2025-10-21 11:23:36] Query: ntp.hpecorp.net. Type: 28
[2025-10-21 11:24:23] Query: tifa.hpc.amslabs.hpecorp.net. Type: 28
[2025-10-21 11:24:33] Query: tifa.hpc.amslabs.hpecorp.net. Type: 1
[2025-10-21 11:24:33] Query: tifa.hpc.amslabs.hpecorp.net. Type: 28
[2025-10-21 11:25:44] Query: grafana.com. Type: 1
[2025-10-21 11:25:44] Query: grafana.com. Type: 28
[2025-10-21 11:27:02] Query: ntp.hpecorp.net. Type: 1
[2025-10-21 11:27:02] Query: ntp.hpecorp.net. Type: 28
[2025-10-21 11:27:54] Query: hpcdc-auth-cfc.hpc.amslabs.hpecorp.net. Type: 1
[2025-10-21 11:28:27] Query: tifa.hpc.amslabs.hpecorp.net. Type: 28
[2025-10-21 11:29:08] Query: ntp.hpecorp.net. Type: 1
[2025-10-21 11:29:08] Query: ntp.hpecorp.net. Type: 28
[2025-10-21 11:29:29] Query: grafana.com. Type: 28
```
## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

