### PR TITLE
CASM-7523/MTL-2609 - Bare-metal FMN node enablement

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.19-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.6
+KUBERNETES_IMAGE_ID=7.2.7
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.6
+PIT_IMAGE_ID=7.2.7
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.6
+STORAGE_CEPH_IMAGE_ID=7.2.7
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.6
+COMPUTE_IMAGE_ID=7.2.7
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.1-1.x86_64
-    - canu-2.0.4-1.x86_64
+    - canu-2.0.5-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

* CANU support for bare-metal Slingshot Fabric Manager nodes
* Add fmn as a valid hostname prefix to metal-lib.sh

## Issues and Related PRs


* Resolves [MTL-2609](https://jira-pro.it.hpe.com:8443/browse/MTL-2609), [CASM-5723](https://jira-pro.it.hpe.com:8443/browse/CASM-5723)

## Testing

### Tested on:

  * `surtur`

### Test description:

* See https://github.com/Cray-HPE/canu/pull/746 for CANU testing

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

