### PR TITLE
CASM-5762 Deprecate expired RPM signing key

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -46,7 +46,6 @@ COMPUTE_IMAGE_ID=7.2.10
 
 # Public keys for RPM signature validation.
 #
-# hpe-signing-key.asc - for all packages signed by HPE Code Signing DST/CSM old key (expires 2025-12-07)
 # hpe-signing-key-fips.asc - for all packages signed by HPE Code Signing, DST new key (expires 2026-09-01), for example kernel-mft-mlnx-kmp-default
 # hpe-sdr-signing-key.asc - older HPE key used by SDR repos (Qlogic driver - qlgc-fastlinq-kmp-default)
 # suse-package-key.asc - for most SUSE packages in embedded repo
@@ -57,10 +56,8 @@ COMPUTE_IMAGE_ID=7.2.10
 # isv_kubernetes_key.gpg - k8s packages taken from https://build.opensuse.org/project/subprojects/isv:kubernetes (expires 2026-12-29)
 # nvidia-mellanox-1.gpg - for Nvidia Mellanox OFED packages in nvidia-external Artifactory repo
 HPE_RPM_SIGNING_KEYS=(
-    https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-signing-key-fips.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/hpe-sdr-signing-key2.asc
-    # https://artifactory.algol60.net/artifactory/gpg-keys/google-package-key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/suse-package-key.asc
     https://artifactory.algol60.net/artifactory/gpg-keys/suse-package-2027-01-18.key
     https://artifactory.algol60.net/artifactory/gpg-keys/opensuse-obs-filesystems-15-sp5.asc

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -36,6 +36,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-2.0.6-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch
+    - cray-switchboard-2.1.0-1.x86_64
     - craycli-0.99.0-1.aarch64
     - craycli-0.99.0-1.x86_64
     - csm-auth-utils-1.0.0-1.noarch
@@ -101,6 +102,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - spire-agent-1.5.5-1.12.x86_64
     - tpm-provisioner-client-1.0.1-3.aarch64
     - tpm-provisioner-client-1.0.1-3.x86_64
+    - yapl-0.1.1-1.x86_64
 
 https://artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.7.0/noos/:
   rpms:

--- a/rpm/cray/csm/sle-15sp2/index.yaml
+++ b/rpm/cray/csm/sle-15sp2/index.yaml
@@ -24,9 +24,5 @@
 
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/:
   rpms:
-    - cray-switchboard-2.1.0-1.x86_64
-    - csm-install-workarounds-1.12.1-1.noarch
     - python3-bos-reporter-3.3.4-1.aarch64
     - python3-bos-reporter-3.3.4-1.x86_64
-    - shasta-authorization-module-1.6.2-1.noarch
-    - yapl-0.1.1-1.x86_64

--- a/rpm/cray/csm/sle-15sp3/index.yaml
+++ b/rpm/cray/csm/sle-15sp3/index.yaml
@@ -23,8 +23,6 @@
 #
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/:
   rpms:
-    - libcsm-0.0.5-1.noarch
-    - loftsman-1.2.0-3.x86_64
     - python39-bos-reporter-3.3.4-1.aarch64
     - python39-bos-reporter-3.3.4-1.x86_64
     - python39-cfs-debugger-1.10.3-1.aarch64


### PR DESCRIPTION
## Summary and Scope

RPM key D4DAE1E39DA39F44 used since 2015 expires on Dec 7th 2025. All packages were rebuilt with new key. With this change we:

* Stop shipping deprecated key
* Move `yapl` and `cray-switchboard` packages from OS specific `sles15-sp2` to `noos` repo
* Remove sp2/sp3 specific versions of some packages (we don't really have SP2 or SP3 based nodes).

## Issues and Related PRs

* Resolves CASM-5762

## Testing
### Tested on:

  * Local development environment

### Test description:

Command

    make clean rpms 2>&1 | grep 'Signature verification failed'

produced no output. It was reporting RPMs with bad signatures until RPMs were rebuilt or moved around to correct repos.

## Risks and Mitigations

Unknown ATM - key did not expire yet.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

