### PR TITLE
CASMHMS-6614: Updated BSS to point to latest SMD v2.44.0

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -36,13 +36,13 @@ spec:
   # Install any operators first, wait for them to come up before continuing.
   - name: cray-hms-bss
     source: csm-algol60
-    version: 3.3.6
+    version: 3.3.7
     namespace: services
     timeout: 10m
     swagger:
     - name: bss
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.36.0/api/swagger.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-bss/v1.37.0/api/swagger.yaml
   - name: cray-hms-capmc
     source: csm-algol60
     version: 5.1.4


### PR DESCRIPTION
### Summary and Scope

Updated BSS to point to latest SMD v2.44.0 image

Adopted app version 3.3.7 for CSM 1.7.1 (helm chart 1.36.0)

### Issues and Related PRs

* Resolves [CASMHMS-6614](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6614)

### Testing

Tested on:

* `mug`

- Deployed on mug and watched logs to ensure no adverse logs were being made
- Ran BSS CT tests on mug and verified there were no failures

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable