### PR TITLE
New csm-config version w.r.t changes CASM-5282 and CASM-5758

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.49.0
+    version: 1.50.0
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

New csm-config version for FM HA image creation/ customization.

## Issues and Related PRs

[CASM-5282](https://jira-pro.it.hpe.com:8443/browse/CASM-5282)
[CASM-5758](https://jira-pro.it.hpe.com:8443/browse/CASM-5758)
[CASM-5755](https://jira-pro.it.hpe.com:8443/browse/CASM-5755)

## Testing

### Tested on:

Tested on surtur

### Test description:

* Verified FM HA base Image creation/ customization and deployment. on baremetal nodes

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

