### PR TITLE
CASMTRIAGE-8984-fix: New version for sbps-marshal agent

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -96,7 +96,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python39-requests-retry-session-0.2.4-1.noarch
     - python39-requests-retry-session-0.5.4-1.noarch
     - python39-requests-retry-session-1.0.4-1.noarch
-    - sbps-marshal-1.0.1-1.noarch
+    - sbps-marshal-1.0.2-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.12.aarch64
     - spire-agent-1.5.5-1.12.x86_64


### PR DESCRIPTION
## Summary and Scope

New version for sbps-marshal agent:

In iSCSI SBPS, after management rollout (rebuild) of the iSCSI target (say ncn-w001 worker node) with 1.7.1.rc3 bits, the corresponding multipath (turned into faulty state as expected during rebuild) not getting recovered (not brought back to active state by iscsid service) on the compute node due to "LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN assignments."

Fixed to restart the target.service once after the first scan of the marshal agent is done (sbps-marshal.service), so that target.service can refresh any stale LUN config (LUN assignments change on the target due to scenarios like rebuild).

## Issues and Related PRs

[CASMTRIAGE-8984](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8984)

## Testing

### Tested on:

groot baremetal system

### Test description:

We have reproduced the issue on groot baremetal system (CSM 1.7.1.rc3) with ncn-w001 rebuild and observed that the corresponding multipath on the compute node is gone into _faulty_ state as expected. However, this path was not getting recovered (not brought back to active state) even after ncn-w001 worker node rebuild followed by CFS config update is complete.

** "multipath -ll" output after ncn-w001 rebuild is complete**

```
nid000001:~ # multipath -ll
249302.650730 | /etc/multipath.conf line 10: ignoring deprecated option "disable_changed_wwids", using built-in value: "yes"
8c743b6d-937b-4e12-b90b-4021cb3675fb_rootfs (360014052afed523784d93c6b5c1d65a7) dm-4 LIO-ORG,2afed523784d93c
size=2.3G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
`-+- policy='round-robin 0' prio=50 status=active
  |- 10:0:0:13 sdad 65:208 active ready  running
  |- 8:0:0:13  sdb  8:16   active ready  running
  **`- 9:0:0:13  sdp  8:240  failed faulty running**
PE_CPE-base.x86_64-26.03.squashfs (360014055c7aede1cb2ddcca702b8813f) dm-0 LIO-ORG,5c7aede1cb2ddcc
size=2.1G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
`-+- policy='round-robin 0' prio=50 status=active
  |- 10:0:0:6 sdak 66:64 active ready  running
  |- 8:0:0:6  sdi  8:128 active ready  running
  **`- 9:0:0:6  sdw  65:96 failed faulty running**
```

After this, modified the sbps marshal agent source to restart the _target.service_ after 1st scan of the marshal agent is complete and we see that after 1st scan after applying the fix, the corresponding multipath in _faulty_ state is brought back to _active_ state.

** "multipath -ll" Output after applying the fix**

```
nid000001:~ # multipath -ll
255440.800079 | /etc/multipath.conf line 10: ignoring deprecated option "disable_changed_wwids", using built-in value: "yes"
8c743b6d-937b-4e12-b90b-4021cb3675fb_rootfs (360014052afed523784d93c6b5c1d65a7) dm-4 LIO-ORG,2afed523784d93c
size=2.3G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
`-+- policy='round-robin 0' prio=50 status=active
  |- 10:0:0:13 sdad 65:208 active ready running
  |- 8:0:0:13  sdb  8:16   active ready running
  **`- 9:0:0:13  sdp  8:240  active ready running**
PE_CPE-base.x86_64-26.03.squashfs (360014055c7aede1cb2ddcca702b8813f) dm-0 LIO-ORG,5c7aede1cb2ddcc
size=2.1G features='1 queue_if_no_path' hwhandler='1 alua' wp=ro
`-+- policy='round-robin 0' prio=50 status=active
  |- 10:0:0:6 sdak 66:64 active ready running
  |- 8:0:0:6  sdi  8:128 active ready running
  **`- 9:0:0:6  sdw  65:96 active ready running**
nid000001:~ #
```

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

