### PR TITLE
CASMHMS-6610 Update hms-hmcollector to use Alpine v3.22

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -79,7 +79,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-hmnfd/v1.26.0/api/swagger_v2.yaml
   - name: cray-hms-hmcollector
     source: csm-algol60
-    version: 2.17.3
+    version: 2.17.4
     namespace: services
   - name: cray-hms-scsd
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Update hms-hmcollector to use Alpine v3.22
Adopted app version 2.40.0 for CSM 1.7.1 (helm chart 2.17.4)

## Issues and Related PRs

* Resolves [CASMHMS-6610](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6610)

## Testing

Tested on:

  * `mug`

Test description:

Deployed on mug and watched if pods are coming up fine
and also looked at logs to ensure no new issues are observed


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

