### PR TITLE
CASMINST-7090 :nls and iuf-cli version update

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -267,11 +267,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.4
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.4
     namespace: argo
     swagger:
     - name: nls

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -275,11 +275,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.4
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.2
+    version: 5.1.4
     namespace: argo
     swagger:
     - name: nls

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -60,7 +60,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - hpe-yq-4.33.3-1.aarch64
     - hpe-yq-4.33.3-1.x86_64
     - ilorest-4.2.0.0-20.x86_64
-    - iuf-cli-1.7.2-1.x86_64
+    - iuf-cli-1.7.3-1.x86_64
     - manifestgen-1.3.10-1.noarch
     - metal-basecamp-1.2.7-1.x86_64
     - metal-init-1.4.13-1.noarch


### PR DESCRIPTION
## Summary and Scope

updating iuf-cli to 1.7.3
cray-nls chart to 5.1.4

## Issues and Related PRs

* Resolves [CASMINST-7090](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7090)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

