### PR TITLE
CASMCMS-9618: BOS API spec: Fix error in description, add warning

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -165,7 +165,7 @@ spec:
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.51/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.0.53/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.12.12


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm/pull/4426 for CSM 1.4, to fix the auto-generated API docs for BOS