### PR TITLE
CASMCMS-9636: Fix broken cfs_sessions_rc_test

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -32,7 +32,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch
     - cfs-trust-1.9.2-1.noarch
-    - cray-cmstools-crayctldeploy-1.34.1-1.x86_64
+    - cray-cmstools-crayctldeploy-1.34.2-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-2.0.7-1.x86_64
     - cray-spire-dracut-2.1.0-1.noarch


### PR DESCRIPTION
This fixes a broken test. It has no impact outside of that test. This test is not run as part of CSM health checks.

In addition, the fix itself is very small and simple, and has been thoroughly tested.

Because of the above, there is extremely little risk of this fix causing any kind of problems, much less any that would be visible to a customer.

This should go into the CSM 1.7 service pack stream.