### PR TITLE
CASMCMS-9593: Fix bug causing BOS to omit error information for some session failures

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.49.0
+    version: 2.49.1
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.0/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.1/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.29.0


### PR DESCRIPTION
This fixes a bug in BOS that was part of the issue reported in CASMTRIAGE-8879 (it wasn't the root cause of the problem, but it was the reason that the BOS session reported no error even though it had encountered one).

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

