### PR TITLE
CASMSEC-599: Webhook timeout during cray-kyverno deployment

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -115,7 +115,7 @@ spec:
       - artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.2
   - name: cray-kyverno
     source: csm-algol60
-    version: 1.7.6
+    version: 1.7.7
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

Customer reported there was a webhook timeout encountered in one of their upgrade during pre-upgrade stage of Kyverno. This was resolved by increasing the timeout. The same is incorporated in Kyverno.


## Testing

Tested Fresh install and Upgrade of Kyverno

### Tested on:

Drax

### Test description:

[kyverno-1_7_7_fresh_install.txt](https://github.com/user-attachments/files/23774560/kyverno-1_7_7_fresh_install.txt)
[Kyverno-177-Upgrade.txt](https://github.com/user-attachments/files/23774563/Kyverno-177-Upgrade.txt)
