### PR TITLE
CASMPET-7692: Use cray-externaldns 1.7.1 chart with new v0.17.0 image

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -193,7 +193,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: services
   # DO NOT INSTALL the cray-sysmgmt-health chart, install after upgraded to K8s 1.32
   # DO NOT INSTALL the cray-postgres-operator, it gets upgraded in prerequisites.sh

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -183,7 +183,7 @@ spec:
     namespace: operators
   - name: cray-externaldns
     source: csm-algol60
-    version: 1.7.0
+    version: 1.7.1
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope
CASMPET-7692: Use external-dns v0.17.0 image from registry.k8s.io rather than bitnami in cray-externaldns chart

The `docker.io/bitnami` registry is no longer serving `external-dns` images. The `cray-externaldns` 1.7.1 chart uses an image from the `registry.k8s.io` instead.  The `registry.k8s.io/external-dns/external-dns:v0.17.0` image scanned free of critical and high severity CVEs.

## Issues and Related PRs

* Resolves [CASMPET-7692](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7692)

## Testing
See [`cray-externaldns` PR](https://github.com/Cray-HPE/cray-externaldns/pull/9) for testing information.

## Risks and Mitigations
Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

