### PR TITLE
CASMTRIAGE-8975: Update and freeze the package versions 

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -310,9 +310,9 @@ spec:
     namespace: kube-system
   - name: cray-rrs
     source: csm-algol60
-    version: 1.1.1
+    version: 1.1.2
     namespace: rack-resiliency
     swagger:
     - name: rrs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.1.1/src/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/cray-rrs/v1.1.2/src/api/openapi.yaml

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

The PR is raised to increase the `cray-rrs` version as the packages in the cray-rrs repo are updated and frozen.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8975](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8975)
* Related PR: [pull/25](https://github.com/Cray-HPE/cray-rrs/pull/25)

## Testing

### Tested on:

  * `Mug`

### Test description:

The latest image was tested on `mug` and all the endpoints and functionalities are working.

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

