### PR TITLE
New Helm chart version for cray-rrs for CASM-5643 & CASM-5644

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -310,9 +310,9 @@ spec:
     namespace: kube-system
   - name: cray-rrs
     source: csm-algol60
-    version: 1.1.0
+    version: 1.1.1
     namespace: rack-resiliency
     swagger:
     - name: rrs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.1.0/src/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.1.1/src/api/openapi.yaml


### PR DESCRIPTION
## Summary and Scope

The version of cray-rrs is changed as new CI test cases are added to the repo.

## Issues and Related PRs

* Resolves [CASM-5643](https://jira-pro.it.hpe.com:8443/browse/CASM-5643) & [CASM-5644](https://jira-pro.it.hpe.com:8443/browse/CASM-5644)

### Tested on:

  * cray-rrs Github actions

### Test description:

All the test cases passed on GitHub Actions, [link to result](https://github.com/Cray-HPE/cray-rrs/actions/runs/19223884554/job/54946876816).

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

