### PR TITLE
Update cray-sts component version to 0.8.4

### DIFF
--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -231,12 +231,12 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.8.3
+    version: 0.8.4
     namespace: services
     swagger:
     - name: sts
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.8.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.8.4/api/openapi.yaml
   - name: cray-etcd-defrag
     source: csm-algol60
     version: 0.4.1

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -239,12 +239,12 @@ spec:
     namespace: services
   - name: cray-sts
     source: csm-algol60
-    version: 0.8.3
+    version: 0.8.4
     namespace: services
     swagger:
     - name: sts
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.8.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-sts/v0.8.4/api/openapi.yaml
   - name: cray-etcd-defrag
     source: csm-algol60
     version: 0.4.1


### PR DESCRIPTION
## Summary and Scope

_Upgraded few python packages in cray-sts to fix KEV(CVE-2020-11023) and thus bumped the cray-sts version. So updating manifest to point to new version of cray-sts_


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [[CASMSEC-596](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-596)]
* Related PR `[(https://github.com/Cray-HPE/cray-sts/pull/24)]`

## Testing

### Tested on:
mug

### Test description:

Deployed on #mug and watched if pods are coming up fine, and also looked at logs to ensure no new issues are observed.

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [] Copyrights updated
- [] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

