### PR TITLE
CASMCMS-9613 - fix IMS kiwi-ng version.

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -195,12 +195,12 @@ spec:
             tag: 2.7.2
   - name: cray-ims
     source: csm-algol60
-    version: 3.32.1
+    version: 3.33.0
     namespace: services
     swagger:
     - name: ims
       version: v3
-      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.32.1/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/ims/v3.33.0/api/openapi.yaml
   - name: cray-tftp
     source: csm-algol60
     version: 1.12.0


### PR DESCRIPTION
## Summary and Scope

The update of the repos was forcing an update of kiwi-ng from 9.24.43 to 10.2.33. This was a breaking change both for the build env (PVC's didn't support needed file features) and recipes. This needs to be addressed in a more controlled manner than at the last minute of a release.

I removed the updates from the docker file that were bringing in the tumbleweed repo as well as the zypper update scripts.

## Issues and Related PRs

* Resolves [CASMCMS-9613](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9613)

## Testing
### Tested on:

  * `Vinland`, `Tyr`

### Test description:

I installed the latest version of IMS via helm, then applied this new image to the job template. I ran x86 and aarch64 uss recipe builds both remote and in-cluster successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This change is required or the in-cluster recipe build jobs won't run correctly.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable