### PR TITLE
CASMHMS-6600: Add new FMN subrole "FabricManager" to SMD

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -48,7 +48,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.12.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.11
+    version: 7.2.12
     namespace: services
     values:
       cray-service:

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -43,7 +43,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.12.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.11
+    version: 7.2.12
     namespace: services
     values:
       cray-service:


### PR DESCRIPTION
### Summary and Scope

Define new subrole `FabricManager` in HSM's `cray-hms-base-config` configmap to be used for the new Slingshot Fabric Manager Nodes (FMN).

Adopted helm chart version 7.2.12 for CSM 1.7.1 (no change in app version)

### Issues and Related PRs

* Resolves [CASMHMS-6600](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6600)

### Testing

Tested on `mug`.  Upgraded to modified helm chart.  Observed change in the configmap:

```
> kubectl get configmap -n services cray-hms-base-config -o yaml
apiVersion: v1
data:
  hms_config.json: |-
    {
       "HMSExtendedDefinitions":{
          "Role":[
             "Compute",
             "Service",
             "System",
             "Application",
             "Storage",
             "Management"
          ],
          "SubRole":[
             "Worker",
             "Master",
             "Storage",
             "UAN",
             "Gateway",
             "LNETRouter",
             "Visualization",
             "UserDefined",
             "FabricManager"
          ]
       }
    }
...
```

Created a new fake component in HSM and assigned it the newsubrole:

```
> cray hsm state components create --components--class River --components--arch X86 --components--net-type Sling --components--nid 123456 --components--role Management --components--sub-role FabricManager --components--state On --components--id x3100c0s0b0n0

> cray hsm state components describe  --format json x3100c0s0b0n0 | jq
{
  "ID": "x3100c0s0b0n0",
  "Type": "Node",
  "State": "On",
  "Flag": "OK",
  "Enabled": true,
  "Role": "Management",
  "SubRole": "FabricManager",
  "NID": 123456,
  "NetType": "Sling",
  "Arch": "X86",
  "Class": "River"
}
```

Also observed its presence in `sat` output:

```
> sat status | grep -e xname -e FabricManager
| xname          | Aliases   | Type | NID      | State     | Flag | Enabled | Arch | Class | Role        | SubRole       | Net Type | Locked  | Desired Config                         | Configuration Status | Error Count | Boot Status | Most Recent BOS Session                | Most Recent Image                    |
| x3100c0s0b0n0  | MISSING   | Node | 123456   | On        | OK   | True    | X86  | River | Management     | FabricManager | Sling    | MISSING |                                        | unconfigured         | 0           | stable      | MISSING                                | MISSING                              |
```

Then created new custom `TestRole` role and `TestSubrole` subrole using https://github.com/Cray-HPE/docs-csm/blob/release/1.7/operations/hardware_state_manager/HSM_Roles_and_Subroles.md and verified correct behavior and coexistance with new role/subrole in the configmap and by modifying the above fake component.

Confirmed CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

