### PR TITLE
CASMPET-7711: Update cray-postgres-operator chart version

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -203,7 +203,7 @@ spec:
             retention: 48h
   - name: cray-postgres-operator
     source: csm-algol60
-    version: 1.14.0
+    version: 1.14.1
     namespace: services
   - name: cray-kafka-operator
     source: csm-algol60


### PR DESCRIPTION
## Summary and Scope

This PR is for updating the version of `cray-postgres-operator`

## Issues and Related PRs

* Resolves [CASMPET-7711](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7711)
* Related PR [cray-postgres-operator/pull/30](https://github.com/Cray-HPE/cray-postgres-operator/pull/30)

## Testing

### Tested on:

  * `mug`

### Test description:

Ran the charts with the latest changes and observed for irregularities; nothing was found.

## Risks and Mitigations

_None_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

