### PR TITLE
CASMPET-7714: Set default K8s caCertificateValidityPeriod to 87600h

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.25-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.17
+KUBERNETES_IMAGE_ID=7.2.18
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.17
+PIT_IMAGE_ID=7.2.18
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.17
+STORAGE_CEPH_IMAGE_ID=7.2.18
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.17
+COMPUTE_IMAGE_ID=7.2.18
 
 # Public keys for RPM signature validation.
 #


### PR DESCRIPTION
## Summary and Scope
CASMPET-7714: Set default K8s `caCertificateValidityPeriod` to 87600h in kubeadm.cfg and kubeadmcfg.yaml in node-images.

## Issues and Related PRs

* Resolves [CASMPET-7714](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7714)
* Change will also be needed in `release/1.7.1`

## Testing
Tested manually on `beau`

## Risks and Mitigations
Low risk. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

