### PR TITLE
CASMCMS-9508: Use latest Product Catalog code

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -192,7 +192,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.7.1
+            tag: 2.7.2
   - name: cray-ims
     source: csm-algol60
     version: 3.32.0
@@ -221,7 +221,7 @@ spec:
             # Unless there is a specific reason not to, this version should be
             # updated whenever the cray-product-catalog chart version is updated, and
             # vice versa.
-            tag: 2.7.1
+            tag: 2.7.2
         import_job:
           initContainers:
           # This init container will write the desired cray-sat version to vars/main.yml
@@ -260,7 +260,7 @@ spec:
     # updated whenever the csm-config catalog image version is updated, and
     # vice versa.
     # Also update the catalog:image:tag value in the barebones recipe section.
-    version: 2.7.1
+    version: 2.7.2
     namespace: services
 
   # Spire service


### PR DESCRIPTION
## Summary and Scope

Ryan H made some small changes to the Cray Product Catalog Python code in CSM 1.7, but we did not update the product catalog chart until after the code cutoff. His updates have already been used in other places and tested. This just brings the product catalog chart up to date.

## Issues and Related PRs

* Resolves [CASMCMS-9508](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9508)
* [CRAYSAT-1944](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1944) made the actual changes to the Python code

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

