### PR TITLE
CASM-5763 -- remove old expiring gpg key

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.22-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.10
+KUBERNETES_IMAGE_ID=7.2.13
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.10
+PIT_IMAGE_ID=7.2.13
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.10
+STORAGE_CEPH_IMAGE_ID=7.2.13
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.10
+COMPUTE_IMAGE_ID=7.2.13
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope

Remove expiring gpg signing key from node-images.

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASM-5763

## Risks and Mitigations

TBD

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable