### PR TITLE
CASMSEC-605: iuf media dir exception

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -119,7 +119,7 @@ spec:
     namespace: kyverno
   - name: kyverno-policy
     source: csm-algol60
-    version: 1.7.23
+    version: 1.7.24
     namespace: kyverno
   - name: cray-kyverno-policies-upstream
     source: csm-algol60

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2025-2026 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

management-node-rollout throws violation yet again to use the `/etc/cray/upgrade/csm` host path volume.

## Issues and Related PRs

* Resolves [CASMSEC-605](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-605)
* Change will also be needed in `release/1.7.1` ?

## Testing
* surtur

### Tested on:

  * `surtur`

### Test description:

Changes were made and IUF run was successful in Surtur. 

https://cray.slack.com/archives/C07742L2X1Q/p1767972683268509

## Risks and Mitigations
None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

