### PR TITLE
CASMCMS-9623: BOS: Fix multi-tenancy bug

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -134,13 +134,13 @@ spec:
     namespace: services
   - name: cray-bos
     source: csm-algol60
-    version: 2.49.2
+    version: 2.50.0
     namespace: services
     timeout: 10m
     swagger:
     - name: bos
       version: v2
-      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.3/api/openapi.yaml.in
+      url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.50.0/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
     version: 1.29.3


### PR DESCRIPTION
This fixes a bug in BOS related to multi-tenancy. Without this fix, in an environment where multi-tenancy is used, some BOS sessions may take longer to be marked `complete` than they should be.

This should go into the CSM 1.7 service pack stream.