### PR TITLE
CASMINST-7369: Version bump up to add the tests for Rack Resiliency

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -49,12 +49,12 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
     # Keep goss-servers and csm-testing in sync
-    - csm-testing-1.19.42-1.noarch
+    - csm-testing-1.19.43-1.noarch
     - csm-udev-network-cn-2.0-1.aarch64
     - csm-udev-network-cn-2.0-1.x86_64
     - csm-udev-network-ncn-2.0-1.x86_64
     # Keep goss-servers and csm-testing in sync
-    - goss-servers-1.19.42-1.noarch
+    - goss-servers-1.19.43-1.noarch
     - hpe-csm-goss-package-0.3.21-hpe4.x86_64
     - hpe-csm-scripts-0.7.2-1.noarch
     - hpe-yq-4.33.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

This PR is to increase the version of csm-testing to include RR tests.


## Issues and Related PRs

* Resolves [CASMINST-7369](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7369)
* Related PR: [csm-testing/pull/760](https://github.com/Cray-HPE/csm-testing/pull/760)

## Testing


### Tested on:

  * `mug`,`wasp`

### Test description:

Ran the suites on `mug` and the results are saved in linked JIRA [CASMINST-7369](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7369)

## Risks and Mitigations

_None_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

