### PR TITLE
CASMNET-1891 - Deleting a record from SLS does not delete it from PowerDNS

### DIFF
--- a/manifests/core-services-v1.24.yaml
+++ b/manifests/core-services-v1.24.yaml
@@ -84,5 +84,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.8.4 # update platform.yaml cray-precache-images with this
+    version: 0.8.5 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -88,5 +88,5 @@ spec:
 
   - name: cray-powerdns-manager
     source: csm-algol60
-    version: 0.8.4 # update platform.yaml cray-precache-images with this
+    version: 0.8.5 # update platform.yaml cray-precache-images with this
     namespace: services

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -102,7 +102,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.5
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -93,7 +93,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.1
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
-      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
+      - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.5
       # cray-ceph-csi-rbd and cray-ceph-csi-cephfs
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       - artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2


### PR DESCRIPTION
## Summary and Scope

This PR fixes a bug where deleting a DNS record from SLS does not delete the corresponding record from PowerDNS. The fix introduces an ownership tracking mechanism using comments on DNS RRsets to identify records managed by cray-powerdns-manager. Only records with the ownership comment are deleted during reconciliation, preventing accidental removal of system-critical or manually-added DNS records.

Change type: Backwards compatible bugfix

## Issues and Related PRs

* Resolves [CASMNET-1891](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1891)

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:

See https://github.com/Cray-HPE/cray-powerdns-manager/pull/65 for test information.

## Risks and Mitigations

Risks:

Existing DNS records created before this fix won't have ownership comments initially, but they will be added during the next reconciliation cycle
If PowerDNS is manually edited between upgrades, records without ownership comments will persist (this is intentional to prevent accidental deletions)

Mitigations:

Ownership check prevents deletion of any records not explicitly managed by cray-powerdns-manager
System-critical records (SOA, root NS records) are explicitly excluded from deletion logic

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

