### PR TITLE
CASMCMS-9598/CASMCMS-9599: Fix bugs in BOS/CFS

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,28 +134,28 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.49.1
+    version: 2.49.2
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.1/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.29.0
+    version: 1.29.1
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.0/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.1/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.13.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.34.1
+    version: 1.34.2
     namespace: services
   - name: cray-console-data
     source: csm-algol60


### PR DESCRIPTION
Resolves:
* [CASMCMS-9598](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9598): Fix bug in how CFS bulk patch handles no-op patches
* [CASMCMS-9599](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9599): Update Redis module to pick up bug fixes and ensure CFS/CFS-operator are using same Redis versions