### PR TITLE
CASMTRIAGE-8951: CFS: Fix regression bug in bulk patch operation

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -143,12 +143,12 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.2/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.29.2
+    version: 1.29.3
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.2/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.3/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
     version: 1.13.1


### PR DESCRIPTION
Fix a CFS bulk patch regression bug that was introduced in v1.28.0. This bug does not exist in CSM 1.7.0 (which uses CFS v1.27.0) or prior CSM versions.