### PR TITLE
CASMHMS-6612: Updates cray-hms-rts component version to 5.1.8

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -92,13 +92,13 @@ spec:
   - name: cray-hms-rts
     source: csm-algol60
     # When updating the version also update cray-hms-rts-snmp
-    version: 5.1.7
+    version: 5.1.8
     namespace: services
   - name: cray-hms-rts
     releaseName: cray-hms-rts-snmp
     source: csm-algol60
     # When updating the version also update cray-hms-rts
-    version: 5.1.7
+    version: 5.1.8
     namespace: services
     values:
       rtsDoInit: false


### PR DESCRIPTION
## Summary and Scope

This PR updates the chart version for hms-rts-charts.
Adopted app version 1.32.0 for CSM 1.7.1 (helm chart 5.1.8)

## Issues and Related PRs

* Resolves [CASMHMS-6612](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6612)
* Related PR: [hms-redfish-translation-layer](https://github.com/Cray-HPE/hms-redfish-translation-layer/pull/60)
* Related PR: [hms-rts-charts](https://github.com/Cray-HPE/hms-rts-charts/pull/33)

## Testing

### Tested on:

  * `mug`

### Test description:

Deployed on #mug and watched if pods are coming up fine, and also looked at logs to ensure no new issues are observed.

## Risks and Mitigations

_None_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

