### PR TITLE
CASMCMS-9618: BOS API spec: Fix error in description, add warning

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -140,7 +140,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.2/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.3/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.29.3


### PR DESCRIPTION
This updates a text field in the BOS API to:
* Remove a false statement
* Add a warning about dangerous values to use for an option

It does not change the behavior of the BOS service, so this PR just changes the API URL, so that the auto-generated docs can be updated. To be clear, this will not impact the CSM build and does not require a rebuild.

Backports:
1.6: https://github.com/Cray-HPE/csm/pull/4427
1.5: https://github.com/Cray-HPE/csm/pull/4428
1.4: https://github.com/Cray-HPE/csm/pull/4429