### PR TITLE
CASMSEC-591: Updates Argoexec and cray-nls and cray-iud versions

### DIFF
--- a/docker/index.yaml
+++ b/docker/index.yaml
@@ -164,7 +164,7 @@ artifactory.algol60.net/csm-docker/stable:
 
     # Argo images
     quay.io/argoproj/argoexec:
-      - v3.3.6
+      - v3.4.5
 
     # Cilium images required by platform
     quay.io/cilium/cilium:

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -267,11 +267,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.5
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.5
     namespace: argo
     swagger:
     - name: nls

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -275,11 +275,11 @@ spec:
     namespace: services
   - name: cray-iuf
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.5
     namespace: argo
   - name: cray-nls
     source: csm-algol60
-    version: 5.1.3
+    version: 5.1.5
     namespace: argo
     swagger:
     - name: nls


### PR DESCRIPTION
## Summary and Scope

Updating argoexec image to v3.4.5
cray-nls chart to 5.1.5

## Issues and Related PRs

* Resolves [CASMSEC-591](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-591)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `fanta`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

