### PR TITLE
CASM-5649-5662: Updates csm-config to version 1.49.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.48.3
+    version: 1.49.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope



- Shifted Rack Resiliency workflows (`csm.rr.*`) toward native Ansible execution so we avoid shelling out to `kubectl` and keep logic idempotent and debuggable.  
- `csm.rr.check_enablement` now publishes the `k8s_zone_prefix` fact, letting downstream roles reuse the value without duplicate secret parsing.  
- `csm.rr.k8s_topology_zoning` rewrites its Python helper to emit a node→zone JSON map; Ansible ingests that file and applies labels via `kubernetes.core.k8s`, fully replacing `kubectl` loops.  
- `csm.rr.mgmt_nodes_placement_discovery` groundwork laid for moving API calls into Ansible while the Python keeps the data-munging logic.  
- `csm.rr.ceph_haproxy` script now only rebuilds the temp config and reports a `hosts_found` flag; Ansible handles Ceph config generation, HAProxy deployment, backups, and conditional restarts, mirroring the original control flow without direct shell commands.



## Issues and Related PRs



- [CASM-5649](https://jira-pro.it.hpe.com:8443/browse/CASM-5649)
- [CASM-5662](https://jira-pro.it.hpe.com:8443/browse/CASM-5662)



## Testing



### Tested on:
#mug and #wasp



### Test description:
- Tested by updating cfs configurations to see if all playbooks were executed properly
- Checked Ansible ara logs for more information



_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_



- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?



## Risks and Mitigations



None



## Pull Request Checklist



- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable