### PR TITLE
CASMTRIAGE-8890: SMD: Return empty list when no components match lock filter for GET requests

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -48,7 +48,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.12.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.13
+    version: 7.2.14
     namespace: services
     values:
       cray-service:
@@ -60,7 +60,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.44.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.45.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -43,7 +43,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-sls/v2.12.0/api/openapi.yaml
   - name: cray-hms-smd
     source: csm-algol60
-    version: 7.2.13
+    version: 7.2.14
     namespace: services
     values:
       cray-service:
@@ -55,7 +55,7 @@ spec:
     swagger:
     - name: smd
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.44.0/api/swagger_v2.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.45.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
     version: 3.1.3


### PR DESCRIPTION
## Summary and Scope

Previously, if a GET on the lock status API turned up no matching components, an HTTP 400 error was returned.  This is not correct behaviour, an empty list should be returned in this case.

The unit and CT tests had to be updated for this change.

Made some additional correctness changes in GetCompLocksV2() so that no result is returned, if an error is returned.

Adopted app version 2.45.0 for CSM 1.7.1 (helm chart 7.2.14)

## Issues and Related PRs

* Resolves [CASMTRIAGE-8890](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8890)

## Testing

Tested on:

  * `mug`

Test description:

Ran following test without change:

```
> cray hsm locks status list --type MgmtSwitch --locked True
Usage: cray hsm locks status list [OPTIONS]
Try 'cray hsm locks status list -h' for help.

Error: Bad Request: Component not found
```

Re-ran with my fix in place:

```
> cray hsm locks status list --type MgmtSwitch --locked True
{
  "Components": []
}
```

Manually ran other various other lock status requests to verify correct functionality remains in place.

Ran the SMD CT tests to verify no regressions.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

