### PR TITLE
Updates to address CASTs and CVEs

### DIFF
--- a/manifests/sysmgmt.yaml
+++ b/manifests/sysmgmt.yaml
@@ -118,15 +118,15 @@ spec:
   # CMS
   - name: cfs-ara
     source: csm-algol60
-    version: 1.5.1
+    version: 1.6.1
     namespace: services
   - name: cfs-hwsync-agent
     source: csm-algol60
-    version: 1.14.1
+    version: 1.15.0
     namespace: services
   - name: cfs-trust
     source: csm-algol60
-    version: 1.9.2
+    version: 1.10.0
     namespace: services
   - name: cms-ipxe
     source: csm-algol60
@@ -143,19 +143,19 @@ spec:
       url: https://raw.githubusercontent.com/Cray-HPE/bos/v2.49.3/api/openapi.yaml.in
   - name: cray-cfs-api
     source: csm-algol60
-    version: 1.29.3
+    version: 1.31.0
     namespace: services
     swagger:
     - name: cfs
       version: v1
-      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.29.3/api/openapi.yaml
+      url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.31.0/api/openapi.yaml
   - name: cray-cfs-batcher
     source: csm-algol60
-    version: 1.13.1
+    version: 1.14.1
     namespace: services
   - name: cray-cfs-operator
     source: csm-algol60
-    version: 1.34.2
+    version: 1.36.0
     namespace: services
   - name: cray-console-data
     source: csm-algol60
@@ -172,7 +172,7 @@ spec:
     timeout: 20m0s
   - name: cray-console-node
     source: csm-algol60
-    version: 2.10.1
+    version: 2.10.2
     namespace: services
     timeout: 20m0s
   - name: cray-csm-barebones-recipe-install
@@ -211,7 +211,7 @@ spec:
     namespace: services
   - name: csm-config
     source: csm-algol60
-    version: 1.50.3
+    version: 1.50.4
     namespace: services
     values:
       cray-import-config:
@@ -245,7 +245,7 @@ spec:
 
   - name: csm-ssh-keys
     source: csm-algol60
-    version: 1.8.1
+    version: 1.8.2
     namespace: services
 
   - name: gitea

--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -31,7 +31,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - cf-ca-cert-config-framework-2.7.1-1.noarch
     - cfs-debugger-1.10.3-1.noarch
     - cfs-state-reporter-1.12.4-1.noarch
-    - cfs-trust-1.9.2-1.noarch
+    - cfs-trust-1.10.0-1.noarch
     - cray-cmstools-crayctldeploy-1.34.1-1.x86_64
     - cray-node-exporter-1.5.0.1-1.noarch
     - cray-site-init-2.0.8-1.x86_64
@@ -45,8 +45,8 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - csm-node-heartbeat-2.8-1.x86_64
     - csm-node-identity-1.0.22-1.noarch
     - csm-scripts-dracut-2.0-1.noarch
-    - csm-ssh-keys-1.8.1-1.noarch
-    - csm-ssh-keys-roles-1.8.1-1.noarch
+    - csm-ssh-keys-1.8.2-1.noarch
+    - csm-ssh-keys-roles-1.8.2-1.noarch
     - csm-sbps-dracut-2.0-1.noarch
     - csm-sbps-utils-2.0.2-1.noarch
     # Keep goss-servers and csm-testing in sync
@@ -71,31 +71,58 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
     - platform-utils-1.7.1-1.noarch
     - platform-utils-1.8.5-1.noarch
     - python3-liveness-1.4.4-1.noarch
