### PR TITLE
CASMCMS-9610: Pull in fix for CFS bulk patch bug

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,12 +143,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.29.1
+    version: 1.29.2
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.2/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.13.1


### PR DESCRIPTION
This pulls in the fix for [CASMCMS-9610](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9610), which is a bug with CFS bulk update operations. The fix is small and low risk, and needs to go into the release. I have tested it to confirm that it corrects the reported problem, and performed regression tests to ensure none of those found any regressions caused by it.