### PR TITLE
CASMCMS-9644: Tyr : Blancapeaks are not booting after USS 1.5.1-1 update

### DIFF
--- a/rpm/cray/csm/noos/index.yaml
+++ b/rpm/cray/csm/noos/index.yaml
@@ -47,7 +47,7 @@
 #     - csm-scripts-dracut-2.0-1.noarch
 #     - csm-ssh-keys-1.8.1-1.noarch
 #     - csm-ssh-keys-roles-1.8.1-1.noarch
-#     - csm-sbps-dracut-2.0-1.noarch
+    - csm-sbps-dracut-2.1-1.noarch
 #     - csm-sbps-utils-2.0.2-1.noarch
 #     # Keep goss-servers and csm-testing in sync
 #     - csm-testing-1.19.45-1.noarch


### PR DESCRIPTION
## Summary and Scope

Manifest update for CASMCMS-9644.

## Issues and Related PRs

* Resolves CASMCMS-9644