-    - python3-requests-retry-session-0.1.8-1.noarch
-    - python3-requests-retry-session-0.2.4-1.noarch
-    - python3-requests-retry-session-0.5.4-1.noarch
-    - python310-requests-retry-session-0.1.8-1.noarch
-    - python310-requests-retry-session-0.2.4-1.noarch
-    - python310-requests-retry-session-0.5.4-1.noarch
-    - python310-requests-retry-session-1.0.4-1.noarch
-    - python310-requests-retry-session-2.0.3-1.noarch
-    - python311-requests-retry-session-0.1.8-1.noarch
-    - python311-requests-retry-session-0.2.4-1.noarch
-    - python311-requests-retry-session-0.5.4-1.noarch
-    - python311-requests-retry-session-1.0.4-1.noarch
-    - python311-requests-retry-session-2.0.3-1.noarch
-    - python311-requests-retry-session-3.0.0-1.noarch
-    - python312-requests-retry-session-0.1.8-1.noarch
-    - python312-requests-retry-session-0.2.4-1.noarch
-    - python312-requests-retry-session-0.5.4-1.noarch
-    - python312-requests-retry-session-1.0.4-1.noarch
-    - python312-requests-retry-session-2.0.3-1.noarch
-    - python312-requests-retry-session-3.0.0-1.noarch
-    - python312-requests-retry-session-4.0.0-1.noarch
-    - python39-requests-retry-session-0.1.8-1.noarch
-    - python39-requests-retry-session-0.2.4-1.noarch
-    - python39-requests-retry-session-0.5.4-1.noarch
-    - python39-requests-retry-session-1.0.4-1.noarch
+    - python3-requests-retry-session-0.1.10-1.noarch
+    - python3-requests-retry-session-0.2.6-1.noarch
+    - python3-requests-retry-session-0.5.7-1.noarch
+    - python3-requests-retry-session-0.6.1-1.noarch
+    - python310-requests-retry-session-0.1.10-1.noarch
+    - python310-requests-retry-session-0.2.6-1.noarch
+    - python310-requests-retry-session-0.5.7-1.noarch
+    - python310-requests-retry-session-0.6.1-1.noarch
+    - python310-requests-retry-session-1.0.9-1.noarch
+    - python310-requests-retry-session-1.1.3-1.noarch
+    - python310-requests-retry-session-2.0.8-1.noarch
+    - python310-requests-retry-session-2.1.3-1.noarch
+    - python311-requests-retry-session-0.1.10-1.noarch
+    - python311-requests-retry-session-0.2.6-1.noarch
+    - python311-requests-retry-session-0.5.7-1.noarch
+    - python311-requests-retry-session-0.6.1-1.noarch
+    - python311-requests-retry-session-1.0.9-1.noarch
+    - python311-requests-retry-session-1.1.3-1.noarch
+    - python311-requests-retry-session-2.0.8-1.noarch
+    - python311-requests-retry-session-2.1.3-1.noarch
+    - python311-requests-retry-session-3.0.5-1.noarch
+    - python311-requests-retry-session-3.1.3-1.noarch
+    - python312-requests-retry-session-0.1.10-1.noarch
+    - python312-requests-retry-session-0.2.6-1.noarch
+    - python312-requests-retry-session-0.5.7-1.noarch
+    - python312-requests-retry-session-0.6.1-1.noarch
+    - python312-requests-retry-session-1.0.9-1.noarch
+    - python312-requests-retry-session-1.1.3-1.noarch
+    - python312-requests-retry-session-2.0.8-1.noarch
+    - python312-requests-retry-session-2.1.3-1.noarch
+    - python312-requests-retry-session-3.0.5-1.noarch
+    - python312-requests-retry-session-3.1.3-1.noarch
+    - python312-requests-retry-session-4.0.5-1.noarch
+    - python312-requests-retry-session-4.1.3-1.noarch
+    - python313-requests-retry-session-0.5.7-1.noarch
+    - python313-requests-retry-session-0.6.1-1.noarch
+    - python313-requests-retry-session-1.0.9-1.noarch
+    - python313-requests-retry-session-1.1.3-1.noarch
+    - python313-requests-retry-session-2.0.8-1.noarch
+    - python313-requests-retry-session-2.1.3-1.noarch
+    - python313-requests-retry-session-3.0.5-1.noarch
+    - python313-requests-retry-session-3.1.3-1.noarch
+    - python313-requests-retry-session-4.0.5-1.noarch
+    - python313-requests-retry-session-4.1.3-1.noarch
+    - python313-requests-retry-session-5.0.6-1.noarch
+    - python313-requests-retry-session-5.1.3-1.noarch
+    - python39-requests-retry-session-0.1.10-1.noarch
+    - python39-requests-retry-session-0.2.6-1.noarch
+    - python39-requests-retry-session-0.5.7-1.noarch
+    - python39-requests-retry-session-0.6.1-1.noarch
+    - python39-requests-retry-session-1.0.9-1.noarch
+    - python39-requests-retry-session-1.1.3-1.noarch
     - sbps-marshal-1.0.3-1.noarch
     - smart-mon-1.0.3-1.noarch
     - spire-agent-1.5.5-1.12.aarch64


### PR DESCRIPTION
These updates address the following tickets. Half are small bug tickets (either solving or related to CAST-39551), and the other half address CVEs.

I realize that this PR merging does not mean we will pull these into any particular service pack (or whatever we decided to call them), but these versions have all already been tagged in their respective repos. (and of course they have been tested on top of CSM 1.7.1 -- in the case of these specifically, I have tested them all in combination together, to ensure there are not conflicts)

* CASMCMS-9627: CFS: Multiple Kubernetes jobs created for same session (CAST-39551)
* CASMCMS-9628: CFS: Bad component patch can break CFS batcher
* CASMCMS-9629: CFS: Prevent some invalid component patches
* CASMCMS-9630: CFS: Correctly implement v2 component patch
* CASMCMS-9631: SECURITY: CVEs in cfs-ara, cfs-batcher, cfs-hwsync-agent, cfs-operator
* CASMCMS-9632: CFS: Do not erroneously update last_updated timestamps for layers
* CASMCMS-9633: CFS: Thread-safety bug
* CASMCMS-9634: CFS: Improve Kafka-related debug logging (CAST-39551)
* CASMCMS-9637: SECURITY: CVEs in cray-aee, console-node, csm-config
* CASMCMS-9638: SECURITY: CVEs in cray-aee, console-node, csm-config
* CASMCMS-9639: SECURITY: CVEs in cray-aee
* CASMCMS-9640: SECURITY: CVEs in console-node
* CASMCMS-9641: SECURITY: CVEs in cfs-batcher, cfs-operator