### PR TITLE
CASMNET-2380 - CANU: NMN Isolation ACLs on Leafs break bgp and ssh

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.22-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.14
+KUBERNETES_IMAGE_ID=7.2.15
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.14
+PIT_IMAGE_ID=7.2.15
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.14
+STORAGE_CEPH_IMAGE_ID=7.2.15
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.14
+COMPUTE_IMAGE_ID=7.2.15
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.1-1.x86_64
-    - canu-2.0.6-1.x86_64
+    - canu-2.0.7-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

An issue was found during testing where certain Aruba platforms were unable to apply the Node Management Network (NMN) Access Control Lists (ACLs) in both inbound and outbound directions due to hardware constraints. Lack of outbound ACLs prevented BGP and SSH from traversing through the leaf switches between workers and spine switches.

## Issues and Related PRs


* Resolves [CASMNET-2380](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2380)

## Testing

### Tested on:

  * `odin`

### Test description:

These changes were applied to odin and the system started working as expected.

## Risks and Mitigations

This change is backwards compatible NMN Isolation is off by default and was introduced in CSM 1.7.0.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

