### PR TITLE
CASMNET-2384 - kea-exporter is not monitored and is not restarted if it dies

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -68,7 +68,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.13.1 # update platform.yaml cray-precache-images with this
+    version: 0.13.2 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -99,7 +99,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS for K8s 1.32
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.5

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -90,7 +90,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.1
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.5


### PR DESCRIPTION
## Summary and Scope

This PR addresses a reliability issue where the kea-exporter process was not being monitored and would not restart if it died. The kea-exporter runs in the background to expose Prometheus metrics for the Kea DHCP server, and when it fails, monitoring data is lost without any automated recovery.

**Changes made:**
- Moved kea-exporter from a background process in the main DHCP container to a dedicated sidecar container
- Added proper liveness and readiness probes to monitor the kea-exporter container health
- Kubernetes will now automatically restart the kea-exporter container if it fails
- Created a new startup script (`startup-exporter.sh`) for the kea-exporter sidecar
- Removed the backgrounded kea-exporter process from `startup-dhcp.sh`
- Added resource limits and requests for the new kea-exporter container

**Impact:** This change improves the reliability of DHCP server monitoring and metrics collection. If the kea-exporter fails, Kubernetes will automatically restart it, ensuring continuous availability of Prometheus metrics.

**Compatibility:** This is a **backwards compatible** change. The kea-exporter functionality remains the same, only the deployment architecture has changed to improve reliability.

## Issues and Related PRs

* Resolves [CASMNET-2384](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2384)/[CAST-38778](https://jira-pro.it.hpe.com:8443/browse/CAST-38778)

## Testing

### Tested on:

  * Local development environment
  * `mug` 

### Test description:

**Testing performed:**
- Verify kea-exporter sidecar container starts successfully alongside the main DHCP container
- Confirm kea-exporter metrics endpoint is accessible on port 8080
- Test liveness probe by killing the kea-exporter process and verifying Kubernetes restarts the container
- Verify DHCP server continues to operate normally with the new sidecar architecture
- Confirm Prometheus can successfully scrape metrics from the kea-exporter endpoint

**Testing checklist:**
- [X] Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- [X] Were continuous integration tests run? If not, why?
- [X] Was upgrade tested? If not, why?
- [X] Was downgrade tested? If not, why?
- [X] Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

**Risks:**
- Additional resource consumption due to running kea-exporter as a separate container (mitigated by setting appropriate resource limits: 50m CPU / 128Mi memory requests)
- Potential timing issues during pod startup if kea-exporter starts before the KEA socket is available (mitigated by initialDelaySeconds of 60s on probes)

**Mitigations:**
- Resource limits are conservative (1 CPU / 1Gi limits) to prevent resource exhaustion
- Liveness and readiness probes use TCP socket checks to avoid unnecessary overhead
- 60-second initial delay on probes allows sufficient time for the main DHCP server to initialize

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [x] Copyrights updated (2023 copyright in new startup-exporter.sh)
- [x] License file intact (MIT license headers included)
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable