### PR TITLE
CASMMON-550 metallb-speaker alert should not be firing for master

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -187,7 +187,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.19
+    version: 1.2.21
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
CASMMON-550 metallb-speaker alert should not be firing for master nodes
https://jira-pro.it.hpe.com:8443/browse/CASMMON-550
Disabling the MetalLBBGPSessionDown alert in CSM 1.7.1 due to issues retrieving the CMN IP address for master nodes
Tested on: Tyr
Before Fix

cm health alertman prometheus

| 10.252.1.18 | critical | MetalLB "speaker" on "metallb-speaker-9gcwq" has BGP session "10.129.107.3:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-9gcwq" has BGP session "10.252.0.2:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-9gcwq" has BGP session "10.252.0.3:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-9gcwq" has BGP session "10.129.107.2:179" down for > 1 minute:1 |
| 10.252.1.16 | critical | MetalLB "speaker" on "metallb-speaker-88dgx" has BGP session "10.129.107.3:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-88dgx" has BGP session "10.252.0.2:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-88dgx" has BGP session "10.252.0.3:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-88dgx" has BGP session "10.129.107.2:179" down for > 1 minute:1 |
| 10.252.1.17 | critical | MetalLB "speaker" on "metallb-speaker-64kgw" has BGP session "10.129.107.3:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-64kgw" has BGP session "10.129.107.2:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-64kgw" has BGP session "10.252.0.3:179" down for > 1 minute:1 |
| | | MetalLB "speaker" on "metallb-speaker-64kgw" has BGP session "10.252.0.2:179" down for > 1 minute:1 |

After fix:

there is no MetalLBBGPSessionDown

