### PR TITLE
CASMTRIAGE-9035/CASMTRIAGE-8987/CASMNET-2387 - NMN Isolation bugfixes

### DIFF
--- a/manifests/core-services.yaml
+++ b/manifests/core-services.yaml
@@ -70,16 +70,16 @@ spec:
 #     source: csm-algol60
 #     version: 0.13.3 # update platform.yaml cray-precache-images with this
 #     namespace: services
-
-  # Cray DNS unbound (resolver)
-  - name: cray-dns-unbound
-    source: csm-algol60
-    version: 0.10.2 # update platform.yaml cray-precache-images with this
-    namespace: services
-    values:
-      global:
-        appVersion: 0.10.2
-
+#
+#  # Cray DNS unbound (resolver)
+#  - name: cray-dns-unbound
+#    source: csm-algol60
+#    version: 0.10.2 # update platform.yaml cray-precache-images with this
+#    namespace: services
+#    values:
+#      global:
+#        appVersion: 0.10.2
+#
 #   # Cray DNS powerdns
 #   - name: cray-dns-powerdns
 #     source: csm-algol60

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -21,13 +21,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
-#   rpms:
+ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
+   rpms:
 #     - acpid-2.0.31-2.1.aarch64
 #     - acpid-2.0.31-2.1.x86_64
 #     - bos-reporter-3.3.4-1.noarch
 #     - cani-0.5.1-1.x86_64
-#     - canu-2.0.7-1.x86_64
+     - canu-2.0.9-1.x86_64
 #     - cf-ca-cert-config-framework-2.7.1-1.noarch
 #     - cfs-debugger-1.10.3-1.noarch
 #     - cfs-state-reporter-1.12.4-1.noarch


### PR DESCRIPTION
## Summary and Scope

 Fix three bugs in the MANAGED_NODE_ISOLATION ACL and CDU switch templates for NMN-isolated systems.

 - CASMTRIAGE-9035: Replaced overly narrow DNS ACL rules with four broad unrestricted rules covering DNS queries/replies (UDP+TCP, port 53) so BMC DNS resolution works correctly.
 - CASMTRIAGE-8987: Added SSH_ALTERNATE port group (ports 22 + range 2022–2040) to support IMS remote build node SSH on non-standard ports.
 - CASMNET-2387: Added permit any HMN↔HMN_MTN rules so NCNs can SSH, run traceroutes, and otherwise manage cabinet BMCs over the HMN network. Includes two new CDU-specific ACL templates and fixes to template variable handling.

## Issues and Related PRs

* Resolves [CASMTRIAGE-9035](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-9035), [CASMTRIAGE-8987](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8987), [CASMNET-2387](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2387)

## Testing

### Tested on:

  * `odin`
  * Local development environment

### Test description:

All golden configs regenerated; unit tests pass. Changes validated on odin for several weeks with no reported issues.

## Risks and Mitigations

This change does not address concerns that the NMN Isolation ACLs may not fit into the TCAM of an Aruba 8325 on large system. We do not have a system large enough in house to validate this.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

