### PR TITLE
CASMMON-564 passwords leaked to container logs in csm cray-sysmgmt-health- canu-test

### DIFF
--- a/manifests/platform.yaml
+++ b/manifests/platform.yaml
@@ -187,7 +187,7 @@ spec:
     namespace: services
   - name: cray-sysmgmt-health
     source: csm-algol60
-    version: 1.2.24
+    version: 1.2.25
     namespace: sysmgmt-health
     values:
       kube-prometheus-stack:


### PR DESCRIPTION
## Summary and Scope
This fix is targeted for CSM 1.7.2, if we end up making that patch version. 
_CASMMON-564 passwords leaked to container logs in csm cray-sysmgmt-health- canu-test
_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMMON-564

https://github.com/Cray-HPE/container-images/pull/728
https://github.com/Cray-HPE/cray-sysmgmt-health/pull/219

found the !nitial0 password in the container logs for deployment.apps/cray-sysmgmt-health-canu-tes
This is installed as part of the helm chart cray-sysmgmt-health
The helm chart is found in csm-1.6.2.tar.gz -> cray-sysmgmt-health-1.1.7.tgz
The content of cray-sysmgmt-health-1.1.7.tgz shows that the passwords are read as env vars, rather than simply read from the file, and exposed on the container logs when passed as arugments.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

Tested on starlord2

kubectl get pods -n sysmgmt-health -o wide|grep canu
cray-sysmgmt-health-canu-test-5d98d649cb-6fqts                    2/2     Running     0          101s   10.48.10.239   ncn-w005   <none>           <none>

ssh ncn-w005

kubectl describe pod -n sysmgmt-health cray-sysmgmt-health-canu-test-5d98d649cb-6fqts

 Container ID:   containerd://4b018db92b305b1b957c3ac8dabc5229d3f47ac16676a89753235111eafe94a4
    Image:          artifactory.algol60.net/csm-docker/unstable/cray-canu/canu-test:2.0.2



ncn-w005:~ # crictl inspect  4b018db92b305b1b957c3ac8dabc5229d3f47ac16676a89753235111eafe94a4 |grep pid
            "pid": 1
    "pid": 702095,
            "type": "pid"


sudo cat /proc/702095/environ | tr '\0' '\n' | grep -iE "password|secret|token|aut
h"
USERNAME_FILE=/etc/canu-secret/USERNAME
PASSWORD_FILE=/etc/canu-secret/PASSWORD


without the fix we are seeing the passwords

ncn-w001:~ # sudo cat /proc/497150/environ |grep password
ncn-w001:~ # sudo cat /proc/497150/environ | tr '\0' '\n' | grep -iE "password"
PASSWORD=!nitial0

<img width="960" height="504" alt="image" src="https://github.com/user-attachments/assets/329af718-a561-4113-b066-05e9393d056d" />
