### PR TITLE
CASM-5744: Remove cos-prechecks-for-worker-reboots on cluster while Upgrading to CSM 1.7.x

### DIFF
--- a/hooks/pre-install-check-prehook.sh
+++ b/hooks/pre-install-check-prehook.sh
@@ -89,6 +89,21 @@ else
     echo "INFO Prerequisites setup for CSM upgrade successfully completed"
 fi
 
+#USS-4483 Remove cos-prechecks-for-worker-reboots if exists on cluster
+result=$(kubectl delete hooks -n argo cos-prechecks-for-worker-reboots --ignore-not-found=true 2>&1)
+if [ $? -ne 0 ]; then
+    echo "ERROR Failed to delete cos-prechecks-for-worker-reboots hook"
+    echo "DEBUG kubectl output: ${result}"
+    exit 1
+fi
+
+if [ -z "$result" ]; then
+    echo "DEBUG cos-prechecks-for-worker-reboots hook not found"
+else
+    echo "INFO Successfully deleted cos-prechecks-for-worker-reboots hook"
+    echo "DEBUG kubectl output: ${result}"
+fi
+
 echo "INFO Updating IUF workflow templates"
 if ! /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh; then
     echo "ERROR Failed to update IUF workflow templates"


### PR DESCRIPTION
## Summary and Scope

CASM-5744: Remove cos-prechecks-for-worker-reboots on CSM 1.6 cluster while Upgrading to CSM 1.7.x
is required by [USS-4483](https://jira-pro.it.hpe.com:8443/browse/USS-4483) Update Cray-HPE/docs-csm to remove cos-prechecks-for-worker-reboots.yaml


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-5744](https://jira-pro.it.hpe.com:8443/browse/CASM-5744)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Groot

### Test description:

- Was upgrade tested? 
yes

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

