### PR TITLE
CASMTRIAGE-9035/CASMTRIAGE-8987/CASMNET-2387 - NMN Isolation bugfixes

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -33,16 +33,16 @@ CN_ARCH=("x86_64" "aarch64")
 KERNEL_VERSION='6.4.0-150700.53.25-default'
 
 # The image ID may not always match the other images and should be defined individually.
-KUBERNETES_IMAGE_ID=7.2.18
+KUBERNETES_IMAGE_ID=7.2.19
 
 # The image ID may not always match the other images and should be defined individually.
-PIT_IMAGE_ID=7.2.18
+PIT_IMAGE_ID=7.2.19
 
 # The image ID may not always match the other images and should be defined individually.
-STORAGE_CEPH_IMAGE_ID=7.2.18
+STORAGE_CEPH_IMAGE_ID=7.2.19
 
 # The image ID may not always match the other images and should be defined individually.
-COMPUTE_IMAGE_ID=7.2.18
+COMPUTE_IMAGE_ID=7.2.19
 
 # Public keys for RPM signature validation.
 #

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -27,7 +27,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - acpid-2.0.31-2.1.x86_64
     - bos-reporter-3.3.4-1.noarch
     - cani-0.5.1-1.x86_64
-    - canu-2.0.7-1.x86_64
+    - canu-2.0.9-1.x86_64
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

 Fix three bugs in the MANAGED_NODE_ISOLATION ACL and CDU switch templates for NMN-isolated systems.

 - CASMTRIAGE-9035: Replaced overly narrow DNS ACL rules with four broad unrestricted rules covering DNS queries/replies (UDP+TCP, port 53) so BMC DNS resolution works correctly.
 - CASMTRIAGE-8987: Added SSH_ALTERNATE port group (ports 22 + range 2022–2040) to support IMS remote build node SSH on non-standard ports.
 - CASMNET-2387: Added permit any HMN↔HMN_MTN rules so NCNs can SSH, run traceroutes, and otherwise manage cabinet BMCs over the HMN network. Includes two new CDU-specific ACL templates and fixes to template variable handling.

## Issues and Related PRs

* Resolves [CASMTRIAGE-9035](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9035), [CASMTRIAGE-8987](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8987), [CASMNET-2387](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2387)

## Testing

### Tested on:

  * `odin`
  * Local development environment

### Test description:

All golden configs regenerated; unit tests pass. Changes validated on odin for several weeks with no reported issues.

## Risks and Mitigations

This change does not address concerns that the NMN Isolation ACLs may not fit into the TCAM of an Aruba 8325 on large system. We do not have a system large enough in house to validate this.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

