### PR TITLE
- new release for csm-config for CASMTRIAGE-8848

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.50.1
+    version: 1.50.2
     namespace: services
     values:
       cray-import-config:


### PR DESCRIPTION
## Summary and Scope

New version for csm-config:

The fix for [CASMTRIAGE-8171](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8171) is causing LUN re-mapping to happen on the iSCSI target (worker node) due to target port group (tpg) is being disabled during worker node personalization during the worker node rebuild, resulting in iSCSI initiator (compute node) loosing it's corresponding rootfs/ PE image multipath with SQUASHFS errors seen in the system log.

So, the quick solution for this now is to revert back [CASMTRIAGE-8171](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8171) change and reopen this [CASMTRIAGE-8171](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8171) to address with appropriate fix (documentation).

## Issues and Related PRs

[CASMTRIAGE-8848](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8848): A SQUASHFS error was observed on booted compute nodes during worker node rebuilds.

## Testing

### Tested on:

Odin.

### Test description:

Verified on the Odin system by reverting the [CASMTRIAGE-8171] change in the local VCS/Gitea (csm-config). Performed a CFS configuration update followed by a worker node rollout (rebuild). After the rebuild was completed, the [CASMTRIAGE-8848] issue was no longer observed.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

