### PR TITLE
CASMCMS-9618: BOS API spec: Fix error in description, add warning

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -138,7 +138,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.32/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.10.34/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.18.16


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/4426 for CSM 1.5, to fix the auto-generated API docs for BOS