### PR TITLE
CASMCMS-9596 - fix version of testtools to fix unit test run.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -195,12 +195,12 @@ spec:
             tag: 2.7.2
   - name: cray-ims
     source: csm-algol60
-    version: 3.32.0
+    version: 3.32.1
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.32.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.32.1/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
## Summary and Scope

Version 2.8.0 of the python module 'testtools' has a breaking API change. This just pins the version to use 2.7.x so the automatic rebuilds will succeed for inclusion of new CVE fixes.

## Issues and Related PRs
* Resolves [CASMCMS-9596](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9596)

## Testing

None - this only impacts the unit tests, so no real system testing is required.

## Risks and Mitigations

If this is not picked up, the automatic rebuilds will fail.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable