### PR TITLE
CASMHMS-6603: Fix failing CT test in SMD and BSS

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -20,7 +20,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.6.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.1.26
+    version: 7.1.27
     namespace: services
     values:
       cray-service:
@@ -32,7 +32,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.32.7/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.32.8/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.0.2

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,13 +36,13 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.2.7
+    version: 3.2.8
     namespace: services
     timeout: 10m
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.30.1/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.30.2/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 5.0.1


### PR DESCRIPTION
## Summary and Scope

Fixed failing CT test by adding optional Subtype field that may be returned from the request.

## Issues and Related PRs

* Resolves [CASMHMS-6603](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6603)

## Testing

Tested on:

  * `mug`

Test description:

Created dummy components with the Subtype field.  Ran CT tests to observe failures.  Upgraded to new version of service with fix and reran the CT tests.  Observed tests no longer fail.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable