### PR TITLE
CASMCMS-9446 - allow Victoria Metrics ingress to bos and cfs db pods.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,21 +134,21 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.48.2
+    version: 2.49.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.48.2/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.28.0
+    version: 1.29.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.28.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.13.1


### PR DESCRIPTION
## Summary and Scope

This allows the Victoria Metrics access the redis db pod for gathering metrics and health status.

## Issues and Related PRs
* Resolves [CASMCMS-9446](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9446)

## Testing
### Tested on:
  * `Mug`

### Test description:

In installed the new version via loftsman and verified that there were no more 'Ingress Denied' messages through hubble. Ran cmsdev tests to verify service was working correctly. Rolled back to the previous install, verified 'Ingress Denied' messages were again present.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk change - just allowing ingress from another namespace.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

