### PR TITLE
Update hms-meds version

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -63,7 +63,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.45.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
-    version: 3.1.3
+    version: 3.1.4
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -58,7 +58,7 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/hms-smd/v2.45.0/api/swagger_v2.yaml
   - name: cray-hms-meds
     source: csm-algol60
-    version: 3.1.3
+    version: 3.1.4
     namespace: services
   - name: cray-hms-discovery
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR focuses on updating the chart version for hms-meds-charts.
Adopted app version 1.26.0 for CSM 1.7.1 (helm chart 3.1.4)

## Issues and Related PRs

* Resolves [CASMHMS-6611](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6611)
* Related PR: [hms-meds](https://github.com/Cray-HPE/hms-meds/pull/43)
* Related PR: [hms-meds-charts](https://github.com/Cray-HPE/hms-meds-charts/pull/19)

## Testing

### Tested on:

  * `mug`

### Test description:

Deployed on mug and watched if pods are coming up fine
and also looked at logs to ensure no new issues are observed

## Risks and Mitigations

_None_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

