### PR TITLE
CASMNET-2385 - cray-dhcp-kea-helper fails with "Argument list too long"

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -68,7 +68,7 @@ spec:
   # Cray DHCP Kea
   - name: cray-dhcp-kea
     source: csm-algol60
-    version: 0.13.2 # update platform.yaml cray-precache-images with this
+    version: 0.13.3 # update platform.yaml cray-precache-images with this
     namespace: services
 
   # Cray DNS unbound (resolver)

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/manifests/platform-v1.24.yaml
+++ b/manifests/platform-v1.24.yaml
@@ -99,7 +99,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS for K8s 1.32
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.5

--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -90,7 +90,7 @@ spec:
       # OPA
       - artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
       # DNS
-      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.2
+      - artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.3
       - artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.2
       - artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.1
       - artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.5


### PR DESCRIPTION
## Summary and Scope

**Critical bug fix** - The `dhcp-helper.py` script was crashing with `OSError: [Errno 7] Argument list too long` when attempting to backup the KEA DHCP configuration to Kubernetes. The root cause was passing a 184 KB base64-encoded configuration string as a command-line argument to `kubectl`, which exceeded the system's ARG_MAX limit (typically 128 KB - 2 MB depending on OS).

This fix writes the patch data to a temporary file and uses `kubectl`'s `--patch-file` flag instead of the inline `-p` argument, completely avoiding the ARG_MAX limitation.

**Backwards compatible bugfix** - This change preserves all existing behavior and only modifies the internal mechanism for passing data to kubectl. No API changes, no behavioral changes.

### What's impacted:
- `dhcp-helper.py` backup functionality in the cray-dhcp-kea-helper CronJob
- Systems with KEA DHCP configurations approaching or exceeding ~150 KB when compressed

### Changes:
- Added `import tempfile` for temporary file creation
- Modified `backup_config()` function to write patch data to a temp file
- Replaced inline `-p` argument with `--patch-file` approach
- Added try/finally block for cleanup
- Preserved all existing stdout/stderr/error handling
- Updated copyright to include 2026

## Issues and Related PRs

* Resolves CASMNET-2385 (also tracked as CAST-39434 internally)
* This is a patch release (v0.13.3) that should be backported to all active CSM releases
* No dependencies on other PRs

## Testing

### Tested on:

* `surtur` (HPE internal development system)
* Customer production system (emergency fix validation)
* Local development environment (syntax and pattern validation)

### Test description:

**How were the changes tested:**
1. Emergency fix was deployed to affected customer system and validated successful backup operations
2. Code changes validated on "surtur" development system
3. Python syntax validation performed
4. Pattern matching confirmed against actual source code (lines 1304-1317 in dhcp-helper.py)

**Success criteria:**
- ✅ No more `OSError: [Errno 7] Argument list too long` errors
- ✅ Backup operations complete successfully
- ✅ ConfigMap `cray-dhcp-kea-backup-v2` updates as expected
- ✅ Temporary files cleaned up properly (verified in finally block)

**Validation checks:**
- ✅ Python syntax check passed
- ✅ Preserves all stdout/stderr handling
- ✅ Return code checking unchanged
- ✅ Error logging format preserved
- ✅ No new external dependencies
- ✅ Minimal code change (+21 lines, -8 lines = +13 net)

**Why certain tests were not run:**
- Install/upgrade tests: This is a runtime script fix, not a chart structure change
- Downgrade testing: Changes are backwards compatible; older versions continue to work as-is
- New tests: Existing integration tests cover the backup_config() function; the fix preserves all behavior

## Risks and Mitigations

**Risks:**
- **Low risk**: Surgical fix to a single function
- Temporary file creation could fail if `/tmp` is full (extremely unlikely)
- Cleanup in finally block could fail (handled with try/except)

**Mitigations:**
- Fix preserves all existing error handling and logging
- Temporary file cleanup uses try/except to avoid masking primary errors
- `delete=False` used with NamedTemporaryFile to ensure atomic write-then-use pattern
- Uses standard Python `tempfile` module (no new dependencies)
- Easy rollback via git revert if issues arise

**Known issues:**
- None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable - **Updated to v0.13.3**
- [x] Copyrights updated - **Updated to include 2025-2026**
- [x] License file intact - **Verified**
- [x] Target branch correct - **Targeting master**
- [x] CHANGELOG.md updated - **Added entry for v0.13.3 with CASMNET-2385**
- [x] Testing is appropriate and complete, if applicable - **Tested on surtur and customer system**
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable - **To be completed by product team**

---

**Additional Context:**

This issue was discovered when the KEA DHCP configuration grew to 4.27 MB (138 KB gzipped, 184 KB base64-encoded), exceeding system argument limits. The fix is minimal (only +412 bytes to the script) and has been validated in production via emergency fix deployment.