### PR TITLE
CASMNET-2389 - Hill cabinet SLS entries contain <nil> gateway and empty CIDR

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -34,7 +34,7 @@
 #     - cfs-trust-1.9.2-1.noarch
 #     - cray-cmstools-crayctldeploy-1.34.1-1.x86_64
 #     - cray-node-exporter-1.5.0.1-1.noarch
-#     - cray-site-init-2.0.7-1.x86_64
+     - cray-site-init-2.0.8-1.x86_64
 #     - cray-spire-dracut-2.1.0-1.noarch
 #     - cray-switchboard-2.1.0-1.x86_64
 #     - craycli-0.99.0-1.aarch64


### PR DESCRIPTION
## Summary and Scope

The CASMNET-2310 IPv6 refactor changed `IPSubnet.CIDR` from `net.IPNet` to a plain `string`, but the subnet-not-found guard in `GenCabinetMap` was not updated to match. The old guard relied on `net.IPNet`'s zero-value `.String()` returning `"<nil>"`:

```go
if subnet.CIDR.String() != "<nil>"   // old: correctly skipped zero-value net.IPNet
```

After the refactor, `CIDR` is a `string` whose zero value is `""`, making the updated guard:

```go
if subnet.CIDR != "<nil>"            // broken: "" != "<nil>" is always true
```

This means every failed subnet lookup writes a bad entry instead of being skipped. For Hill cabinets the effect is compounded by the network lookup loop ordering (`NMN → HMN → NMN_MTN → HMN_MTN → NMN_RVR → HMN_RVR`): the `_MTN` lookups succeed and write correct data, but the `_RVR` lookups that follow return empty subnets, pass the broken guard, and overwrite the good data — producing `{CIDR: "", Gateway: "\u003cnil\u003e"}` in the generated `sls_input_file.json`.

## Issues and Related PRs

* Resolves [CASMNET-2389](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2389)

## Testing

### Tested on:

  * `odin`
  * Local development environment

### Test description:

Verified against the **odin** system (`hpc-shasta-system-configs/odin/1.7`) which has one Hill cabinet (`x9000`).

**Before fix** — `sls_input_file.json` contained:

```json
"x9000": {
  "ExtraProperties": {
    "Networks": {
      "cn": {
        "HMN": {
          "CIDR": "",
          "Gateway": "\u003cnil\u003e"
        },
        "NMN": {
          "CIDR": "",
          "Gateway": "\u003cnil\u003e"
        }
      }
    }
  }
}
```

**After fix** — `sls_input_file.json` correctly contains:

```json
"x9000": {
  "ExtraProperties": {
    "Networks": {
      "cn": {
        "HMN": {
          "CIDR": "10.104.0.0/22",
          "Gateway": "10.104.0.1",
          "VLan": 3000
        },
        "NMN": {
          "CIDR": "10.120.0.0/22",
          "Gateway": "10.120.0.1",
          "VLan": 2000
        }
      }
    }
  }
}
```

CIDR and Gateway values match the corresponding `HMN_MTN` and `NMN_MTN` subnet entries in the same file. VLAN IDs match those defined in `cabinets.yaml` (`hmn-vlan: 3000`, `nmn-vlan: 2000`).

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable

