### PR TITLE
Update cray-nls and cray-iuf chart versions to use metacontroller v4.11.25

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -267,11 +267,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.3
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.3
     namespace: argo
     swagger:
     - name: nls

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -275,11 +275,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.3
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.3
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION


## Summary and Scope

This PR upgrades Metacontroller from v4.10.3 to v4.11.25.

The upgrade is necessary to:
Fix vulnerability issues in the previous Metacontroller version.
Eliminate 16 HIGH severity OpenSSL vulnerabilities.

## Issues and Related PRs



* Resolves [CASMINST-6462](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6462
)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Mug

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?yes
- Were continuous integration tests run? If not, why?yes
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?yes
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [x ] Copyrights updated
- [x ] License file intact
- [x ] Target branch correct
- [x ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

