### PR TITLE
CASMCMS-9618: BOS API spec: Fix error in description, add warning

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -140,7 +140,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.15/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.30.16/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.23.6


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/4426 for CSM 1.6, to fix the auto-generated API docs for BOS