### PR TITLE
CASMCMS-9605: cfs race condition test fails if using the default cfs session name

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch
     - cfs-trust-1.9.2-1.noarch
-    - cray-cmstools-crayctldeploy-1.34.0-1.x86_64
+    - cray-cmstools-crayctldeploy-1.34.1-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-2.0.6-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9605: cfs race condition test fails if using the default cfs session name

