### PR TITLE
CASMPET-7637: Remove redundant images of kubectl

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -81,10 +81,6 @@ artifactory.algol60.net/csm-docker/stable:
     docker.io/ghostunnel/ghostunnel:
       - v1.6.0
 
-    # XXX Is this missing from cray-istio chart?
-    docker.io/istio/kubectl:
-      - 1.5.4
-
     # This image is used in an init container specified in the loftsman manifest
     # for the csm-config import job.
     docker.io/library/alpine:


### PR DESCRIPTION

## Summary and Scope

Remove redundant images of kubectl which are not used by the chart.

## Issues and Related PRs

[CASMPET-7637](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7637)

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7637](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7637)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

