### PR TITLE
CASM-5738 - Support bare-metal fabric manager nodes

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.22-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.9
+KUBERNETES_IMAGE_ID=7.2.10
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.9
+PIT_IMAGE_ID=7.2.10
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.9
+STORAGE_CEPH_IMAGE_ID=7.2.10
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.9
+COMPUTE_IMAGE_ID=7.2.10
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -34,7 +34,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-trust-1.9.2-1.noarch
     - cray-cmstools-crayctldeploy-1.33.0-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
-    - cray-site-init-2.0.5-1.x86_64
+    - cray-site-init-2.0.6-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch
     - craycli-0.99.0-1.aarch64
     - craycli-0.99.0-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -63,7 +63,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - iuf-cli-1.7.2-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
-    - metal-init-1.4.12-1.noarch
+    - metal-init-1.4.13-1.noarch
     - metal-ipxe-2.7.0-1.noarch
     - metal-nexus-1.7.0-3.70.4.x86_64
     - metal-observability-1.1.0-1.x86_64

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.1-1.x86_64
-    - canu-2.0.5-1.x86_64
+    - canu-2.0.6-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

This PR adds support for bare-metal fabric manager nodes during a fresh install of CSM.

This PR also includes a minor `canu` bugfix.

## Issues and Related PRs

* Resolves [CASM-5738](https://jira-pro.it.hpe.com:8443/browse/CASM-5738)
* [CASMTRIAGE-8900](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8900)
* Documentation changes to follow, they will not be merged until Slingshot release compatible code.

## Testing

### Tested on:

  * `redbull`

### Test description:

See https://github.com/Cray-HPE/metal-init/pull/83 and https://github.com/Cray-HPE/cray-site-init/pull/533.

## Risks and Mitigations

Changes are backwards compatible

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

