### PR TITLE
New version for sbps-marshal agent with fix CASMTRIAGE-8999

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -96,7 +96,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - python39-requests-retry-session-0.2.4-1.noarch
     - python39-requests-retry-session-0.5.4-1.noarch
     - python39-requests-retry-session-1.0.4-1.noarch
-    - sbps-marshal-1.0.2-1.noarch
+    - sbps-marshal-1.0.3-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.12.aarch64
     - spire-agent-1.5.5-1.12.x86_64


### PR DESCRIPTION
## Summary and Scope

New release for sbps-marshal agent with fix for [CASMTRIAGE-8999](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8999)

## Issues and Related PRs

[CASMTRIAGE-8999](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8999)
https://github.com/Cray-HPE/sbps-marshal/pull/26

## Testing

### Tested on:

groot baremetal system

### Test description:

Below test scenarios covered and see that there are not "LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN" seen on the compute nodes and also the faulty path was getting recovered back to active state as before.

1. reboot worker node
2. management (worker) rollout (rebuild)
3. shutdown of the worker node, wait for some time say (30min-45 min) and power on back after that.
4. restart marshal-agent 3-4 times with some time gap (5 to 10 seconds gap)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

