### PR TITLE
CASMNET-2381 - dhcp-helper.py is crashing following FMN node addition

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -68,7 +68,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.13.0 # update platform.yaml cray-precache-images with this
+    version: 0.13.1 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -99,7 +99,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS for K8s 1.32
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -90,7 +90,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4


### PR DESCRIPTION
## Summary and Scope

Fix KeyError in dhcp-helper.py for management interface parsing

The script was failing with "KeyError: 'nmn'" when processing host records with management interfaces like fmn002-mgmt that don't follow the standard NCN naming pattern.

## Issues and Related PRs

* Resolves [CASMNET-2381](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2381)

## Testing

### Tested on:

  * `surtur`
  * `mug`

### Test description:

See https://github.com/Cray-HPE/cray-dhcp-kea/pull/70 for test description. Fixed code was deployed on two systems, one with a FMN node added and one with no FMN nodes.

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

